### PR TITLE
Derive default for Scalar

### DIFF
--- a/secp256kfun/src/scalar.rs
+++ b/secp256kfun/src/scalar.rs
@@ -290,6 +290,24 @@ impl HashInto for Scalar {
     }
 }
 
+impl<S> Default for Scalar<S, Zero>
+where
+    S: Secrecy,
+{
+    fn default() -> Self {
+        Scalar::zero().mark::<S>()
+    }
+}
+
+impl<S> Default for Scalar<S, NonZero>
+where
+    S: Secrecy,
+{
+    fn default() -> Self {
+        Scalar::one().mark::<S>()
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;


### PR DESCRIPTION
There may be a reason why you are not already deriving `Default` for `Scalar`, but I can't find it.