### PR TITLE
Feature-gate all nightly features behind a nightly feature

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,70 +21,31 @@ jobs:
           command: fmt
           args: --all -- --check
 
-  test-nostd:
+  test:
     runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        args: [
+            --no-default-features,
+            --no-default-features --features=serde,
+            --no-default-features --features=std,
+            --all-features,
+        ]
+        rust: [nightly, stable]
+        exclude:
+          - rust: stable
+            args: --all-features
+          - rust: nightly
+            args: --no-default-features
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: nightly
-        override: true
-    - name: secp256kfun-test
-      run: ( cd secp256kfun && cargo test --no-default-features --release --verbose )
-    - name: schnorr_fun-test
-      run: ( cd schnorr_fun && cargo test --no-default-features --release --verbose )
-    - name: ecdsa_fun-test
-      run: ( cd ecdsa_fun && cargo test --no-default-features --release --verbose )
-    - name: sigma_fun-test
-      run: (cd sigma_fun && cargo test --no-default-features --release --verbose)
-
-  test-all-features:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: nightly
-        override: true
-    - uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --release --all-features
-
-  test-default:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: nightly
-        override: true
-    - uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --release
-
-  test-serde:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: nightly
-        override: true
-    - name: secp256kfun-test
-      run: ( cd secp256kfun && cargo test --no-default-features --features=serde --release --verbose )
-    - name: schnorr_fun-test
-      run: ( cd schnorr_fun && cargo test --no-default-features --features=serde --release --verbose )
-    - name: ecdsa_fun-test
-      run: ( cd ecdsa_fun && cargo test --no-default-features --features=serde --release --verbose )
-    - name: sigma_fun-test
-      run: ( cd sigma_fun && cargo test --no-default-features --features=serde --release --verbose )
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+      - uses: Swatinem/rust-cache@v1.2.0
+      - run: cargo test ${{ matrix.args }} --release --verbose
 
   doc-build:
      name: doc-build

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,4 @@ members = [
     "secp256kfun_parity_backend",
     "sigma_fun"
 ]
+resolver = "2"

--- a/ecdsa_fun/Cargo.toml
+++ b/ecdsa_fun/Cargo.toml
@@ -24,7 +24,7 @@ bincode = { version = "1.0", optional = true }
 
 [dev-dependencies]
 secp256k1 = { default-features = false, version = "0.20", features = ["std"] }
-secp256kfun = { path = "../secp256kfun", version = "0.6.2-alpha.0", features = ["libsecp_compat"] }
+secp256kfun = { path = "../secp256kfun", version = "0.6.2-alpha.0", default-features = false, features = ["libsecp_compat"] }
 rand = "0.8"
 criterion = "0.3"
 hex-literal = "0.2"
@@ -37,9 +37,10 @@ name = "bench_ecdsa"
 harness = false
 
 [features]
-default = ["std"]
+default = ["std", "nightly"]
 all = ["std", "serde", "libsecp_compat"]
 libsecp_compat = ["secp256kfun/libsecp_compat"]
 std = ["alloc"]
 alloc = ["secp256kfun/alloc"]
 serde = ["secp256kfun/serde", "serde_crate", "sigma_fun/serde", "bincode"]
+nightly = ["secp256kfun/nightly"]

--- a/ecdsa_fun/src/lib.rs
+++ b/ecdsa_fun/src/lib.rs
@@ -1,5 +1,4 @@
-#![feature(extended_key_value_attributes)]
-#![doc = include_str!("../README.md")]
+// #![doc = include_str!("../README.md")] TODO: Activate with 1.54
 #![no_std]
 #![allow(non_snake_case)]
 

--- a/schnorr_fun/Cargo.toml
+++ b/schnorr_fun/Cargo.toml
@@ -24,7 +24,7 @@ rand = { version = "0.8" }
 lazy_static = "1.4"
 bincode = "1.0"
 sha2 = "0.9"
-secp256kfun = { path = "../secp256kfun", version = "0.6.2-alpha.0", features = ["alloc"] }
+secp256kfun = { path = "../secp256kfun", version = "0.6.2-alpha.0", default-features = false, features = ["alloc"] }
 
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
@@ -39,9 +39,10 @@ harness = false
 
 
 [features]
-default = ["std"]
+default = ["std", "nightly"]
 all = ["std","serde", "libsecp_compat"]
 alloc = ["secp256kfun/alloc"]
 std = ["alloc", "secp256kfun/std"]
 serde = ["serde_crate", "secp256kfun/serde"]
 libsecp_compat = ["secp256kfun/libsecp_compat"]
+nightly = ["secp256kfun/nightly"]

