### PR TITLE
Remove grin secp dev dependency

### DIFF
--- a/ecdsa_fun/Cargo.toml
+++ b/ecdsa_fun/Cargo.toml
@@ -20,7 +20,8 @@ secp256kfun = { path = "../secp256kfun", version = "^0.3.2-alpha.0", default-fea
 serde = { version = "1.0", default-features = false, optional = true, features = ["derive"] }
 
 [dev-dependencies]
-secp256k1 = { default-features = false, version = "0.17", features = ["std"] }
+secp256k1 = { default-features = false, version = "0.19", features = ["std"] }
+secp256kfun = { path = "../secp256kfun", version = "^0.3.2-alpha.0", features = ["libsecp_compat"] }
 rand = "0.7"
 criterion = "0.3"
 hex-literal = "0.2"

--- a/ecdsa_fun/benches/bench_ecdsa.rs
+++ b/ecdsa_fun/benches/bench_ecdsa.rs
@@ -1,5 +1,5 @@
 use criterion::{criterion_group, criterion_main, Criterion};
-use secp256kfun::{marker::*, nonce::Deterministic, Scalar};
+use secp256kfun::{marker::*, nonce::Deterministic, secp256k1, Scalar};
 use sha2::Sha256;
 
 const MESSAGE: &'static [u8; 32] = b"hello world you are beautiful!!!";

--- a/ecdsa_fun/tests/against_c_lib.rs
+++ b/ecdsa_fun/tests/against_c_lib.rs
@@ -1,9 +1,11 @@
 #![cfg(feature = "libsecp_compat")]
 use ecdsa_fun::{
     self,
-    fun::{Point, Scalar, TEST_SOUNDNESS},
+    fun::{
+        secp256k1::{self, Message, PublicKey, SecretKey},
+        Point, Scalar, TEST_SOUNDNESS,
+    },
 };
-use secp256k1::{Message, PublicKey, SecretKey};
 
 fn rand_32_bytes() -> [u8; 32] {
     use rand::RngCore;

--- a/schnorr_fun/Cargo.toml
+++ b/schnorr_fun/Cargo.toml
@@ -29,7 +29,6 @@ secp256kfun = { path = "../secp256kfun", version = "^0.3.2-alpha.0", features = 
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 criterion = "0.3"
-grin_secp256k1zkp = "0.7"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test = "0.3"

--- a/schnorr_fun/benches/bench_schnorr.rs
+++ b/schnorr_fun/benches/bench_schnorr.rs
@@ -1,3 +1,4 @@
+//! This broken and just as a reference until we get proper bip340 benchmarks from proper rust lib
 #![allow(non_upper_case_globals)]
 use criterion::{criterion_group, criterion_main, Criterion};
 use schnorr_fun::{MessageKind, Schnorr};

--- a/secp256kfun/Cargo.toml
+++ b/secp256kfun/Cargo.toml
@@ -21,7 +21,7 @@ subtle = { version = "2.2" }
 rand_core = { version = "0.5" }
 serde = { version = "1.0",  optional = true, default-features = false, features = ["derive"] }
 parity_backend = { path = "../parity_backend", version = "0.1.3-alpha.0", "package" = "secp256kfun_parity_backend" }
-secp256k1 = { version = "0.17", optional = true, default-features = false }
+secp256k1 = { version = "0.19", optional = true, default-features = false }
 
 [dev-dependencies]
 hex-literal = "0.2"
@@ -31,8 +31,7 @@ lazy_static = "1.4"
 sha2 = "0.9"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-secp256k1 = { default-features = false, version = "0.17", features = ["std"] }
-grin_secp256k1zkp = "0.7"
+secp256k1 = { default-features = false, version = "0.19", features = ["std"] }
 bincode = "1.0"
 criterion = "0.3"
 

--- a/secp256kfun/tests/against_c_lib.rs
+++ b/secp256kfun/tests/against_c_lib.rs
@@ -134,27 +134,12 @@ mod test {
     }
 
     #[test]
-    fn scalar_inversion() {
-        // we have to test against this grin secp because that's the one that exposes it
-        use secp256k1zkp::key::SecretKey;
-        let secp = secp256k1zkp::Secp256k1::new();
-        let bytes = rand_32_bytes();
-        let mut sk = SecretKey::from_slice(&secp, &bytes).unwrap();
-        let scalar = Scalar::from_bytes_mod_order(bytes.clone())
-            .mark::<NonZero>()
-            .unwrap();
-        sk.inv_assign(&secp).unwrap();
-        assert_eq!(&scalar.invert().to_bytes()[..], &sk[..]);
-    }
-
-    #[test]
     fn scalar_negation() {
-        use secp256k1zkp::key::SecretKey;
-        let secp = secp256k1zkp::Secp256k1::new();
+        use secp256k1::key::SecretKey;
         let bytes = rand_32_bytes();
-        let mut sk = SecretKey::from_slice(&secp, &bytes).unwrap();
+        let mut sk = SecretKey::from_slice(&bytes).unwrap();
         let scalar = Scalar::from_bytes_mod_order(bytes.clone());
-        sk.neg_assign(&secp).unwrap();
+        sk.negate_assign();
         assert_eq!(&(-scalar).to_bytes()[..], &sk[..]);
     }
 }


### PR DESCRIPTION
These benchmarks/tests are not adding much value. 
It is unfortunate we lost the inversion one but this can be verified by a mulitplication.