### PR TITLE
Release 0.5

### DIFF
--- a/ecdsa_fun/Cargo.toml
+++ b/ecdsa_fun/Cargo.toml
@@ -16,7 +16,7 @@ keywords = ["bitcoin", "ecdsa", "secp256k1"]
 features = ["serde", "libsecp_compat"]
 
 [dependencies]
-secp256kfun = { path = "../secp256kfun", version = "^0.4.2-alpha.0", default-features = false }
+secp256kfun = { path = "../secp256kfun", version = "^0.5.0", default-features = false }
 serde_crate = { package = "serde", version = "1.0", default-features = false, optional = true, features = ["derive", "alloc"] }
 sigma_fun = { path = "../sigma_fun", version = "^0.1.3-alpha.0", features = ["secp256k1"]}
 rand_chacha = "0.3" # needed for adaptor signatures atm but would be nice to get rid of
@@ -24,7 +24,7 @@ bincode = { version = "1.0", optional = true }
 
 [dev-dependencies]
 secp256k1 = { default-features = false, version = "0.20", features = ["std"] }
-secp256kfun = { path = "../secp256kfun", version = "^0.4.2-alpha.0", features = ["libsecp_compat"] }
+secp256kfun = { path = "../secp256kfun", version = "^0.5.0", features = ["libsecp_compat"] }
 rand = "0.8"
 criterion = "0.3"
 hex-literal = "0.2"

--- a/ecdsa_fun/Cargo.toml
+++ b/ecdsa_fun/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ecdsa_fun"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["LLFourn <lloyd.fourn@gmail.com>"]
 edition = "2018"
 license = "0BSD"
@@ -16,7 +16,7 @@ keywords = ["bitcoin", "ecdsa", "secp256k1"]
 features = ["serde", "libsecp_compat"]
 
 [dependencies]
-secp256kfun = { path = "../secp256kfun", version = "^0.5.0", default-features = false }
+secp256kfun = { path = "../secp256kfun", version = "0.5", default-features = false }
 serde_crate = { package = "serde", version = "1.0", default-features = false, optional = true, features = ["derive", "alloc"] }
 sigma_fun = { path = "../sigma_fun", version = "^0.2", features = ["secp256k1"]}
 rand_chacha = "0.3" # needed for adaptor signatures atm but would be nice to get rid of
@@ -24,7 +24,7 @@ bincode = { version = "1.0", optional = true }
 
 [dev-dependencies]
 secp256k1 = { default-features = false, version = "0.20", features = ["std"] }
-secp256kfun = { path = "../secp256kfun", version = "^0.5.0", features = ["libsecp_compat"] }
+secp256kfun = { path = "../secp256kfun", version = "^0.5", features = ["libsecp_compat"] }
 rand = "0.8"
 criterion = "0.3"
 hex-literal = "0.2"

--- a/ecdsa_fun/Cargo.toml
+++ b/ecdsa_fun/Cargo.toml
@@ -18,7 +18,7 @@ features = ["serde", "libsecp_compat"]
 [dependencies]
 secp256kfun = { path = "../secp256kfun", version = "^0.5.0", default-features = false }
 serde_crate = { package = "serde", version = "1.0", default-features = false, optional = true, features = ["derive", "alloc"] }
-sigma_fun = { path = "../sigma_fun", version = "^0.1.3-alpha.0", features = ["secp256k1"]}
+sigma_fun = { path = "../sigma_fun", version = "^0.2.0", features = ["secp256k1"]}
 rand_chacha = "0.3" # needed for adaptor signatures atm but would be nice to get rid of
 bincode = { version = "1.0", optional = true }
 

--- a/ecdsa_fun/Cargo.toml
+++ b/ecdsa_fun/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ecdsa_fun"
-version = "0.5.1"
+version = "0.5.2-alpha.0"
 authors = ["LLFourn <lloyd.fourn@gmail.com>"]
 edition = "2018"
 license = "0BSD"
@@ -16,15 +16,15 @@ keywords = ["bitcoin", "ecdsa", "secp256k1"]
 features = ["serde", "libsecp_compat"]
 
 [dependencies]
-secp256kfun = { path = "../secp256kfun", version = "0.5", default-features = false }
+secp256kfun = { path = "../secp256kfun", version = "0.5.2-alpha.0", default-features = false }
 serde_crate = { package = "serde", version = "1.0", default-features = false, optional = true, features = ["derive", "alloc"] }
