### PR TITLE
Introduce GlobalRng to hide hack

### DIFF
--- a/ecdsa_fun/src/adaptor/encrypted_signature.rs
+++ b/ecdsa_fun/src/adaptor/encrypted_signature.rs
@@ -50,9 +50,8 @@ mod test {
         use crate::{adaptor::Adaptor, fun::nonce};
         use rand::rngs::ThreadRng;
         use sha2::Sha256;
-
-        let ecdsa_adaptor =
-            Adaptor::<Sha256, _>::new(nonce::from_global_rng::<Sha256, ThreadRng>());
+        let nonce_gen = nonce::Synthetic::<Sha256, nonce::GlobalRng<ThreadRng>>::default();
+        let ecdsa_adaptor = Adaptor::<Sha256, _>::new(nonce_gen);
         let secret_key = Scalar::random(&mut rand::thread_rng());
         let encryption_key = Point::random(&mut rand::thread_rng());
         let encrypted_signature = ecdsa_adaptor.encrypted_sign(

--- a/ecdsa_fun/src/adaptor/mod.rs
+++ b/ecdsa_fun/src/adaptor/mod.rs
@@ -20,7 +20,8 @@
 //! // use deterministic nonce generation
 //! let adaptor = Adaptor::<Sha256, nonce::Deterministic<Sha256>>::default();
 //! // use synthetic nonce generation (preferred)
-//! let adaptor = Adaptor::<Sha256, _>::new(nonce::from_global_rng::<Sha256, ThreadRng>());
+//! let nonce_gen = nonce::Synthetic::<Sha256, nonce::GlobalRng<ThreadRng>>::default();
+//! let adaptor = Adaptor::<Sha256, _>::new(nonce_gen);
 //! let secret_signing_key = Scalar::random(&mut rand::thread_rng());
 //! let verification_key = adaptor.ecdsa.verification_key_for(&secret_signing_key);
 //! let decryption_key = Scalar::random(&mut rand::thread_rng());
@@ -282,8 +283,8 @@ mod test {
 
     #[test]
     fn end_to_end() {
-        let ecdsa_adaptor =
-            Adaptor::<Sha256, _>::new(nonce::from_global_rng::<Sha256, ThreadRng>());
+        let nonce_gen = nonce::Synthetic::<Sha256, nonce::GlobalRng<ThreadRng>>::default();
+        let ecdsa_adaptor = Adaptor::<Sha256, _>::new(nonce_gen);
         for _ in 0..20 {
             let msg = b"hello world you are beautiful!!!";
             let signing_key = Scalar::random(&mut rand::thread_rng());

--- a/ecdsa_fun/src/lib.rs
+++ b/ecdsa_fun/src/lib.rs
@@ -55,7 +55,7 @@ impl<NG> ECDSA<NG> {
     /// use ecdsa_fun::{nonce, ECDSA};
     /// use rand::rngs::ThreadRng;
     /// use sha2::Sha256;
-    /// let nonce_gen = nonce::from_global_rng::<Sha256, ThreadRng>();
+    /// let nonce_gen = nonce::Synthetic::<Sha256, nonce::GlobalRng<ThreadRng>>::default();
     /// let ecdsa = ECDSA::new(nonce_gen);
     /// ```
     ///
@@ -137,7 +137,8 @@ impl<NG: NonceGen> ECDSA<NG> {
     /// use rand::rngs::ThreadRng;
     /// use sha2::Sha256;
     /// let secret_key = Scalar::random(&mut rand::thread_rng());
-    /// let ecdsa = ECDSA::new(nonce::from_global_rng::<Sha256, ThreadRng>());
+    /// let nonce_gen = nonce::Synthetic::<Sha256, nonce::GlobalRng<ThreadRng>>::default();
+    /// let ecdsa = ECDSA::new(nonce_gen);
     /// let verification_key = ecdsa.verification_key_for(&secret_key);
     /// let message_hash = {
     ///     let message = b"Attack at dawn";

--- a/schnorr_fun/README.md
+++ b/schnorr_fun/README.md
@@ -29,7 +29,7 @@ use schnorr_fun::{
 use sha2::Sha256;
 use rand::rngs::ThreadRng;
 // Use synthetic nonces
-let nonce_gen = nonce::from_global_rng::<Sha256,ThreadRng>();
+let nonce_gen = nonce::Synthetic::<Sha256, nonce::GlobalRng<ThreadRng>>::default();
 // Create a BIP-341 compatible instance
 let schnorr = Schnorr::<Sha256, _>::new(nonce_gen.clone(),MessageKind::Prehashed);
 // Or create an instance for your own application

--- a/schnorr_fun/src/adaptor/mod.rs
+++ b/schnorr_fun/src/adaptor/mod.rs
@@ -17,7 +17,7 @@
 //!     MessageKind, Schnorr,
 //! };
 //! use sha2::Sha256;
-//! let nonce_gen = nonce::from_global_rng::<Sha256, ThreadRng>();
+//! let nonce_gen = nonce::Synthetic::<Sha256, nonce::GlobalRng<ThreadRng>>::default();
 //! let schnorr = Schnorr::<Sha256, _>::new(nonce_gen, MessageKind::Plain { tag: "my-app" });
 //! let signing_keypair = schnorr.new_keypair(Scalar::random(&mut rand::thread_rng()));
 //! let verification_key = signing_keypair.verification_key();
@@ -314,7 +314,7 @@ mod test {
             use sha2::Sha256;
             use rand::rngs::ThreadRng;
             test_schnorr(Schnorr::new(Deterministic::<Sha256>::default(),MessageKind::Plain{ tag: "test" }));
-            test_schnorr(Schnorr::new(nonce::from_global_rng::<Sha256, ThreadRng>(), MessageKind::Plain { tag: "test" }));
+            test_schnorr(Schnorr::new(nonce::Synthetic::<Sha256, nonce::GlobalRng<ThreadRng>>::default(), MessageKind::Plain { tag: "test" }));
         }
     }
 }

--- a/schnorr_fun/src/schnorr.rs
+++ b/schnorr_fun/src/schnorr.rs
@@ -87,12 +87,12 @@ where
     /// ```
     /// use rand::rngs::ThreadRng;
     /// use schnorr_fun::{
-    ///     nonce::{self, Deterministic},
+    ///     nonce::{Deterministic, GlobalRng, Synthetic},
     ///     MessageKind, Schnorr,
     /// };
     /// use sha2::Sha256;
     /// // Use synthetic nonces (preferred)
-    /// let nonce_gen = nonce::from_global_rng::<Sha256, ThreadRng>();
+    /// let nonce_gen = Synthetic::<Sha256, GlobalRng<ThreadRng>>::default();
     /// // Use deterministic nonces.
     /// let nonce_gen = Deterministic::<Sha256>::default();
     /// // Sign pre-hashed messges as in BIP-341.


### PR DESCRIPTION
With the previous API I had to explictly use `PhantomData<fn(R)>` which
sucked. Now we just use GlobalRng<R> instead.