### PR TITLE
Make core primitives Eq and Hash

### DIFF
--- a/parity_backend/src/scalar.rs
+++ b/parity_backend/src/scalar.rs
@@ -28,7 +28,7 @@ const SECP256K1_N_H_5: u32 = 0xFFFFFFFF;
 const SECP256K1_N_H_6: u32 = 0xFFFFFFFF;
 const SECP256K1_N_H_7: u32 = 0x7FFFFFFF;
 
-#[derive(Debug, Clone, Eq, PartialEq, Copy)]
+#[derive(Debug, Clone, Eq, PartialEq, Copy, Hash)]
 /// A 256-bit scalar value.
 pub struct Scalar(pub [u32; 8]);
 

--- a/secp256kfun/src/backend/parity/mod.rs
+++ b/secp256kfun/src/backend/parity/mod.rs
@@ -125,7 +125,7 @@ impl crate::backend::BackendPoint for Jacobian {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Copy)]
+#[derive(Debug, Clone, PartialEq, Copy, Eq, Hash)]
 pub struct XOnly([u8; 32]);
 
 impl XOnly {

--- a/secp256kfun/src/point.rs
+++ b/secp256kfun/src/point.rs
@@ -250,6 +250,14 @@ impl<T1, S1, Z1, T2, S2, Z2> PartialEq<Point<T2, S2, Z2>> for Point<T1, S1, Z1> 
     }
 }
 
+impl<T, S, Z> Eq for Point<T, S, Z> {}
+
+impl<T: Normalized> core::hash::Hash for Point<T, Public, NonZero> {
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+        self.to_bytes().hash(state)
+    }
+}
+
 impl<S, T: Normalized> Point<T, S, NonZero> {
     /// Returns the x and y coordinates of the point as two 32-byte arrays containing their big endian encoding.
     ///

--- a/secp256kfun/src/scalar.rs
+++ b/secp256kfun/src/scalar.rs
@@ -47,8 +47,14 @@ use rand_core::{CryptoRng, RngCore};
 /// [`Secrecy`]: crate::marker::Secrecy
 /// [`Secret`]: crate::marker::Secret
 /// [`ZeroChoice]: crate::marker::ZeroChoice
-#[derive(Clone)]
+#[derive(Clone, Eq)]
 pub struct Scalar<S = Secret, Z = NonZero>(pub(crate) backend::Scalar, PhantomData<(Z, S)>);
+
+impl<Z> core::hash::Hash for Scalar<Public, Z> {
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+        self.to_bytes().hash(state)
+    }
+}
 
 impl<Z, S> Scalar<S, Z> {
     /// Serializes the scalar to its 32-byte big-endian representation

--- a/secp256kfun/src/xonly.rs
+++ b/secp256kfun/src/xonly.rs
@@ -15,7 +15,7 @@ use rand_core::{CryptoRng, RngCore};
 /// store the full point in memory.
 ///
 /// [`Point<T,S,Z>`]: crate::Point
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Eq, Hash)]
 pub struct XOnly(pub(crate) backend::XOnly);
 
 impl XOnly {


### PR DESCRIPTION
Because there's no reason not to!

- Only Hash if they're Public since it's likely the hash algorithm is not constant time
- I only made NonZero normalized Points hash because it was awkward to hash th point at infinity.