-sigma_fun = { path = "../sigma_fun", version = "^0.2", features = ["secp256k1"]}
+sigma_fun = { path = "../sigma_fun", version = "0.2.3-alpha.0", features = ["secp256k1"]}
 rand_chacha = "0.3" # needed for adaptor signatures atm but would be nice to get rid of
 bincode = { version = "1.0", optional = true }
 
 [dev-dependencies]
 secp256k1 = { default-features = false, version = "0.20", features = ["std"] }
-secp256kfun = { path = "../secp256kfun", version = "^0.5", features = ["libsecp_compat"] }
+secp256kfun = { path = "../secp256kfun", version = "0.5.2-alpha.0", features = ["libsecp_compat"] }
 rand = "0.8"
 criterion = "0.3"
 hex-literal = "0.2"

--- a/ecdsa_fun/Cargo.toml
+++ b/ecdsa_fun/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ecdsa_fun"
-version = "0.4.2-alpha.0"
+version = "0.5.0"
 authors = ["LLFourn <lloyd.fourn@gmail.com>"]
 edition = "2018"
 license = "0BSD"
@@ -18,7 +18,7 @@ features = ["serde", "libsecp_compat"]
 [dependencies]
 secp256kfun = { path = "../secp256kfun", version = "^0.5.0", default-features = false }
 serde_crate = { package = "serde", version = "1.0", default-features = false, optional = true, features = ["derive", "alloc"] }
-sigma_fun = { path = "../sigma_fun", version = "^0.2.0", features = ["secp256k1"]}
+sigma_fun = { path = "../sigma_fun", version = "^0.2", features = ["secp256k1"]}
 rand_chacha = "0.3" # needed for adaptor signatures atm but would be nice to get rid of
 bincode = { version = "1.0", optional = true }
 

--- a/ecdsa_fun/README.md
+++ b/ecdsa_fun/README.md
@@ -12,7 +12,7 @@ Uses [secp256kfun].
 
 ``` toml
 [dependencies]
-ecdsa_fun = "0.4"
+ecdsa_fun = "0.5"
 sha2 = "0.9" # You need a hash function for nonce derivation
 ```
 

--- a/schnorr_fun/Cargo.toml
+++ b/schnorr_fun/Cargo.toml
@@ -16,7 +16,7 @@ keywords = ["bitcoin", "schnorr"]
 features = ["all"]
 
 [dependencies]
-secp256kfun = { path = "../secp256kfun", version = "^0.4.2-alpha.0", default-features = false }
+secp256kfun = { version = "0.5",  default-features = false, path = "../secp256kfun" }
 serde_crate = { package = "serde", version = "1.0", default-features = false, optional = true, features = ["derive", "alloc"] }
 
 [dev-dependencies]
@@ -24,7 +24,7 @@ rand = { version = "0.8" }
 lazy_static = "1.4"
 bincode = "1.0"
 sha2 = "0.9"
-secp256kfun = { path = "../secp256kfun", version = "^0.4.2-alpha.0", features = ["alloc"] }
+secp256kfun = { version = "0.5", features = ["alloc"], path = "../secp256kfun" }
 
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]

--- a/schnorr_fun/Cargo.toml
+++ b/schnorr_fun/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "schnorr_fun"
-version = "0.5.1"
+version = "0.5.2-alpha.0"
 authors = ["LLFourn <lloyd.fourn@gmail.com>"]
 edition = "2018"
 license = "0BSD"
@@ -16,7 +16,7 @@ keywords = ["bitcoin", "schnorr"]
 features = ["all"]
 
 [dependencies]
-secp256kfun = { version = "0.5",  default-features = false, path = "../secp256kfun" }
+secp256kfun = { version = "0.5.2-alpha.0",  default-features = false, path = "../secp256kfun" }
 serde_crate = { package = "serde", version = "1.0", default-features = false, optional = true, features = ["derive", "alloc"] }
 
 [dev-dependencies]
@@ -24,7 +24,7 @@ rand = { version = "0.8" }
 lazy_static = "1.4"
 bincode = "1.0"
 sha2 = "0.9"
