### PR TITLE
Revamp schnorr fun

### DIFF
--- a/ecdsa_fun/src/adaptor/mod.rs
+++ b/ecdsa_fun/src/adaptor/mod.rs
@@ -60,8 +60,12 @@
 //! ```
 use crate::{Signature, ECDSA};
 use secp256kfun::{
-    derive_nonce_rng, digest::generic_array::typenum::U32, g, hash::AddTag, marker::*,
-    nonce::NonceGen, s, Point, Scalar, G,
+    derive_nonce_rng,
+    digest::generic_array::typenum::U32,
+    g,
+    marker::*,
+    nonce::{AddTag, NonceGen},
+    s, Point, Scalar, G,
 };
 pub use sigma_fun::HashTranscript;
 use sigma_fun::{secp256k1, Eq, FiatShamir, ProverTranscript, Transcript};

--- a/ecdsa_fun/src/lib.rs
+++ b/ecdsa_fun/src/lib.rs
@@ -17,7 +17,12 @@ mod libsecp_compat;
 #[cfg(feature = "serde")]
 extern crate serde_crate as serde;
 
-use fun::{derive_nonce, g, hash::AddTag, marker::*, nonce::NonceGen, s, Point, Scalar, G};
+use fun::{
+    derive_nonce, g,
+    marker::*,
+    nonce::{AddTag, NonceGen},
+    s, Point, Scalar, G,
+};
 pub use secp256kfun as fun;
 pub use secp256kfun::nonce;
 mod signature;
