### PR TITLE
Revert "Re-export proptest from secp256kfun"

### DIFF
--- a/secp256kfun/src/proptest.rs
+++ b/secp256kfun/src/proptest.rs
@@ -2,9 +2,7 @@
 //!
 //! [`proptest`]: https://github.com/altsysrq/proptest
 use crate::{marker::*, Point, Scalar, G};
-use proptest::prelude::*;
-
-pub use proptest::*;
+use ::proptest::prelude::*;
 
 prop_compose! {
     /// Generate a random `Scalar`.

--- a/sigma_fun/Cargo.toml
+++ b/sigma_fun/Cargo.toml
@@ -9,12 +9,14 @@ edition = "2018"
 [dependencies]
 generic-array = "0.14"
 digest = "0.9"
-secp256kfun = { path = "../secp256kfun", version = "^0.3.2-alpha.0", default-features = false, optional = true, features = ["proptest"] }
+secp256kfun = { path = "../secp256kfun", version = "^0.3.2-alpha.0", default-features = false, optional = true }
 curve25519-dalek = { version = "3", default-features = false, optional = true, features = ["u64_backend"] }
 rand_chacha = "0.2"
 serde_crate = { package = "serde", version = "1.0", optional = true, default-features = false, features = ["derive"] }
+proptest = "0.10"
 
 [dev-dependencies]
+secp256kfun = { path = "../secp256kfun", version = "^0.3.2-alpha.0", default-features = false, features = ["proptest"] }
 rand = "0.7"
 sha2 = "0.9"
 bincode = "1"

--- a/sigma_fun/src/and.rs
+++ b/sigma_fun/src/and.rs
@@ -122,7 +122,7 @@ crate::impl_display!(And<A,B>);
 mod test {
     use super::*;
     use crate::secp256k1::fun::proptest::non_zero_scalar;
-    use secp256kfun::proptest::prelude::*;
+    use ::proptest::prelude::*;
 
     proptest! {
         #[test]

--- a/sigma_fun/src/ed25519.rs
+++ b/sigma_fun/src/ed25519.rs
@@ -185,7 +185,7 @@ fn normalize_challenge<L: ArrayLength<u8>>(challenge: &GenericArray<u8, L>) -> S
 
 pub mod proptest {
     use super::*;
-    use secp256kfun::proptest::prelude::*;
+    use ::proptest::prelude::*;
 
     prop_compose! {
         pub fn ed25519_scalar()(
@@ -208,8 +208,8 @@ pub mod proptest {
 mod test {
     use super::*;
     use crate::{ed25519::proptest::ed25519_scalar, FiatShamir};
+    use ::proptest::prelude::*;
     use generic_array::typenum::U31;
-    use secp256kfun::proptest::prelude::*;
     use sha2::Sha256;
 
     proptest! {

--- a/sigma_fun/src/ext/dl_secp256k1_ed25519_eq.rs
+++ b/sigma_fun/src/ext/dl_secp256k1_ed25519_eq.rs
@@ -243,7 +243,7 @@ mod test {
         ed25519::proptest::{ed25519_point, ed25519_scalar},
         secp256k1::fun::proptest::point as secp256k1_point,
     };
-    use secp256kfun::proptest::prelude::*;
+    use ::proptest::prelude::*;
     use sha2::Sha256;
 
     proptest! {

--- a/sigma_fun/src/or.rs
+++ b/sigma_fun/src/or.rs
@@ -194,8 +194,9 @@ mod test {
         },
         Either,
     };
+    use ::proptest::prelude::*;
     use generic_array::typenum::U32;
-    use secp256kfun::{g, marker::*, proptest::prelude::*, G};
+    use secp256kfun::{g, marker::*, G};
     use sha2::Sha256;
 
     proptest! {

--- a/sigma_fun/tests/dleq.rs
+++ b/sigma_fun/tests/dleq.rs
@@ -1,5 +1,5 @@
 #![allow(non_snake_case)]
-use secp256kfun::proptest::prelude::*;
+use ::proptest::prelude::*;
 use sha2::Sha256;
 use sigma_fun::{
     ed25519::{


### PR DESCRIPTION
Reverts LLFourn/secp256kfun#40

Actually this is a bad idea since secp256kfun is an optional dependency.