### PR TITLE
Libsecp compatability

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,9 +26,7 @@ jobs:
     - name: Build
       run: cargo build --verbose
     - name: Run tests
-      run: cargo test --verbose --release
-    - name: Run serde tests
       run: |
-        (cd secp256kfun && cargo test --features=serialize_hex --release)
-        (cd schnorr_fun && cargo test --features=serialize_hex --release)
-        (cd ecdsa_fun   && cargo test --features=serialize_hex --release)
+        (cd secp256kfun && cargo test --features=all --release --verbose)
+        (cd schnorr_fun && cargo test --features=all --release --verbose)
+        (cd ecdsa_fun   && cargo test --features=all --release --verbose)

--- a/ecdsa_fun/Cargo.toml
+++ b/ecdsa_fun/Cargo.toml
@@ -34,6 +34,8 @@ harness = false
 
 [features]
 default = ["std"]
+all = ["std", "serialize_hex", "libsecp_compat"]
+libsecp_compat = ["secp256kfun/libsecp_compat"]
 std = ["alloc"]
 alloc = []
 serialization = ["serde", "secp256kfun/serialization"]

--- a/ecdsa_fun/README.md
+++ b/ecdsa_fun/README.md
@@ -18,6 +18,10 @@ Not well reviewed or tested.
 
 ### Extra Features
 
+- From implementation for converting to [rust-secp256k1] types (`libsecp_compat`)
 - ECDSA Adaptor signatures
+- Hex and binary `serde` serlialization for all types (`serlialization` or `serialize_hex`)
 
 [secp256kfun]: https://docs.rs/secp256kfun
+[rust-secp256k1]: https://github.com/rust-bitcoin/rust-secp256k1/ 
+

--- a/ecdsa_fun/src/lib.rs
+++ b/ecdsa_fun/src/lib.rs
@@ -11,6 +11,9 @@ extern crate alloc;
 #[macro_use]
 extern crate std;
 
+#[cfg(feature = "libsecp_compat")]
+mod libsecp_compat;
+
 use fun::{derive_nonce, g, hash::AddTag, marker::*, nonce::NonceGen, s, Point, Scalar, G};
 pub use secp256kfun as fun;
 pub use secp256kfun::nonce;
@@ -99,6 +102,7 @@ impl<NG> ECDSA<NG> {
         g!(secret_key * G).mark::<Normal>()
     }
     /// Verify an ECDSA signature.
