### PR TITLE
Re-Enable readme embedding

### DIFF
--- a/ecdsa_fun/src/lib.rs
+++ b/ecdsa_fun/src/lib.rs
@@ -1,4 +1,4 @@
-// #![doc = include_str!("../README.md")] TODO: Activate with 1.54
+#![doc = include_str!("../README.md")]
 #![no_std]
 #![allow(non_snake_case)]
 

--- a/schnorr_fun/src/lib.rs
+++ b/schnorr_fun/src/lib.rs
@@ -1,7 +1,7 @@
 //!
 #![no_std]
 #![allow(non_snake_case)]
-// #![doc = include_str!("../README.md")] TODO: Activate with 1.54
+#![doc = include_str!("../README.md")]
 #![deny(warnings, missing_docs)]
 #[cfg(all(feature = "alloc", not(feature = "std")))]
 #[macro_use]

--- a/secp256kfun/CHANGELOG.md
+++ b/secp256kfun/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+
+- can be built on stable if `nightly` feature is not enabled
+
 ## 0.6.2
 
 - Fix serialization of `Point<EvenY>`

--- a/secp256kfun/src/lib.rs
+++ b/secp256kfun/src/lib.rs
@@ -1,9 +1,10 @@
 //!
-#![cfg_attr(feature = "nightly", feature(rustc_attrs, min_specialization))]
+#![cfg_attr(feature = "nightly", feature(min_specialization, rustc_attrs))]
 #![no_std]
 #![allow(non_snake_case)]
 #![deny(missing_docs, warnings)]
-// #![doc = include_str!("../README.md")] TODO: Activate with 1.54
+#![doc = include_str!("../README.md")]
+
 #[cfg(all(feature = "alloc", not(feature = "std")))]
 #[allow(unused_imports)]
 #[macro_use]

--- a/sigma_fun/src/lib.rs
+++ b/sigma_fun/src/lib.rs
@@ -1,7 +1,7 @@
 //!
 #![no_std]
 #![allow(non_snake_case)]
-// #![cfg_attr(feature = "secp256k1", doc = include_str!("../README.md"))] TODO: Activate with 1.54
+#![cfg_attr(feature = "secp256k1", doc = include_str!("../README.md"))]
 #![deny(missing_docs, warnings)]
 
 use core::fmt::Debug;


### PR DESCRIPTION
The doc attribute thingy works as of 1.54 so we are ready to go with this