-secp256kfun = { version = "0.5", features = ["alloc"], path = "../secp256kfun" }
+secp256kfun = { version = "0.5.2-alpha.0", features = ["alloc"], path = "../secp256kfun" }
 
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]

--- a/schnorr_fun/Cargo.toml
+++ b/schnorr_fun/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "schnorr_fun"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["LLFourn <lloyd.fourn@gmail.com>"]
 edition = "2018"
 license = "0BSD"

--- a/schnorr_fun/Cargo.toml
+++ b/schnorr_fun/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "schnorr_fun"
-version = "0.4.2-alpha.0"
+version = "0.5.0"
 authors = ["LLFourn <lloyd.fourn@gmail.com>"]
 edition = "2018"
 license = "0BSD"
@@ -40,8 +40,8 @@ harness = false
 
 [features]
 default = ["std"]
-all = ["std","serde"]
-alloc = []
-std = ["alloc"]
+all = ["std","serde", "libsecp_compat"]
+alloc = ["secp256kfun/alloc"]
+std = ["alloc", "secp256kfun/std"]
 serde = ["serde_crate", "secp256kfun/serde"]
 libsecp_compat = ["secp256kfun/libsecp_compat"]

--- a/schnorr_fun/README.md
+++ b/schnorr_fun/README.md
@@ -14,7 +14,7 @@ This implementation is based on the [BIP-340] specification, but is flexible eno
 
 ``` toml
 [dependencies]
-schnorr_fun = "0.4"
+schnorr_fun = "0.5"
 sha2 = "0.9"
 ```
 

--- a/secp256kfun/Cargo.toml
+++ b/secp256kfun/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "secp256kfun"
-version = "0.5.1"
+version = "0.5.2-alpha.0"
 authors = ["LLFourn <lloyd.fourn@gmail.com>"]
 license = "0BSD"
 homepage = "https://github.com/LLFourn/secp256kfun"
@@ -20,7 +20,7 @@ digest = "0.9"
 subtle = { package = "subtle-ng", version = "2" }
 rand_core = { version = "0.6" }
 serde_crate = { package = "serde", version = "1.0",  optional = true, default-features = false, features = ["alloc", "derive"] }
-secp256kfun_parity_backend = "^0.1.5"
+secp256kfun_parity_backend = { path = "../secp256kfun_parity_backend", version = "0.1.6-alpha.0" }
 secp256k1 = { version = "0.20", optional = true, default-features = false }
 proptest = { version = "0.10", optional = true }
 
@@ -37,7 +37,7 @@ bincode = "1.0"
 criterion = "0.3"
 
 [build-dependencies]
-secp256kfun_parity_backend = { version = "^0.1.5", features = ["alloc"] }
+secp256kfun_parity_backend = { path = "../secp256kfun_parity_backend", version = "^0.1.6-alpha.0", features = ["alloc"] }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test = "0.3"

--- a/secp256kfun/Cargo.toml
+++ b/secp256kfun/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "secp256kfun"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["LLFourn <lloyd.fourn@gmail.com>"]
 license = "0BSD"
 homepage = "https://github.com/LLFourn/secp256kfun"

--- a/secp256kfun/Cargo.toml
+++ b/secp256kfun/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "secp256kfun"
-version = "0.4.2-alpha.0"
+version = "0.5.0"
 authors = ["LLFourn <lloyd.fourn@gmail.com>"]
 license = "0BSD"
 homepage = "https://github.com/LLFourn/secp256kfun"
@@ -20,7 +20,7 @@ digest = "0.9"
 subtle = { package = "subtle-ng", version = "2" }
 rand_core = { version = "0.6" }
 serde_crate = { package = "serde", version = "1.0",  optional = true, default-features = false, features = ["alloc", "derive"] }
-secp256kfun_parity_backend = { path = "../secp256kfun_parity_backend", version = "^0.1.4-alpha.0"}
+secp256kfun_parity_backend = "^0.1.5"
 secp256k1 = { version = "0.20", optional = true, default-features = false }
 proptest = { version = "0.10", optional = true }
 
@@ -37,7 +37,7 @@ bincode = "1.0"
 criterion = "0.3"
 
 [build-dependencies]
-secp256kfun_parity_backend = { version = "^0.1.4-alpha.0", path = "../secp256kfun_parity_backend", features = ["alloc"], "package"  = "secp256kfun_parity_backend" }
+secp256kfun_parity_backend = { version = "^0.1.5", features = ["alloc"] }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test = "0.3"