+    #[must_use]
     pub fn verify(
         &self,
         verification_key: &Point<impl PointType, Public, NonZero>,

--- a/ecdsa_fun/src/libsecp_compat.rs
+++ b/ecdsa_fun/src/libsecp_compat.rs
@@ -1,0 +1,13 @@
+use crate::{fun::secp256k1, Signature};
+
+impl From<Signature> for secp256k1::Signature {
+    fn from(sig: Signature) -> Self {
+        secp256k1::Signature::from_compact(sig.to_bytes().as_ref()).unwrap()
+    }
+}
+
+impl From<secp256k1::Signature> for Signature {
+    fn from(sig: secp256k1::Signature) -> Self {
+        Signature::from_bytes(sig.serialize_compact()).unwrap()
+    }
+}

--- a/ecdsa_fun/tests/against_c_lib.rs
+++ b/ecdsa_fun/tests/against_c_lib.rs
@@ -1,6 +1,7 @@
+#![cfg(feature = "libsecp_compat")]
 use ecdsa_fun::{
     self,
-    fun::{Scalar, TEST_SOUNDNESS},
+    fun::{Point, Scalar, TEST_SOUNDNESS},
 };
 use secp256k1::{Message, PublicKey, SecretKey};
 
@@ -18,9 +19,8 @@ fn ecdsa_sign() {
     let ecdsa = ecdsa_fun::test_instance!();
     for _ in 0..TEST_SOUNDNESS {
         let secret_key = Scalar::random(&mut rand::thread_rng());
-        let c_secret_key = SecretKey::from_slice(&secret_key.to_bytes()).unwrap();
-        let c_public_key = PublicKey::from_secret_key(&secp, &c_secret_key);
-
+        let public_key = ecdsa.verification_key_for(&secret_key);
+        let c_public_key = PublicKey::from(public_key);
         let message = rand_32_bytes();
         let signature = ecdsa.sign(&secret_key, &message);
         let c_message = Message::from_slice(&message[..]).unwrap();
@@ -37,14 +37,14 @@ fn ecdsa_verify() {
 
     for _ in 0..TEST_SOUNDNESS {
         let secret_key = Scalar::random(&mut rand::thread_rng());
-        let verification_key = ecdsa.verification_key_for(&secret_key);
-        let c_secret_key = SecretKey::from_slice(&secret_key.to_bytes()).unwrap();
+        let c_secret_key = SecretKey::from(secret_key);
+        let c_public_key = PublicKey::from_secret_key(&secp, &c_secret_key);
+        let public_key = Point::from(c_public_key);
         let message = rand_32_bytes();
         let c_message = Message::from_slice(&message[..]).unwrap();
         let c_signature = secp.sign(&c_message, &c_secret_key);
-        let signature = ecdsa_fun::Signature::from_bytes(c_signature.serialize_compact()).unwrap();
-
-        assert!(ecdsa.verify(&verification_key, &message, &signature));
+        let signature = ecdsa_fun::Signature::from(c_signature);
+        assert!(ecdsa.verify(&public_key, &message, &signature));
     }
 }
 

--- a/schnorr_fun/Cargo.toml
+++ b/schnorr_fun/Cargo.toml
@@ -42,6 +42,7 @@ harness = false
 
 [features]
 default = ["std"]
+all = ["std","serialize_hex"]
 alloc = []
 std = ["alloc"]
 serialization = ["serde", "secp256kfun/serialization"]

--- a/secp256kfun/Cargo.toml
+++ b/secp256kfun/Cargo.toml
@@ -21,6 +21,7 @@ subtle = { version = "2.2" }
 rand_core = { version = "0.5" }
 serde = { version = "1.0",  optional = true, default-features = false, features = ["derive"] }
 parity_backend = { version = "0.1.1", package = "secp256kfun_parity_backend" }
+secp256k1 = { version = "0.17", optional = true, default-features = false }
 
 [dev-dependencies]
 hex-literal = "0.2"
@@ -44,11 +45,12 @@ wasm-bindgen-test = "0.3"
 
 [features]
 default = ["std"]
-all = ["std", "serialize_hex"]
+all = ["std", "serialize_hex", "libsecp_compat"]
 alloc = []
 std = ["alloc"]
 serialization = ["serde"]
 serialize_hex = [ "alloc", "serialization" ]
+libsecp_compat = ["secp256k1"]
 
 
 [[bench]]

--- a/secp256kfun/README.md
+++ b/secp256kfun/README.md
@@ -177,10 +177,11 @@ When you pass in `G`, which is a `BasePoint`, the compiler will specialize the c
 - Nonce derivation functionality to help avoid messing this up.
 - `serde` serialization/deserialization for binary and hex for human-readable formats (enable with `serialization` or `serialize_hex` features).
 - `no_std` support
+- `From` implementations for [rust-secp256k1][2] types with `libsecp_compat` feature.
 
 
 [1]: https://github.com/bitcoin-core/secp256k1
-[2]: https://github.com/rust-bitcoin/
+[2]: https://github.com/rust-bitcoin/rust-secp256k1/ 
 [3]: https://github.com/dalek-cryptography/curve25519-dalek
 [4]: https://github.com/paritytech/libsecp256k1
 [_specialization_]: https://github.com/rust-lang/rust/issues/31844

--- a/secp256kfun/src/lib.rs
+++ b/secp256kfun/src/lib.rs
@@ -32,9 +32,12 @@ pub use scalar::Scalar;
 pub use slice::Slice;
 pub use xonly::XOnly;
 
+#[cfg(feature = "secp256k1")]
+pub extern crate secp256k1;
 #[cfg(feature = "serialization")]
 pub extern crate serde;
-
+#[cfg(feature = "libsecp_compat")]
+mod libsecp_compat;
 /// The main basepoint for secp256k1 as specified in [_SEC 2: Recommended Elliptic Curve Domain Parameters_] and used in Bitcoin.
 ///
 /// At the moment, [`G`] is the only [`BasePoint`] in the library.

--- a/secp256kfun/src/libsecp_compat.rs
+++ b/secp256kfun/src/libsecp_compat.rs
@@ -1,0 +1,55 @@
+use crate::{
+    marker::*,
+    secp256k1::{PublicKey, SecretKey},
+    Point, Scalar,
+};
+
+impl From<Scalar> for SecretKey {
+    fn from(scalar: Scalar) -> Self {
+        SecretKey::from_slice(scalar.to_bytes().as_ref()).unwrap()
+    }
+}
+
+impl From<SecretKey> for Scalar {
+    fn from(sk: SecretKey) -> Self {
+        Scalar::from_slice(&sk[..])
+            .unwrap()
+            .mark::<NonZero>()
+            .expect("SecretKey is never zero")
+    }
+}
+
+impl From<PublicKey> for Point {
+    fn from(pk: PublicKey) -> Self {
+        Point::from_bytes(pk.serialize()).unwrap()
+    }
+}
+
+impl<T: Normalized> From<Point<T>> for PublicKey {
+    fn from(pk: Point<T>) -> Self {
+        PublicKey::from_slice(pk.to_bytes().as_ref()).unwrap()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use core::str::FromStr;
+    use rand_core::RngCore;
+
+    #[test]
+    fn secret_key() {
+        let mut bytes = [0u8; 32];
+        rand::thread_rng().fill_bytes(&mut bytes);
+        let sk = SecretKey::from_slice(&bytes[..]).unwrap();
+        let scalar = Scalar::from(sk);
+        assert_eq!(&sk[..], scalar.to_bytes().as_ref());
+    }
+
+    #[test]
+    fn public_key() {
+        let pk = PublicKey::from_str("0479BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798483ADA7726A3C4655DA4FBFC0E1108A8FD17B448A68554199C47D08FFB10D4B8").unwrap();
+        let point = Point::from(pk);
+        assert_eq!(pk.serialize().as_ref(), point.to_bytes().as_ref());
+    }
+}


### PR DESCRIPTION
Add From implementations to and from libsecp types                                

- secret keys                                                                       
- public keys                                                                       
- ECDSA signatures