### PR TITLE
Allow passing in your own custom nonce for derivation "BYOYOLO"

### DIFF
--- a/secp256kfun/src/hash.rs
+++ b/secp256kfun/src/hash.rs
@@ -143,7 +143,7 @@ impl NonceHash<sha2::Sha256> {
 impl<H: Digest<OutputSize = U32> + Clone + digest::Digest> NonceHash<H> {
     /// Create a nonce derivation hash from a given derivation and secret
     /// unpredictable scalar. Rather than use this method directly it's generally clearer
-    /// to use the [`derive_nonce`](macro.derive_nonce) macro.
+    /// to use the [`derive_nonce`](crate::derive_nonce!) macro.
     ///
     /// # Examples
     ///

--- a/secp256kfun/src/macros.rs
+++ b/secp256kfun/src/macros.rs
@@ -289,6 +289,8 @@ macro_rules! test_plus_wasm {
 /// are the same. For example, if you are implementing a signature scheme, then
 /// the message you are signing would go into `public`.
 ///
+/// This macro compiles to a call to [`NonceHash::begin_derivation`] which has further examples.
+///
 /// # Example
 /// Derive a nonce using a secret scalar and additional randomness from `thread_rng`
 /// ```
@@ -301,6 +303,8 @@ macro_rules! test_plus_wasm {
 ///     public => [b"public-inputs-to-the-algorithm".as_ref()]
 /// );
 /// ```
+///
+/// [`NonceHash::begin_derivation`]: crate::hash::NonceHash::begin_derivation
 #[macro_export]
 macro_rules! derive_nonce {
     (
@@ -311,7 +315,7 @@ macro_rules! derive_nonce {
     ) => {{
         use $crate::hash::HashAdd;
         use core::borrow::Borrow;
-        Scalar::from_hash(
+        Scalar::from(
             $nonce_hash.begin_derivation($derivation, $secret.borrow())$(.add($public.borrow()))+
         )
     }}


### PR DESCRIPTION
In some applications like DLCs it is necessary to pre-commit to a
nonce up front and then use the specified nonce later on.