--- a/schnorr_fun/src/adaptor/mod.rs
+++ b/schnorr_fun/src/adaptor/mod.rs
@@ -277,6 +277,8 @@ mod test {
     use super::*;
     use crate::nonce::{self, Deterministic};
     use secp256kfun::TEST_SOUNDNESS;
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::wasm_bindgen_test as test;
 
     fn test_schnorr<NG: NonceGen>(schnorr: Schnorr<sha2::Sha256, NG>) {
         for _ in 0..TEST_SOUNDNESS {
@@ -306,12 +308,15 @@ mod test {
             assert_eq!(rec_decryption_key, decryption_key);
         }
     }
-    secp256kfun::test_plus_wasm! {
-        fn sign_plain_message() {
-            use sha2::Sha256;
-            use rand::rngs::ThreadRng;
-            test_schnorr(Schnorr::new(Deterministic::<Sha256>::default()));
-            test_schnorr(Schnorr::new(nonce::Synthetic::<Sha256, nonce::GlobalRng<ThreadRng>>::default()));
-        }
+
+    #[test]
+    fn sign_plain_message() {
+        use rand::rngs::ThreadRng;
+        use sha2::Sha256;
+        test_schnorr(Schnorr::new(Deterministic::<Sha256>::default()));
+        test_schnorr(Schnorr::new(nonce::Synthetic::<
+            Sha256,
+            nonce::GlobalRng<ThreadRng>,
+        >::default()));
     }
 }

--- a/schnorr_fun/src/lib.rs
+++ b/schnorr_fun/src/lib.rs
@@ -1,7 +1,7 @@
+//!
 #![no_std]
 #![allow(non_snake_case)]
-#![feature(extended_key_value_attributes)]
-#![doc = include_str!("../README.md")]
+// #![doc = include_str!("../README.md")] TODO: Activate with 1.54
 #![deny(warnings, missing_docs)]
 #[cfg(all(feature = "alloc", not(feature = "std")))]
 #[macro_use]

--- a/secp256kfun/Cargo.toml
+++ b/secp256kfun/Cargo.toml
@@ -43,13 +43,13 @@ wasm-bindgen-test = "0.3"
 
 
 [features]
-default = ["std"]
-all = ["std", "serde", "libsecp_compat"]
+default = ["std", "nightly"]
+all = ["std", "serde", "libsecp_compat", "nightly"]
 alloc = []
 std = ["alloc"]
 libsecp_compat = ["secp256k1"]
 serde = [ "serde_crate" ]
-
+nightly = [ ]
 
 [[bench]]
 name = "bench_ecmult"

--- a/secp256kfun/src/backend/mod.rs
+++ b/secp256kfun/src/backend/mod.rs
@@ -41,6 +41,10 @@ pub trait TimeSensitive {
         Self::point_neg(&mut rhs);
         Self::point_add_point(lhs, &rhs)
     }
+    // "any" variants are because doing a jacobian point neg is not good enough for a normalized
+    // point neg so for the general case we have to have a slower one that works for both.
+    fn any_point_neg(point: &mut Point);
+    fn any_point_conditional_negate(point: &mut Point, cond: bool);
     fn point_neg(point: &mut Point);
     fn point_sub_norm_point(lhs: &Point, rhs: &Point) -> Point;
     fn point_conditional_negate(point: &mut Point, cond: bool);

--- a/secp256kfun/src/backend/parity/constant_time.rs
+++ b/secp256kfun/src/backend/parity/constant_time.rs
@@ -235,6 +235,19 @@ impl crate::backend::TimeSensitive for ConstantTime {
         scalar.inv()
     }
 
+    fn any_point_neg(point: &mut Jacobian) {
+        point.y.normalize_weak();
+        point.y = point.y.neg(1);
+        point.y.normalize();
+    }
+
+    fn any_point_conditional_negate(point: &mut Jacobian, cond: bool) {
+        point.y.normalize_weak();
+        let mut neg_y = point.y.neg(1);
+        neg_y.normalize();
+        point.y.cmov(&neg_y, cond)
+    }
+
     fn point_neg(point: &mut Jacobian) {
         point.y.normalize_weak();
         point.y = point.y.neg(1);

--- a/secp256kfun/src/backend/parity/variable_time.rs
+++ b/secp256kfun/src/backend/parity/variable_time.rs
@@ -204,6 +204,14 @@ impl crate::backend::TimeSensitive for VariableTime {
         ConstantTime::scalar_invert(scalar)
     }
 
+    fn any_point_neg(_point: &mut Jacobian) {
+        unreachable!("this should never get hit by secp256kfun");
+    }
+
+    fn any_point_conditional_negate(_point: &mut Jacobian, _cond: bool) {
+        unreachable!("this should never get hit by secp256kfun");
+    }
+
     fn point_neg(point: &mut Jacobian) {
         ConstantTime::point_neg(point)
     }

--- a/secp256kfun/src/lib.rs
+++ b/secp256kfun/src/lib.rs
@@ -1,9 +1,9 @@
 //!
-#![feature(rustc_attrs, min_specialization, extended_key_value_attributes)]
+#![cfg_attr(feature = "nightly", feature(rustc_attrs, min_specialization))]
 #![no_std]
 #![allow(non_snake_case)]
 #![deny(missing_docs, warnings)]
-#![doc = include_str!("../README.md")]
+// #![doc = include_str!("../README.md")] TODO: Activate with 1.54
 #[cfg(all(feature = "alloc", not(feature = "std")))]
 #[allow(unused_imports)]
 #[macro_use]
@@ -26,11 +26,12 @@ mod scalar;
 mod slice;
 mod xonly;
 
+#[macro_use]
+mod macros;
 mod backend;
 pub mod marker;
 pub mod op;
 
-mod macros;
 pub use point::Point;
 pub use scalar::Scalar;
 pub use slice::Slice;

--- a/secp256kfun/src/macros.rs
+++ b/secp256kfun/src/macros.rs
@@ -280,21 +280,6 @@ macro_rules! g {
         $crate::_g!(@scalar [] $($t)+) }};
 }
 
-/// Makes all tests within the block valid wasm32 tests as well with wasm_bindgen_test
-#[doc(hidden)]
-#[macro_export]
-macro_rules! test_plus_wasm {
-    ($($test:item)*) => {
-        #[cfg(target_arch = "wasm32")]
-        use wasm_bindgen_test::*;
-        $(
-            #[cfg_attr(not(target_arch = "wasm32"), test)]
-            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
-            $test
-         )*
-    };
-}
-
 /// Macro to make nonce derivation clear and explicit.
 ///
 /// Nonce derivation is a sensitive action where mistakes can have catastrophic

--- a/secp256kfun/src/macros.rs
+++ b/secp256kfun/src/macros.rs
@@ -580,3 +580,34 @@ macro_rules! impl_fromstr_deserailize {
 
     };
 }
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! maybe_specialized {
+    (fn $name:ident($($args:tt)*) -> $ret:ty {
+        $($body:tt)*
+    }) => {
+        #[cfg(not(feature = "nightly"))]
+        fn $name($( $args )*) -> $ret {
+            $( $body )*
+        }
+
+        #[cfg(feature = "nightly")]
+        default fn $name($( $args )*) -> $ret {
+            $( $body )*
+        }
+    };
+    (fn $name:ident($($args:tt)*) {
+        $($body:tt)*
+    }) => {
+        #[cfg(not(feature = "nightly"))]
+        fn $name($( $args )*) {
+            $( $body )*
+        }
+
+        #[cfg(feature = "nightly")]
+        default fn $name($( $args )*) {
+            $( $body )*
+        }
+    };
+}

