### PR TITLE
Replace ordinary tests with proptests

### DIFF
--- a/secp256kfun/Cargo.toml
+++ b/secp256kfun/Cargo.toml
@@ -22,6 +22,7 @@ rand_core = { version = "0.5" }
 serde = { version = "1.0",  optional = true, default-features = false, features = ["derive"] }
 parity_backend = { version = "0.1.1", package = "secp256kfun_parity_backend" }
 secp256k1 = { version = "0.17", optional = true, default-features = false }
+proptest = { version = "0.10", optional = true }
 
 [dev-dependencies]
 hex-literal = "0.2"

--- a/secp256kfun/src/lib.rs
+++ b/secp256kfun/src/lib.rs
@@ -40,6 +40,8 @@ pub extern crate secp256k1;
 pub extern crate serde;
 #[cfg(feature = "libsecp_compat")]
 mod libsecp_compat;
+#[cfg(feature = "proptest")]
+pub mod proptest;
 /// The main basepoint for secp256k1 as specified in [_SEC 2: Recommended Elliptic Curve Domain Parameters_] and used in Bitcoin.
 ///
 /// At the moment, [`G`] is the only [`BasePoint`] in the library.

--- a/secp256kfun/src/proptest.rs
+++ b/secp256kfun/src/proptest.rs
@@ -1,0 +1,34 @@
+//! Functions used to generate test data for property-based testing with [`proptest`].
+//!
+//! [`proptest`]: https://github.com/altsysrq/proptest
+use crate::{marker::*, Point, Scalar, G};
+use ::proptest::prelude::*;
+
+prop_compose! {
+    /// Generate a random `Scalar`.
+    pub fn scalar()(
+        bytes in any::<[u8; 32]>(),
+    ) -> Scalar<Secret, Zero> {
+        Scalar::from_bytes_mod_order(bytes)
+    }
+}
+
+prop_compose! {
+    /// Generate a random, non-zero `Scalar`.
+    pub fn non_zero_scalar()(
+        bytes in any::<[u8; 32]>()
+            .prop_filter("Value cannot be zero",
+                         |bytes| bytes != &[0u8; 32]),
+    ) -> Scalar {
+        Scalar::from_bytes_mod_order(bytes).mark::<NonZero>().unwrap()
+    }
+}
+
+prop_compose! {
+    /// Generate a random `Point`.
+    pub fn point()(
+        mut x in non_zero_scalar(),
+    ) -> Point {
+        Point::from_scalar_mul(G, &mut x).mark::<Normal>()
+    }
+}

--- a/sigma_fun/Cargo.toml
+++ b/sigma_fun/Cargo.toml
@@ -9,13 +9,14 @@ edition = "2018"
 [dependencies]
 generic-array = "0.14"
 digest = "0.9"
-secp256kfun = { path = "../secp256kfun", version = "^0.3.2-alpha.0", default-features = false, optional = true, features = ["proptest"] }
+secp256kfun = { path = "../secp256kfun", version = "^0.3.2-alpha.0", default-features = false, optional = true }
 curve25519-dalek = { version = "3", default-features = false, optional = true, features = ["u64_backend"] }
 rand_chacha = "0.2"
 serde_crate = { package = "serde", version = "1.0", optional = true, default-features = false, features = ["derive"] }
 proptest = "0.10"
 
 [dev-dependencies]
+secp256kfun = { path = "../secp256kfun", version = "^0.3.2-alpha.0", default-features = false, features = ["proptest"] }
 rand = "0.7"
 sha2 = "0.9"
 bincode = "1"

--- a/sigma_fun/Cargo.toml
+++ b/sigma_fun/Cargo.toml
@@ -9,10 +9,11 @@ edition = "2018"
 [dependencies]
 generic-array = "0.14"
 digest = "0.9"
-secp256kfun = { path = "../secp256kfun", version = "^0.3.2-alpha.0", default-features = false, optional = true }
+secp256kfun = { path = "../secp256kfun", version = "^0.3.2-alpha.0", default-features = false, optional = true, features = ["proptest"] }
 curve25519-dalek = { version = "3", default-features = false, optional = true, features = ["u64_backend"] }
 rand_chacha = "0.2"
 serde_crate = { package = "serde", version = "1.0", optional = true, default-features = false, features = ["derive"] }
+proptest = "0.10"
 
 [dev-dependencies]
 rand = "0.7"

--- a/sigma_fun/src/and.rs
+++ b/sigma_fun/src/and.rs
@@ -121,25 +121,29 @@ crate::impl_display!(And<A,B>);
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::secp256k1::fun::proptest::non_zero_scalar;
+    use ::proptest::prelude::*;
 