--- a/secp256kfun/README.md
+++ b/secp256kfun/README.md
@@ -19,7 +19,7 @@ Fun does not mean (yet -- please help!):
 - **stable**: This library will frequently add/remove/change APIs for the foreseeable future. It also needs a nightly compiler for [_specialization_] (it uses the `min_specialization` feature).
 - **well reviewed or tested**: This code is fresh and experimental and not rigorously tested.
 - **side-channel resistant**: There has been no empirical investigation into whether this library or the underlying [parity/libsecp256k1][4] is resistant against timing attacks etc.
-- **performant**: The library is in general not as performant as [libsecp256k1][1], at least on 64-bit platforms.
+- **performant**: The library is in general not as performant as [libsecp256k1][1].
 
 The goal is for this library to let researchers experiment with ideas, have them work on Bitcoin *and* to enjoy it!
 I hope you can build very satisfying implementations of cryptographic schemes with this library.
@@ -30,7 +30,7 @@ _Low-level_ libraries like [parity/libsecp256k1][4] make it possible but the res
 
 ```toml
 [dependencies]
-secp256kfun = "0.4"
+secp256kfun = "0.5"
 ```
 
 ### Should use?
@@ -53,11 +53,7 @@ Here's the distinguishing features of this library.
 Both secp256k1 points and scalars have a notional _zero_ element.
 Unfortunately, in things surrounding Bitcoin, the zero scalar and zero point are illegal values in most cases.
 The _high-level_ [rust-secp256k1][2] deals with zero problem by returning a `Result` in its API whenever the return value might be zero.
-This is annoying for two reasons:
-
-1. Sometimes zero is fine and now you have an error case where you should just have zero.
-2. In many cases, we can rule out zero as a result of a computation through some context specific information.
-
+This causes friction because you have an error case where you should just have zero.
 At worst, this can lead to a habitual use of `.unwrap` to ignore the errors that the engineer *thinks* are unreachable.
 A mistaken `.unwrap` is often a security bug if a malicious party can trigger it.
 
