### PR TITLE
Make things copy when they're `Public`

### DIFF
--- a/parity_backend/src/field.rs
+++ b/parity_backend/src/field.rs
@@ -13,7 +13,7 @@ macro_rules! debug_assert_bits {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 /// Field element for secp256k1.
 pub struct Field {
     /// Store representation of X.

--- a/parity_backend/src/group.rs
+++ b/parity_backend/src/group.rs
@@ -6,7 +6,7 @@
 // at commit: d453081f81579b03f8ce8c56494779185f0cc29c
 use crate::field::{Field, FieldStorage};
 
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq, Copy)]
 /// A group element of the secp256k1 curve, in affine coordinates.
 pub struct Affine {
     pub x: Field,
@@ -14,7 +14,7 @@ pub struct Affine {
     pub infinity: bool,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 /// A group element of the secp256k1 curve, in jacobian coordinates.
 pub struct Jacobian {
     pub x: Field,

--- a/parity_backend/src/scalar.rs
+++ b/parity_backend/src/scalar.rs
@@ -28,15 +28,9 @@ const SECP256K1_N_H_5: u32 = 0xFFFFFFFF;
 const SECP256K1_N_H_6: u32 = 0xFFFFFFFF;
 const SECP256K1_N_H_7: u32 = 0x7FFFFFFF;
 
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq, Copy)]
 /// A 256-bit scalar value.
 pub struct Scalar(pub [u32; 8]);
-
-impl Drop for Scalar {
-    fn drop(&mut self) {
-        self.clear();
-    }
-}
 
 impl Scalar {
     /// Clear a scalar to prevent the leak of sensitive data.

--- a/schnorr_fun/Cargo.toml
+++ b/schnorr_fun/Cargo.toml
@@ -16,8 +16,7 @@ keywords = ["bitcoin", "schnorr"]
 features = ["serialize_hex", "serialization"]
 
 [dependencies]
-# secp256kfun = { path = "../secp256kfun", version = "^0.3.2-alpha.0", default-features = false }
-secp256kfun = { version = "0.3.1", default-features = false }
+secp256kfun = { path = "../secp256kfun", version = "^0.3.2-alpha.0", default-features = false }
 serde = { version = "1.0", default-features = false, optional = true, features = ["derive"] }
 
 [dev-dependencies]
@@ -25,8 +24,7 @@ rand = { version = "0.7", features = ["wasm-bindgen"] }
 lazy_static = "1.4"
 bincode = "1.0"
 sha2 = "0.9"
-secp256kfun = { version = "0.3.1"  }
-#secp256kfun = { path = "../secp256kfun", version = "^0.3.2-alpha.0", features = ["alloc"] }
+secp256kfun = { path = "../secp256kfun", version = "^0.3.2-alpha.0", features = ["alloc"] }
 
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]

--- a/secp256kfun/Cargo.toml
+++ b/secp256kfun/Cargo.toml
@@ -20,7 +20,7 @@ digest = "0.9"
 subtle = { version = "2.2" }
 rand_core = { version = "0.5" }
 serde = { version = "1.0",  optional = true, default-features = false, features = ["derive"] }
-parity_backend = { version = "0.1.1", package = "secp256kfun_parity_backend" }
+parity_backend = { path = "../parity_backend", version = "0.1.3-alpha.0", "package" = "secp256kfun_parity_backend" }
 secp256k1 = { version = "0.17", optional = true, default-features = false }
 
 [dev-dependencies]
@@ -37,7 +37,7 @@ bincode = "1.0"
 criterion = "0.3"
 
 [build-dependencies]
-parity_backend = { version = "0.1.2", package = "secp256kfun_parity_backend", features = ["alloc"] }
+parity_backend = { version = "0.1.3-alpha.0", path = "../parity_backend", features = ["alloc"], "package"  = "secp256kfun_parity_backend" }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test = "0.3"

--- a/secp256kfun/src/backend/parity/mod.rs
+++ b/secp256kfun/src/backend/parity/mod.rs
@@ -125,7 +125,7 @@ impl crate::backend::BackendPoint for Jacobian {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Copy)]
 pub struct XOnly([u8; 32]);
 
 impl XOnly {

--- a/secp256kfun/src/marker/zero_choice.rs
+++ b/secp256kfun/src/marker/zero_choice.rs
@@ -1,10 +1,10 @@
 /// Something marked with Zero might be `0` i.e. the additive identity
-#[derive(Debug, Clone, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
 #[cfg_attr(feautre = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Zero;
 
 /// Something marked with `NonZero` is guaranteed not to be 0.
-#[derive(Debug, Clone, Default, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
 #[cfg_attr(feautre = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct NonZero;
 

--- a/secp256kfun/src/point.rs
+++ b/secp256kfun/src/point.rs
@@ -56,6 +56,8 @@ impl<Z, S, T: Clone> Clone for Point<T, S, Z> {
     }
 }
 
+impl<T: Copy, Z: Copy> Copy for Point<T, Public, Z> {}
+
 impl Point<Normal, Public, NonZero> {
     /// Creates a Point the compressed encoding specified in [_Standards for
     /// Efficient Cryptography_]. This is the typical encoding used in

--- a/secp256kfun/src/xonly.rs
+++ b/secp256kfun/src/xonly.rs
@@ -15,7 +15,7 @@ use rand_core::{CryptoRng, RngCore};
 /// store the full point in memory.
 ///
 /// [`Point<T,S,Z>`]: crate::Point
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct XOnly(pub(crate) backend::XOnly);
 
 impl XOnly {


### PR DESCRIPTION
Things should be `Copy` if they're Public. In the future hopefully things that are `Secret` will be zeroed and Pinned in memory internally but for now we can at least make `Public` things `Copy`.