-    #[test]
-    fn and_dlbp() {
-        use crate::{
-            secp256k1,
-            secp256k1::fun::{g, marker::*, Scalar, G},
-        };
-        use generic_array::typenum::U32;
-        use sha2::Sha256;
+    proptest! {
+        #[test]
+        fn and_dlbp(
+            x in non_zero_scalar(),
+            y in non_zero_scalar(),
+        ) {
+            use crate::{
+                secp256k1::{self, fun::{g, marker::*, G}},
+            };
+            use generic_array::typenum::U32;
+            use sha2::Sha256;
 
-        type AndDL = And<secp256k1::DLBP<U32>, secp256k1::DLBP<U32>>;
+            type AndDL = And<secp256k1::DLBP<U32>, secp256k1::DLBP<U32>>;
 
-        let x = Scalar::random(&mut rand::thread_rng());
-        let y = Scalar::random(&mut rand::thread_rng());
-        let xG = g!(x * G).mark::<Normal>();
-        let yG = g!(y * G).mark::<Normal>();
-        let statement = (xG, yG);
-        let proof_system = crate::FiatShamir::<_, Sha256>::new(AndDL::default());
-        let proof = proof_system.prove(&(x, y), &statement, &mut rand::thread_rng());
-        assert!(proof_system.verify(&statement, &proof));
+            let xG = g!(x * G).mark::<Normal>();
+            let yG = g!(y * G).mark::<Normal>();
+            let statement = (xG, yG);
+            let proof_system = crate::FiatShamir::<_, Sha256>::new(AndDL::default());
+            let proof = proof_system.prove(&(x, y), &statement, &mut rand::thread_rng());
+            assert!(proof_system.verify(&statement, &proof));
+        }
     }
 }

--- a/sigma_fun/tests/dleq.rs
+++ b/sigma_fun/tests/dleq.rs
@@ -1,7 +1,15 @@
 #![allow(non_snake_case)]
+use ::proptest::prelude::*;
 use sha2::Sha256;
 use sigma_fun::{
-    ed25519, secp256k1,
+    ed25519::{
+        self,
+        proptest::{ed25519_point, ed25519_scalar},
+    },
+    secp256k1::{
+        self,
+        fun::proptest::{non_zero_scalar as secp256k1_non_zero_scalar, point as secp256k1_point},
+    },
     typenum::{U20, U31, U32},
     Eq, FiatShamir,
 };
@@ -40,30 +48,61 @@ fn secp256k1_dleq_has_correct_name() {
     assert_eq!(&format!("{}", dleq), "eq(DLBP-secp256k1,DL-secp256k1)");
 }
 
-#[test]
-pub fn test_dleq_secp256k1() {
-    use sigma_fun::secp256k1::fun::{g, marker::*, Point, Scalar, G};
-    let x = Scalar::random(&mut rand::thread_rng());
-    let H = Point::random(&mut rand::thread_rng());
-    let xG = g!(x * G).mark::<Normal>();
-    let xH = g!(x * H).mark::<Normal>();
-    let statement = ((xG), (H, xH));
+proptest! {
+    #[test]
+    fn test_dleq_secp256k1(
+        x in secp256k1_non_zero_scalar(),
+        H in secp256k1_point(),
+        unrelated_point in secp256k1_point(),
+    ) {
+        use sigma_fun::secp256k1::fun::{g, marker::*, G};
+        let xG = g!(x * G).mark::<Normal>();
+        let xH = g!(x * H).mark::<Normal>();
+        let statement = ((xG), (H, xH));
 
-    run_dleq!(secp256k1, challenge_length => U32, statement => statement, witness => x, unrelated_point => Point::random(&mut rand::thread_rng()));
-    run_dleq!(secp256k1, challenge_length => U20, statement => statement, witness => x, unrelated_point => Point::random(&mut rand::thread_rng()));
+        run_dleq!(
+            secp256k1,
+            challenge_length => U32,
+            statement => statement,
+            witness => x,
+            unrelated_point => unrelated_point.clone()
+        );
+        run_dleq!(
+            secp256k1,
+            challenge_length => U20,
+            statement => statement,
+            witness => x,
+            unrelated_point => unrelated_point
+        );
+    }
 }
 
-#[test]
-pub fn test_dleq_ed25519() {
-    use curve25519_dalek::{constants::ED25519_BASEPOINT_POINT, scalar::Scalar};
-    let G = ED25519_BASEPOINT_POINT;
-    let x = Scalar::random(&mut rand::thread_rng());
-    let h = Scalar::random(&mut rand::thread_rng());
-    let H = h * G;
-    let xG = x * G;
-    let xH = x * H;
-    let statement = ((xG), (H, xH));
+proptest! {
+    #[test]
+    fn test_dleq_ed25519(
+        x in ed25519_scalar(),
+        H in ed25519_point(),
+        unrelated_point in ed25519_point(),
+    ) {
+        use curve25519_dalek::{constants::ED25519_BASEPOINT_POINT};
+        let G = ED25519_BASEPOINT_POINT;
+        let xG = x * G;
+        let xH = x * H;
+        let statement = ((xG), (H, xH));
 
-    run_dleq!(ed25519, challenge_length => U31, statement => statement, witness => x, unrelated_point =>  H + G);
-    run_dleq!(ed25519, challenge_length => U20, statement => statement, witness => x, unrelated_point =>  H + G);
+        run_dleq!(
+            ed25519,
+            challenge_length => U31,
+            statement => statement,
+            witness => x,
+            unrelated_point => unrelated_point
+        );
+        run_dleq!(
+            ed25519,
+            challenge_length => U20,
+            statement => statement,
+            witness => x,
+            unrelated_point => unrelated_point
+        );
+    }
 }


### PR DESCRIPTION
I tried to modify all the tests that would benefit from this approach. Let me know if I missed some.

I added a `proptest` feature flag to `secp256kfun` so that we can define the functions which generate the test data in one place and a consumer of the library (such as the `sigma_fun` crate) can use them to write property-based tests.

I configured the tests in `dl_secp256k1_ed25519_eq.rs` with `#![proptest_config(ProptestConfig::with_cases(10))]`, because these are slow tests (2-4 seconds). You may want to only run them once as opposed to 10 times if you care about CI speed.