--- a/secp256kfun/src/marker/point_type.rs
+++ b/secp256kfun/src/marker/point_type.rs
@@ -46,10 +46,10 @@ pub struct EvenY;
 pub struct BasePoint(pub(crate) crate::backend::BasePoint);
 
 /// A marker trait that indicates a `PointType` uses a affine internal representation.
-#[rustc_specialization_trait]
+#[cfg_attr(feature = "nightly", rustc_specialization_trait)]
 pub trait Normalized: PointType {}
 
-#[rustc_specialization_trait]
+#[cfg_attr(feature = "nightly", rustc_specialization_trait)]
 pub(crate) trait NotBasePoint: Default {}
 
 impl Normalized for EvenY {}

--- a/secp256kfun/src/nonce.rs
+++ b/secp256kfun/src/nonce.rs
@@ -88,8 +88,8 @@ impl<H: Default, R: NonceRng> Synthetic<H, R> {
     }
 }
 
-/// A zero sized type that wraps an instance of an RNG that implementes
-/// `Default` e.g. [`OsRng`]. `GlobalRng` implements
+/// A zero sized type that wraps an RNG that implementes
+/// `Default` e.g. [`ThreadRng`]. `GlobalRng` implements
 /// [`NonceRng`] and care has been taken to ensure it is `Sync`.
 ///
 /// # Examples