@@ -68,7 +73,7 @@ impl<NG> ECDSA<NG> {
         NG: AddTag,
     {
         ECDSA {
-            nonce_gen: nonce_gen.add_protocol_tag("ECDSA"),
+            nonce_gen: nonce_gen.add_tag("secp256kfun/ecdsa_fun"),
             enforce_low_s: false,
         }
     }

--- a/schnorr_fun/README.md
+++ b/schnorr_fun/README.md
@@ -29,21 +29,17 @@ This library and [secp256kfun] are experimental.
 use schnorr_fun::{
     fun::{marker::*, Scalar, nonce},
     Schnorr,
-    MessageKind,
+    Message
 };
 use sha2::Sha256;
 use rand::rngs::ThreadRng;
 // Use synthetic nonces
 let nonce_gen = nonce::Synthetic::<Sha256, nonce::GlobalRng<ThreadRng>>::default();
-// Create a BIP-341 compatible instance
-let schnorr = Schnorr::<Sha256, _>::new(nonce_gen.clone(),MessageKind::Prehashed);
-// Or create an instance for your own application
-let schnorr = Schnorr::<Sha256,_>::new(nonce_gen, MessageKind::Plain { tag: "my-app" });
+let schnorr = Schnorr::<Sha256, _>::new(nonce_gen.clone());
 // Generate your public/private key-pair
 let keypair = schnorr.new_keypair(Scalar::random(&mut rand::thread_rng()));
-let message = b"Chancellor on brink of second bailout for banks"
-    .as_ref()
-    .mark::<Public>();
+// Sign a variable length message
+let message = Message::<Public>::plain("the-times-of-london", b"Chancellor on brink of second bailout for banks");
 // Sign the message with our keypair
 let signature = schnorr.sign(&keypair, message);
 // Get the verifier's key

--- a/schnorr_fun/src/adaptor/encrypted_signature.rs
+++ b/schnorr_fun/src/adaptor/encrypted_signature.rs
@@ -41,12 +41,15 @@ mod test {
     #[test]
     fn encrypted_signature_serialization_roundtrip() {
         use super::*;
-        use crate::{adaptor::*, fun::Scalar};
+        use crate::{adaptor::*, fun::Scalar, Message};
         let schnorr = crate::test_instance!();
         let kp = schnorr.new_keypair(Scalar::random(&mut rand::thread_rng()));
         let encryption_key = Point::random(&mut rand::thread_rng());
-        let encrypted_signature =
-            schnorr.encrypted_sign(&kp, &encryption_key, b"test".as_ref().mark::<Public>());
+        let encrypted_signature = schnorr.encrypted_sign(
+            &kp,
+            &encryption_key,
+            Message::<Public>::plain("test", b"foo"),
+        );
         let serialized = bincode::serialize(&encrypted_signature).unwrap();
         assert_eq!(serialized.len(), 65);
         let deserialized = bincode::deserialize::<EncryptedSignature>(&serialized).unwrap();

--- a/schnorr_fun/src/lib.rs
+++ b/schnorr_fun/src/lib.rs
@@ -23,6 +23,8 @@ mod keypair;
 pub use keypair::KeyPair;
 mod schnorr;
 pub use schnorr::*;
+mod message;
+pub use message::*;
 
 #[macro_export]
 #[doc(hidden)]
@@ -30,7 +32,6 @@ macro_rules! test_instance {
     () => {
         $crate::Schnorr::<sha2::Sha256, _>::new(
             $crate::nonce::Deterministic::<sha2::Sha256>::default(),
-            $crate::MessageKind::Plain { tag: "test" },
         )
     };
 }

--- a/schnorr_fun/src/message.rs
+++ b/schnorr_fun/src/message.rs
@@ -1,0 +1,69 @@
+use secp256kfun::{digest::Digest, hash::HashInto, marker::*, Slice};
+
+/// A message to be signed.
+///
+/// The `S` parameter is a [`Secrecy`] which is used when signing a verifying to check whether the
+/// challenge scalar produced with the message should be secret.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Message<'a, S = Public> {
+    /// The message bytes
+    pub bytes: Slice<'a, S>,
+    /// The optional application tag to separate the signature from other applications.
+    pub app_tag: Option<&'static str>,
+}
+
+impl<'a, 'b, S: Secrecy> Message<'a, S> {
+    /// Create a raw message with no `app_tag`. The message bytes will be passed straight into the
+    /// challenge hash. Usually, you only use this when signing a pre-hashed message.
+    pub fn raw(bytes: &'a [u8]) -> Self {
+        Message {
+            bytes: bytes.mark::<S>(),
+            app_tag: None,
+        }
+    }
+
+    /// Signs a plain variable length message.
+    ///
+    /// You must provide an application tag to make sure signatures valid in one context are not
+    /// valid in another. The tag is used as described [here].
+    ///
+    /// [here]: https://github.com/sipa/bips/issues/207#issuecomment-673681901
+    pub fn plain(app_tag: &'static str, bytes: &'a [u8]) -> Self {
+        assert!(app_tag.len() <= 64, "tag must not be 64 bytes or less");
+        assert!(!app_tag.is_empty(), "tag must not be empty");
+        Message {
+            bytes: bytes.mark::<S>(),
+            app_tag: Some(app_tag),
+        }
+    }
+}
+
+impl<S> HashInto for Message<'_, S> {
+    fn hash_into(&self, hash: &mut impl Digest) {
+        if let Some(prefix) = self.app_tag {
+            let mut padded_prefix = [0u8; 64];
+            padded_prefix[..prefix.len()].copy_from_slice(prefix.as_bytes());
+            hash.update(padded_prefix);
+        }
+        hash.update(<&[u8]>::from(self.bytes));
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use sha2::Sha256;
+
+    #[test]
+    fn message_hash_into() {
+        let mut hash1 = Sha256::default();
+        hash1.update("test");
+        hash1.update([0u8; 60].as_ref());
+        hash1.update("hello world");
+
+        let mut hash2 = Sha256::default();
+        Message::<Public>::plain("test", b"hello world").hash_into(&mut hash2);
+
+        assert_eq!(hash1.finalize(), hash2.finalize());
+    }
+}

--- a/schnorr_fun/src/signature.rs
+++ b/schnorr_fun/src/signature.rs
@@ -139,10 +139,10 @@ mod test {
     #[test]
     fn signature_serialization_roundtrip() {
         use super::*;
-        use crate::fun::Scalar;
+        use crate::{fun::Scalar, Message};
         let schnorr = crate::test_instance!();
         let kp = schnorr.new_keypair(Scalar::random(&mut rand::thread_rng()));
-        let signature = schnorr.sign(&kp, b"test".as_ref().mark::<Public>());
+        let signature = schnorr.sign(&kp, Message::<Public>::plain("test", b"foo"));
         let serialized = bincode::serialize(&signature).unwrap();
         assert_eq!(serialized.len(), 64);
         let deserialized = bincode::deserialize::<Signature>(&serialized).unwrap();

--- a/secp256kfun/src/hash.rs
+++ b/secp256kfun/src/hash.rs
@@ -96,35 +96,3 @@ impl<D: Digest> HashAdd for D {
         self
     }
 }
-
-/// Trait for things that can domain separate themselves.
-///
-/// i.e. given a protocol or application tag can produce a new version that will
-/// not give the same outputs for a given input if the tags are different.
-pub trait AddTag {
-    /// Tells the invocant to return a new version of itself modifies with the
-    /// protocol tag. This is to ensure that the `AddTag` does not produce the
-    /// same outputs for tow different protocols even if they have the same
-    /// public inputs. By "protocol" we mean type of cryptographic scheme. For
-    /// example, for the [BIP-340] signature scheme you would use "BIP340" as
-    /// the tag.
-    ///
-    /// [BIP-340]: https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki
-    fn add_protocol_tag(self, tag: &str) -> Self;
-    /// Tells the `AddTag` to further domain separate itself for a particular
-    /// application. This is useful when you are domain separating signatures in
-    /// your application from other signatures.
-    fn add_application_tag(self, tag: &str) -> Self;
-}
-
-/// AddTag is implemented for () so you can use implement things generically for
-/// `AddTag` even for things that have some field set to () (for example
-/// `NonceGen` when you're doing verification only).
-impl AddTag for () {
-    fn add_protocol_tag(self, _tag: &str) -> Self {
-        ()
-    }
-    fn add_application_tag(self, _tag: &str) -> Self {
-        ()
-    }
-}

--- a/secp256kfun/src/macros.rs
+++ b/secp256kfun/src/macros.rs
@@ -314,10 +314,10 @@ macro_rules! test_plus_wasm {
 /// on the cryptographic scheme and is crucial to get right.
 ///
 /// ```
-/// use secp256kfun::{Scalar, derive_nonce, hash::AddTag, nonce::{NonceGen,Deterministic}};
+/// use secp256kfun::{Scalar, derive_nonce, nonce::AddTag, nonce::{NonceGen,Deterministic}};
 /// use sha2::Sha256;
 /// let secret_scalar = Scalar::random(&mut rand::thread_rng());
-/// let nonce_gen = Deterministic::<Sha256>::default().add_protocol_tag("my-protocol");
+/// let nonce_gen = Deterministic::<Sha256>::default().add_tag("my-protocol");
 /// let r = derive_nonce!(
 ///     nonce_gen => nonce_gen,
 ///     secret => &secret_scalar,
@@ -349,10 +349,10 @@ macro_rules! derive_nonce {
 /// # Examples
 ///
 /// ```
-/// use secp256kfun::{Scalar, derive_nonce_rng, hash::AddTag, nonce::{NonceGen,Deterministic}};
+/// use secp256kfun::{Scalar, derive_nonce_rng, nonce::AddTag, nonce::{NonceGen,Deterministic}};
 /// use sha2::Sha256;
 /// let secret_scalar = Scalar::random(&mut rand::thread_rng());
-/// let nonce_gen = Deterministic::<Sha256>::default().add_protocol_tag("my-protocol");
+/// let nonce_gen = Deterministic::<Sha256>::default().add_tag("my-protocol");
 /// let mut rng = derive_nonce_rng!(
 ///     nonce_gen => nonce_gen,
 ///     secret => &secret_scalar,

--- a/secp256kfun/src/slice.rs
+++ b/secp256kfun/src/slice.rs
@@ -22,11 +22,22 @@ use subtle::ConstantTimeEq;
 /// ```
 ///
 /// [`mark`]: crate::marker::Mark::mark
-#[derive(Debug, Clone, Copy)]
-pub struct Slice<'a, S> {
+#[derive(Debug)]
+pub struct Slice<'a, S = Public> {
     pub(crate) inner: &'a [u8],
     secrecy: PhantomData<S>,
 }
+
+impl<'a, S> Clone for Slice<'a, S> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner,
+            secrecy: PhantomData,
+        }
+    }
+}
+
+impl<'a, S> Copy for Slice<'a, S> {}
 
 impl<'a, 'b, S1, S2> PartialEq<Slice<'b, S2>> for Slice<'a, S1> {
     default fn eq(&self, rhs: &Slice<'b, S2>) -> bool {


### PR DESCRIPTION
Before you had to create a new Schnorr instance for each application.
Now you just call `.sign` with the application tag provided at call time through a `Message` struct.

This feels much better.