@@ -110,7 +106,7 @@ match sum.mark::<(Normal, NonZero)>() {
 
 ## Variable time or Constant time?
 
-If a function's execution time depends on its inputs, then information about those inputs may leak to anyone that can measure its execution time.
+If a function's execution time is not indepent of its inputs, then information about those inputs may leak to anyone that can measure its execution time.
 Therefore it is crucial that functions that take secret inputs run in _constant time_.
 Good low-level libraries tend to have one constant time version of an algorithm and then a faster variable time version. In _high-level_ libraries the experts have made the choice for you.
 Here's a question that demonstrates the problem with this: **Should a signature verification algorithm run in variable time or constant time?**

--- a/secp256kfun_parity_backend/Cargo.toml
+++ b/secp256kfun_parity_backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "secp256kfun_parity_backend"
-version = "0.1.4-alpha.0"
+version = "0.1.5"
 description = "Vendored version of paritytech/libsecp256k1 for secp256kfun"
 license = "Apache-2.0"
 repository = "https://github.com/LLFourn/secp256kfun"

--- a/secp256kfun_parity_backend/Cargo.toml
+++ b/secp256kfun_parity_backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "secp256kfun_parity_backend"
-version = "0.1.5"
+version = "0.1.6-alpha.0"
 description = "Vendored version of paritytech/libsecp256k1 for secp256kfun"
 license = "Apache-2.0"
 repository = "https://github.com/LLFourn/secp256kfun"

--- a/sigma_fun/Cargo.toml
+++ b/sigma_fun/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sigma_fun"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["LLFourn <lloyd.fourn@gmail.com>"]
 edition = "2018"
 license = "0BSD"
@@ -17,13 +17,13 @@ features = ["all"]
 [dependencies]
 generic-array = "0.14"
 digest = "0.9"
-secp256kfun = { path = "../secp256kfun", version = "^0.5.0", default-features = false, optional = true }
+secp256kfun = { path = "../secp256kfun", version = "0.5", default-features = false, optional = true }
 curve25519-dalek = { package = "curve25519-dalek-ng", version = "4", default-features = false, optional = true, features = ["u64_backend"] }
 serde_crate = { package = "serde", version = "1.0", optional = true, default-features = false, features = ["derive"] }
 rand_core = "0.6"
 
 [dev-dependencies]
-secp256kfun = { path = "../secp256kfun", version = "^0.5.0", default-features = false, features = ["proptest"] }
+secp256kfun = { path = "../secp256kfun", version = "0.5", default-features = false, features = ["proptest"] }
 rand = "0.8"
 sha2 = "0.9"
 bincode = "1"

--- a/sigma_fun/Cargo.toml
+++ b/sigma_fun/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sigma_fun"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["LLFourn <lloyd.fourn@gmail.com>"]
 edition = "2018"
 license = "0BSD"

--- a/sigma_fun/Cargo.toml
+++ b/sigma_fun/Cargo.toml
@@ -17,13 +17,13 @@ features = ["all"]
 [dependencies]
 generic-array = "0.14"
 digest = "0.9"
-secp256kfun = { path = "../secp256kfun", version = "^0.4.2-alpha.0", default-features = false, optional = true }
+secp256kfun = { path = "../secp256kfun", version = "^0.5.0", default-features = false, optional = true }
 curve25519-dalek = { package = "curve25519-dalek-ng", version = "4", default-features = false, optional = true, features = ["u64_backend"] }
 serde_crate = { package = "serde", version = "1.0", optional = true, default-features = false, features = ["derive"] }
 rand_core = "0.6"
 
 [dev-dependencies]
-secp256kfun = { path = "../secp256kfun", version = "^0.4.2-alpha.0", default-features = false, features = ["proptest"] }
+secp256kfun = { path = "../secp256kfun", version = "^0.5.0", default-features = false, features = ["proptest"] }
 rand = "0.8"
 sha2 = "0.9"
 bincode = "1"

--- a/sigma_fun/Cargo.toml
+++ b/sigma_fun/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sigma_fun"
-version = "0.2.2"
+version = "0.2.3-alpha.0"
 authors = ["LLFourn <lloyd.fourn@gmail.com>"]
 edition = "2018"
 license = "0BSD"
@@ -17,13 +17,13 @@ features = ["all"]
 [dependencies]
 generic-array = "0.14"
 digest = "0.9"
-secp256kfun = { path = "../secp256kfun", version = "0.5", default-features = false, optional = true }
+secp256kfun = { path = "../secp256kfun", version = "0.5.2-alpha.0", default-features = false, optional = true }
 curve25519-dalek = { package = "curve25519-dalek-ng", version = "4", default-features = false, optional = true, features = ["u64_backend"] }
 serde_crate = { package = "serde", version = "1.0", optional = true, default-features = false, features = ["derive"] }
 rand_core = "0.6"
 
 [dev-dependencies]
-secp256kfun = { path = "../secp256kfun", version = "0.5", default-features = false, features = ["proptest"] }
+secp256kfun = { path = "../secp256kfun", version = "0.5.2-alpha.0", default-features = false, features = ["proptest"] }
 rand = "0.8"
 sha2 = "0.9"
 bincode = "1"

--- a/sigma_fun/Cargo.toml
+++ b/sigma_fun/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sigma_fun"
-version = "0.1.3-alpha.0"
+version = "0.2.0"
 authors = ["LLFourn <lloyd.fourn@gmail.com>"]
 edition = "2018"
 license = "0BSD"

--- a/sigma_fun/README.md
+++ b/sigma_fun/README.md
@@ -12,9 +12,9 @@ A rust library for making Sigma protocols fun!
 ``` toml
 [dependencies]
 # For just the traits and combinators
-sigma_fun = {version = "0.1", no-default-features = true, features = ["alloc"]}
+sigma_fun = {version = "0.2", no-default-features = true, features = ["alloc"]}
 # To create secp256k1 non-interactive proofs and serialize them
-sigma_fun = { version = "0.1", features = ["secp256k1", "serde"] }
+sigma_fun = { version = "0.2", features = ["secp256k1", "serde"] }
 # you need a hash function and an rng for non-interactive proofs
 rand_chacha = "0.3"
 sha2 = "0.9"


### PR DESCRIPTION
Release 0.5

- minor changes to nonce generation in schnorr_fun and changes in secp256kfun to support it.
- Dependency upgrades esp rand, secp256k1
- Points now implement `ConditionallySelectible` trait form `subtle`.