@@ -107,7 +107,7 @@ impl<H: Default, R: NonceRng> Synthetic<H, R> {
 /// assert!(is_sync(nonce_rng));
 /// ```
 ///
-/// [`OsRng`]: rand_core::OsRng
+/// [`ThreadRng`]: https://docs.rs/rand/latest/rand/rngs/struct.ThreadRng.html
 #[derive(Debug, Default, Clone)]
 pub struct GlobalRng<R> {
     // Using fn(R) ensures that it is sync even if R is not sync

--- a/secp256kfun/src/op.rs
+++ b/secp256kfun/src/op.rs
@@ -484,14 +484,14 @@ pub(crate) trait NormPointUnary {
 impl<T, S, Z> PointUnary for Point<T, Z, S> {
     maybe_specialized! {
         fn negate(mut self) -> backend::Point {
-            ConstantTime::point_neg(&mut self.0);
+            ConstantTime::any_point_neg(&mut self.0);
             self.0
         }
     }
 
     maybe_specialized! {
         fn conditional_negate(mut self, cond: bool) -> backend::Point {
-            ConstantTime::point_conditional_negate(&mut self.0, cond);
+            ConstantTime::any_point_conditional_negate(&mut self.0, cond);
             self.0
         }
     }
@@ -501,6 +501,19 @@ impl<T, S, Z> PointUnary for Point<T, Z, S> {
             ConstantTime::point_normalize(&mut self.0);
             self.0
         }
+    }
+}
+
+#[cfg(feature = "nightly")]
+impl<Z> PointUnary for Point<Jacobian, Z, Secret> {
+    fn negate(mut self) -> backend::Point {
+        ConstantTime::point_neg(&mut self.0);
+        self.0
+    }
+
+    fn conditional_negate(mut self, cond: bool) -> backend::Point {
+        ConstantTime::point_conditional_negate(&mut self.0, cond);
+        self.0
     }
 }
 

--- a/secp256kfun/src/op.rs
+++ b/secp256kfun/src/op.rs
@@ -91,22 +91,29 @@ pub(crate) trait PointBinary {
 }
 
 impl<T1, S1, Z1, T2, S2, Z2> PointBinary for (&Point<S1, T1, Z1>, &Point<S2, T2, Z2>) {
-    default fn add(self) -> backend::Point {
-        let (lhs, rhs) = self;
-        ConstantTime::point_add_point(&lhs.0, &rhs.0)
+    maybe_specialized! {
+        fn add(self) -> backend::Point {
+            let (lhs, rhs) = self;
+            ConstantTime::point_add_point(&lhs.0, &rhs.0)
+        }
     }
 
-    default fn sub(self) -> backend::Point {
-        let (lhs, rhs) = self;
-        ConstantTime::point_sub_point(&lhs.0, &rhs.0)
+    maybe_specialized! {
+        fn sub(self) -> backend::Point {
+            let (lhs, rhs) = self;
+            ConstantTime::point_sub_point(&lhs.0, &rhs.0)
+        }
     }
 
-    default fn eq(self) -> bool {
-        let (lhs, rhs) = self;
-        ConstantTime::point_eq_point(&lhs.0, &rhs.0)
+    maybe_specialized! {
+        fn eq(self) -> bool {
+            let (lhs, rhs) = self;
+            ConstantTime::point_eq_point(&lhs.0, &rhs.0)
+        }
     }
 }
 
+#[cfg(feature = "nightly")]
 impl<Z1, Z2, T1: Normalized, S1, S2, T2> PointBinary for (&Point<S1, T1, Z1>, &Point<T2, S2, Z2>) {
     default fn add(self) -> backend::Point {
         let (lhs, rhs) = self;
@@ -124,6 +131,7 @@ impl<Z1, Z2, T1: Normalized, S1, S2, T2> PointBinary for (&Point<S1, T1, Z1>, &P
     }
 }
 
+#[cfg(feature = "nightly")]
 impl<Z1, Z2, S1, S2, T2: Normalized> PointBinary
     for (&Point<S1, Jacobian, Z1>, &Point<T2, S2, Z2>)
 {
@@ -143,6 +151,7 @@ impl<Z1, Z2, S1, S2, T2: Normalized> PointBinary
     }
 }
 
+#[cfg(feature = "nightly")]
 impl<Z1, Z2> PointBinary for (&Point<Public, Jacobian, Z1>, &Point<Jacobian, Public, Z2>) {
     fn add(self) -> backend::Point {
         let (lhs, rhs) = self;
@@ -160,6 +169,7 @@ impl<Z1, Z2> PointBinary for (&Point<Public, Jacobian, Z1>, &Point<Jacobian, Pub
     }
 }
 
+#[cfg(feature = "nightly")]
 impl<Z1, Z2, T1: Normalized, T2> PointBinary for (&Point<Public, T1, Z1>, &Point<T2, Public, Z2>) {
     fn add(self) -> backend::Point {
         let (lhs, rhs) = self;
@@ -177,6 +187,7 @@ impl<Z1, Z2, T1: Normalized, T2> PointBinary for (&Point<Public, T1, Z1>, &Point
     }
 }
 
+#[cfg(feature = "nightly")]
 impl<Z1, Z2, T2: Normalized> PointBinary
     for (&Point<Public, Jacobian, Z1>, &Point<T2, Public, Z2>)
 {
@@ -201,23 +212,28 @@ pub(crate) trait PointEqXOnly {
 }
 
 impl<T, S, Z> PointEqXOnly for Point<T, S, Z> {
-    default fn point_eq_xonly(&self, xonly: &XOnly) -> bool {
-        ConstantTime::point_eq_xonly(&self.0, &xonly.0)
+    maybe_specialized! {
+        fn point_eq_xonly(&self, xonly: &XOnly) -> bool {
+            ConstantTime::point_eq_xonly(&self.0, &xonly.0)
+        }
     }
 }
 
+#[cfg(feature = "nightly")]
 impl<T, Z> PointEqXOnly for Point<T, Public, Z> {
     default fn point_eq_xonly(&self, xonly: &XOnly) -> bool {
         VariableTime::point_eq_xonly(&self.0, &xonly.0)
     }
 }
 
+#[cfg(feature = "nightly")]
 impl<T: Normalized, Z> PointEqXOnly for Point<T, Secret, Z> {
     default fn point_eq_xonly(&self, xonly: &XOnly) -> bool {
         ConstantTime::norm_point_eq_xonly(&self.0, &xonly.0)
     }
 }
 
+#[cfg(feature = "nightly")]
 impl<T: Normalized, Z> PointEqXOnly for Point<T, Public, Z> {
     fn point_eq_xonly(&self, xonly: &XOnly) -> bool {
         VariableTime::norm_point_eq_xonly(&self.0, &xonly.0)
@@ -228,36 +244,48 @@ pub(crate) trait MulPoint<S2, T2> {
     fn mul_point<Z2>(&self, rhs: &Point<T2, S2, Z2>) -> backend::Point;
 }
 
+// we don't use the maybe_specialized! macro here because matching against fn level type parameters is tricky
 impl<Z1, S1, S2, T2> MulPoint<S2, T2> for Scalar<S1, Z1> {
+    #[cfg(not(feature = "nightly"))]
+    fn mul_point<Z2>(&self, rhs: &Point<T2, S2, Z2>) -> backend::Point {
+        ConstantTime::scalar_mul_point(&self.0, &rhs.0)
+    }
+
+    #[cfg(feature = "nightly")]
     default fn mul_point<Z2>(&self, rhs: &Point<T2, S2, Z2>) -> backend::Point {
         ConstantTime::scalar_mul_point(&self.0, &rhs.0)
     }
 }
 
+#[cfg(feature = "nightly")]
 impl<Z1, S1, S2, T2: NotBasePoint + Normalized> MulPoint<S2, T2> for Scalar<S1, Z1> {
     default fn mul_point<Z2>(&self, rhs: &Point<T2, S2, Z2>) -> backend::Point {
         ConstantTime::scalar_mul_norm_point(&self.0, &rhs.0)
     }
 }
 
+#[cfg(feature = "nightly")]
 impl<Z1, S1, S2> MulPoint<S2, BasePoint> for Scalar<S1, Z1> {
     default fn mul_point<Z2>(&self, rhs: &Point<BasePoint, S2, Z2>) -> backend::Point {
         ConstantTime::scalar_mul_basepoint(&self.0, &(rhs.1).0)
     }
 }
 
+#[cfg(feature = "nightly")]
 impl<Z1> MulPoint<Public, Jacobian> for Scalar<Public, Z1> {
     fn mul_point<Z2>(&self, rhs: &Point<Jacobian, Public, Z2>) -> backend::Point {
         VariableTime::scalar_mul_point(&self.0, &rhs.0)
     }
 }
 
+#[cfg(feature = "nightly")]
 impl<Z1, T2: Normalized + NotBasePoint> MulPoint<Public, T2> for Scalar<Public, Z1> {
     fn mul_point<Z2>(&self, rhs: &Point<T2, Public, Z2>) -> backend::Point {
         VariableTime::scalar_mul_norm_point(&self.0, &rhs.0)
     }
 }
 
+#[cfg(feature = "nightly")]
 impl<Z1> MulPoint<Public, BasePoint> for Scalar<Public, Z1> {
     fn mul_point<Z2>(&self, rhs: &Point<BasePoint, Public, Z2>) -> backend::Point {
         VariableTime::scalar_mul_basepoint(&self.0, &(rhs.1).0)
@@ -276,14 +304,17 @@ impl<XZ, XS, AZ, AS, AT, YZ, YS, BZ, BS, BT> DoubleMul
         &Point<BT, BS, BZ>,
     )
 {
-    default fn double_mul(self) -> backend::Point {
-        let (x, A, y, B) = self;
-        let xA = x.mul_point(A);
-        let yB = y.mul_point(B);
-        VariableTime::point_add_point(&xA, &yB)
+    maybe_specialized! {
+        fn double_mul(self) -> backend::Point {
+            let (x, A, y, B) = self;
+            let xA = x.mul_point(A);
+            let yB = y.mul_point(B);
+            VariableTime::point_add_point(&xA, &yB)
+        }
     }
 }
 
+#[cfg(feature = "nightly")]
 impl<XZ, AZ, YZ, BZ, BT> DoubleMul
     for (
         &Scalar<Public, XZ>,
@@ -298,6 +329,7 @@ impl<XZ, AZ, YZ, BZ, BT> DoubleMul
     }
 }
 
+#[cfg(feature = "nightly")]
 impl<XZ, AZ, YZ, BZ, AT: Normalized + NotBasePoint> DoubleMul
     for (
         &Scalar<Public, XZ>,
@@ -306,7 +338,7 @@ impl<XZ, AZ, YZ, BZ, AT: Normalized + NotBasePoint> DoubleMul
         &Point<BasePoint, Public, BZ>,
     )
 {
-    default fn double_mul(self) -> backend::Point {
+    fn double_mul(self) -> backend::Point {
         let (x, A, y, B) = self;
         VariableTime::basepoint_double_mul(&y.0, &(B.1).0, &x.0, &A.0)
     }
@@ -320,27 +352,36 @@ pub(crate) trait ScalarBinary {
 }
 
 impl<Z1, S1, Z2, S2> ScalarBinary for (&Scalar<S1, Z1>, &Scalar<S2, Z2>) {
-    default fn mul(self) -> backend::Scalar {
-        let (lhs, rhs) = self;
-        ConstantTime::scalar_mul(&lhs.0, &rhs.0)
+    maybe_specialized! {
+        fn mul(self) -> backend::Scalar {
+            let (lhs, rhs) = self;
+            ConstantTime::scalar_mul(&lhs.0, &rhs.0)
+        }
     }
 
-    default fn add(self) -> backend::Scalar {
-        let (lhs, rhs) = self;
-        ConstantTime::scalar_add(&lhs.0, &rhs.0)
+    maybe_specialized! {
+        fn add(self) -> backend::Scalar {
+            let (lhs, rhs) = self;
+            ConstantTime::scalar_add(&lhs.0, &rhs.0)
+        }
     }
 
-    default fn sub(self) -> backend::Scalar {
-        let (lhs, rhs) = self;
-        ConstantTime::scalar_sub(&lhs.0, &rhs.0)
+    maybe_specialized! {
+        fn sub(self) -> backend::Scalar {
+            let (lhs, rhs) = self;
+            ConstantTime::scalar_sub(&lhs.0, &rhs.0)
+        }
     }
 
-    default fn eq(self) -> bool {
-        let (lhs, rhs) = self;
-        ConstantTime::scalar_eq(&lhs.0, &rhs.0)
+    maybe_specialized! {
+        fn eq(self) -> bool {
+            let (lhs, rhs) = self;
+            ConstantTime::scalar_eq(&lhs.0, &rhs.0)
+        }
     }
 }
 
+#[cfg(feature = "nightly")]
 impl<Z1, Z2> ScalarBinary for (&Scalar<Public, Z1>, &Scalar<Public, Z2>) {
     fn mul(self) -> backend::Scalar {
         let (lhs, rhs) = self;
@@ -372,29 +413,40 @@ pub(crate) trait ScalarUnary {
 }
 
 impl<Z, S> ScalarUnary for Scalar<S, Z> {
-    default fn negate(&self) -> backend::Scalar {
-        let mut negated = self.0.clone();
-        ConstantTime::scalar_cond_negate(&mut negated, true);
-        negated
+    maybe_specialized! {
+        fn negate(&self) -> backend::Scalar {
+            let mut negated = self.0.clone();
+            ConstantTime::scalar_cond_negate(&mut negated, true);
+            negated
+        }
     }
 
-    default fn invert(&self) -> backend::Scalar {
-        ConstantTime::scalar_invert(&self.0)
+    maybe_specialized! {
+        fn invert(&self) -> backend::Scalar {
+            ConstantTime::scalar_invert(&self.0)
+        }
     }
 
-    default fn conditional_negate(&mut self, cond: bool) {
-        ConstantTime::scalar_cond_negate(&mut self.0, cond)
+    maybe_specialized! {
+        fn conditional_negate(&mut self, cond: bool) {
+            ConstantTime::scalar_cond_negate(&mut self.0, cond)
+        }
     }
 
-    default fn is_high(&self) -> bool {
-        ConstantTime::scalar_is_high(&self.0)
+    maybe_specialized! {
+        fn is_high(&self) -> bool {
+            ConstantTime::scalar_is_high(&self.0)
+        }
     }
 
-    default fn is_zero(&self) -> bool {
-        ConstantTime::scalar_is_zero(&self.0)
+    maybe_specialized! {
+        fn is_zero(&self) -> bool {
+            ConstantTime::scalar_is_zero(&self.0)
+        }
     }
 }
 
+#[cfg(feature = "nightly")]
 impl<Z> ScalarUnary for Scalar<Public, Z> {
     fn negate(&self) -> backend::Scalar {
         let mut negated = self.0.clone();
@@ -430,22 +482,29 @@ pub(crate) trait NormPointUnary {
 }
 
 impl<T, S, Z> PointUnary for Point<T, Z, S> {
-    default fn negate(mut self) -> backend::Point {
-        ConstantTime::point_neg(&mut self.0);
-        self.0
+    maybe_specialized! {
+        fn negate(mut self) -> backend::Point {
+            ConstantTime::point_neg(&mut self.0);
+            self.0
+        }
     }
 
-    default fn conditional_negate(mut self, cond: bool) -> backend::Point {
-        ConstantTime::point_conditional_negate(&mut self.0, cond);
-        self.0
+    maybe_specialized! {
+        fn conditional_negate(mut self, cond: bool) -> backend::Point {
+            ConstantTime::point_conditional_negate(&mut self.0, cond);
+            self.0
+        }
     }
 
-    default fn normalize(mut self) -> backend::Point {
-        ConstantTime::point_normalize(&mut self.0);
-        self.0
+    maybe_specialized! {
+        fn normalize(mut self) -> backend::Point {
+            ConstantTime::point_normalize(&mut self.0);
+            self.0
+        }
     }
 }
 
+#[cfg(feature = "nightly")]
 impl<T: Normalized, S, Z> PointUnary for Point<T, Z, S> {
     default fn negate(mut self) -> backend::Point {
         ConstantTime::norm_point_neg(&mut self.0);
@@ -462,6 +521,7 @@ impl<T: Normalized, S, Z> PointUnary for Point<T, Z, S> {
     }
 }
 
+#[cfg(feature = "nightly")]
 impl<Z> PointUnary for Point<Jacobian, Z, Public> {
     default fn negate(mut self) -> backend::Point {
         VariableTime::point_neg(&mut self.0);
@@ -479,6 +539,7 @@ impl<Z> PointUnary for Point<Jacobian, Z, Public> {
     }
 }
 
+#[cfg(feature = "nightly")]
 impl<T: Normalized, Z> PointUnary for Point<T, Z, Public> {
     fn negate(mut self) -> backend::Point {
         VariableTime::norm_point_neg(&mut self.0);
@@ -492,11 +553,14 @@ impl<T: Normalized, Z> PointUnary for Point<T, Z, Public> {
 }
 
 impl<T: Normalized, Z, S> NormPointUnary for Point<T, Z, S> {
-    default fn is_y_even(&self) -> bool {
-        ConstantTime::norm_point_is_y_even(&self.0)
+    maybe_specialized! {
+        fn is_y_even(&self) -> bool {
+            ConstantTime::norm_point_is_y_even(&self.0)
+        }
     }
 }
 
+#[cfg(feature = "nightly")]
 impl<T: Normalized, Z> NormPointUnary for Point<T, Z, Public> {
     fn is_y_even(&self) -> bool {
         VariableTime::norm_point_is_y_even(&self.0)

--- a/secp256kfun/src/slice.rs
+++ b/secp256kfun/src/slice.rs
@@ -40,12 +40,20 @@ impl<'a, S> Clone for Slice<'a, S> {
 impl<'a, S> Copy for Slice<'a, S> {}
 
 impl<'a, 'b, S1, S2> PartialEq<Slice<'b, S2>> for Slice<'a, S1> {
+    #[cfg(not(feature = "nightly"))]
+    fn eq(&self, rhs: &Slice<'b, S2>) -> bool {
+        // by default do comparison constant time
+        self.inner.ct_eq(rhs.inner).into()
+    }
+
+    #[cfg(feature = "nightly")]
     default fn eq(&self, rhs: &Slice<'b, S2>) -> bool {
         // by default do comparison constant time
         self.inner.ct_eq(rhs.inner).into()
     }
 }
 
+#[cfg(feature = "nightly")]
 impl<'a, 'b> PartialEq<Slice<'b, Public>> for Slice<'a, Public> {
     fn eq(&self, rhs: &Slice<'b, Public>) -> bool {
         // if both are public do variable time

--- a/secp256kfun/src/xonly.rs
+++ b/secp256kfun/src/xonly.rs
@@ -163,33 +163,34 @@ crate::impl_display_debug_serialize! {
 #[cfg(test)]
 mod test {
     use super::*;
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::wasm_bindgen_test as test;
 
-    crate::test_plus_wasm! {
-        fn xonly_random() {
-            let _ = XOnly::random(&mut rand::thread_rng());
-        }
+    #[test]
+    fn xonly_random() {
+        let _ = XOnly::random(&mut rand::thread_rng());
+    }
 
-        fn from_str() {
-            use crate::G;
-            use core::str::FromStr;
+    #[test]
+    fn from_str() {
+        use crate::G;
+        use core::str::FromStr;
 
-            assert_eq!(
-                XOnly::from_str(
-                    "79BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798",
-                )
-                    .unwrap()
-                    .to_point(),
-                *G
-            );
-        }
+        assert_eq!(
+            XOnly::from_str("79BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798",)
+                .unwrap()
+                .to_point(),
+            *G
+        );
+    }
 
-        fn xonly_to_point() {
-            for _ in 0..crate::TEST_SOUNDNESS {
-                let xonly_even = XOnly::random(&mut rand::thread_rng());
+    #[test]
+    fn xonly_to_point() {
+        for _ in 0..crate::TEST_SOUNDNESS {
+            let xonly_even = XOnly::random(&mut rand::thread_rng());
 
-                let point_even = xonly_even.to_point();
-                assert!(point_even.is_y_even());
-            }
+            let point_even = xonly_even.to_point();
+            assert!(point_even.is_y_even());
         }
     }
 }

--- a/sigma_fun/Cargo.toml
+++ b/sigma_fun/Cargo.toml
@@ -31,9 +31,10 @@ proptest = "0.10"
 rand_chacha = "0.3"
 
 [features]
-all = ["secp256k1", "ed25519", "alloc", "serde"]
+all = ["secp256k1", "ed25519", "alloc", "serde", "nightly"]
 default = ["alloc", "secp256k1"]
 alloc = ["serde_crate/alloc", "secp256kfun/alloc"]
 secp256k1 = ["secp256kfun"]
 ed25519 = ["curve25519-dalek"]
 serde = ["serde_crate", "secp256kfun/serde", "curve25519-dalek/serde", "generic-array/serde"]
+nightly = ["secp256kfun/nightly"]

--- a/sigma_fun/src/lib.rs
+++ b/sigma_fun/src/lib.rs
@@ -1,8 +1,7 @@
 //!
 #![no_std]
 #![allow(non_snake_case)]
-#![feature(extended_key_value_attributes)]
-#![cfg_attr(feature = "secp256k1", doc = include_str!("../README.md"))]
+// #![cfg_attr(feature = "secp256k1", doc = include_str!("../README.md"))] TODO: Activate with 1.54
 #![deny(missing_docs, warnings)]
 
 use core::fmt::Debug;


### PR DESCRIPTION
Attempting to solve #64.

For details see commit messages.

I've encountered three problems so far:

1. We can't conditionally use `extended_key_value_attributes` on nightly because we already fail during parsing time for an attribute like `#[cfg_attr(feature = "nightly", extended_key_value_attributes)]`. However, the feature is being stabilized with 1.54 which is in 10 weeks. Still quite some time away so not sure how to deal with this. For now I've commented it out to make progress on the more important items.
2. For some reason, rustdoc is mucking around now and can't find `OsRng`? I suspect it has to do with the new feature resolver I activated as part of the patch but I haven't found a solution yet.
3. There seems to be an issue where, once we don't use specialization, the `g_to_and_from_bytes` test fails. If compiled in debug mode, we hit an assertion that the point is not normalized yet. I don't understand the details but you can reproduce the failing test with `cargo +stable test point::test::g_to_and_from_bytes --no-default-features`