### PR TITLE
Replace parity backend with k256

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,17 +26,19 @@ jobs:
     strategy:
       matrix:
         args: [
-            --no-default-features,
-            --no-default-features --features=serde,
-            --no-default-features --features=std,
-            --all-features,
+            "--no-default-features",
+            # // test seperately from --all-features since for secp256kfun this will enable parity backend
+            "--no-default-features --features=std,serde,libsecp_compat",
+            "--no-default-features --features=std,serde,libsecp_compat,nightly",
+            "--all-features",
+            ""
         ]
         rust: [nightly, stable]
         exclude:
           - rust: stable
             args: --all-features
-          - rust: nightly
-            args: --no-default-features
+          - rust: stable
+            args: "--no-default-features --features=std,serde,libsecp_compat,nightly"
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/ecdsa_fun/Cargo.toml
+++ b/ecdsa_fun/Cargo.toml
@@ -36,7 +36,7 @@ name = "bench_ecdsa"
 harness = false
 
 [features]
-default = ["std", "nightly", "adaptor"]
+default = ["std", "adaptor"]
 all = ["std", "serde", "libsecp_compat", "adaptor"]
 libsecp_compat = ["secp256kfun/libsecp_compat"]
 std = ["alloc"]

--- a/ecdsa_fun/Cargo.toml
+++ b/ecdsa_fun/Cargo.toml
@@ -36,7 +36,7 @@ name = "bench_ecdsa"
 harness = false
 
 [features]
-default = ["std", "adaptor"]
+default = ["std"]
 all = ["std", "serde", "libsecp_compat", "adaptor"]
 libsecp_compat = ["secp256kfun/libsecp_compat"]
 std = ["alloc"]

--- a/ecdsa_fun/Cargo.toml
+++ b/ecdsa_fun/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ecdsa_fun"
-version = "0.6.3-alpha.0"
+version = "0.7.0-pre.0"
 authors = ["LLFourn <lloyd.fourn@gmail.com>"]
 edition = "2018"
 license = "0BSD"
@@ -16,7 +16,7 @@ keywords = ["bitcoin", "ecdsa", "secp256k1"]
 features = ["serde", "libsecp_compat"]
 
 [dependencies]
-secp256kfun = { path = "../secp256kfun", version = "0.6.3-alpha.0", default-features = false }
+secp256kfun = { path = "../secp256kfun", version = "0.7.0-pre.0", default-features = false }
 serde_crate = { package = "serde", version = "1.0", default-features = false, optional = true, features = ["derive", "alloc"] }
 sigma_fun = { path = "../sigma_fun", version = "0.3.3-alpha.0", features = ["secp256k1"], default-features = false, optional = true }
 rand_chacha = {  version = "0.3", optional = true }  # needed for adaptor signatures atm but would be nice to get rid of
@@ -24,7 +24,7 @@ bincode = { version = "1.0", optional = true }
 
 [dev-dependencies]
 secp256k1 = { default-features = false, version = "0.20", features = ["std"] }
-secp256kfun = { path = "../secp256kfun", version = "0.6.3-alpha.0", default-features = false, features = ["libsecp_compat"] }
+secp256kfun = { path = "../secp256kfun", version = "0.7.0-pre.0", default-features = false, features = ["libsecp_compat"] }
 rand = "0.8"
 criterion = "0.3"
 lazy_static = "1.4"

--- a/ecdsa_fun/tests/adaptor_test_vectors.rs
+++ b/ecdsa_fun/tests/adaptor_test_vectors.rs
@@ -1,4 +1,4 @@
-#![cfg(all(feature = "serde", feature = "alloc"))]
+#![cfg(all(feature = "serde", feature = "alloc", feature = "adaptor"))]
 extern crate serde_crate as serde;
 
 static DLC_SPEC_JSON: &'static str = include_str!("./test_vectors.json");

--- a/schnorr_fun/Cargo.toml
+++ b/schnorr_fun/Cargo.toml
@@ -39,7 +39,7 @@ harness = false
 
 
 [features]
-default = ["std", "nightly"]
+default = ["std"]
 all = ["std","serde", "libsecp_compat"]
 alloc = ["secp256kfun/alloc"]
 std = ["alloc", "secp256kfun/std"]

--- a/schnorr_fun/Cargo.toml
+++ b/schnorr_fun/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "schnorr_fun"
-version = "0.6.3-alpha.0"
+version = "0.7.0-pre.0"
 authors = ["LLFourn <lloyd.fourn@gmail.com>"]
 edition = "2018"
 license = "0BSD"
@@ -16,7 +16,7 @@ keywords = ["bitcoin", "schnorr"]
 features = ["all"]
 
 [dependencies]
-secp256kfun = { path = "../secp256kfun", version = "0.6.3-alpha.0",  default-features = false }
+secp256kfun = { path = "../secp256kfun", version = "0.7.0-pre.0",  default-features = false }
 serde_crate = { package = "serde", version = "1.0", default-features = false, optional = true, features = ["derive", "alloc"] }
 
 [dev-dependencies]
@@ -24,7 +24,7 @@ rand = { version = "0.8" }
 lazy_static = "1.4"
 bincode = "1.0"
 sha2 = "0.9"
-secp256kfun = { path = "../secp256kfun", version = "0.6.3-alpha.0", default-features = false, features = ["alloc"] }
+secp256kfun = { path = "../secp256kfun", version = "0.7.0-pre.0", default-features = false, features = ["alloc"] }
 
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]

--- a/secp256kfun/Cargo.toml
+++ b/secp256kfun/Cargo.toml
@@ -17,10 +17,12 @@ features = ["all"]
 
 [dependencies]
 digest = "0.9"
-subtle = { package = "subtle-ng", version = "2" }
+subtle = { version = "2" }
 rand_core = { version = "0.6" }
 serde_crate = { package = "serde", version = "1.0",  optional = true, default-features = false, features = ["derive"] }
-secp256kfun_parity_backend = { path = "../secp256kfun_parity_backend", version = "0.1.6-alpha.0" }
+#secp256kfun_k256_backend = { path = "../../k256_backend/k256", features = ["expose-field"] }
+secp256kfun_k256_backend = {  version = "0.9.6", features = ["expose-field"] }
+secp256kfun_parity_backend = { version = "0.1.5", optional = true }
 secp256k1 = { version = "0.20", optional = true, default-features = false }
 proptest = { version = "0.10", optional = true }
 
@@ -36,20 +38,21 @@ bincode = "1.0"
 criterion = "0.3"
 
 [build-dependencies]
-secp256kfun_parity_backend = { path = "../secp256kfun_parity_backend", version = "0.1.6-alpha.0", features = ["alloc"] }
+secp256kfun_parity_backend = { version = "0.1.5", features = ["alloc"], optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test = "0.3"
 
 
 [features]
-default = ["std", "nightly"]
+default = ["std"]
 all = ["std", "serde", "libsecp_compat", "nightly"]
 alloc = ["serde_crate/alloc"]
 std = ["alloc"]
 libsecp_compat = ["secp256k1"]
 serde = [ "serde_crate" ]
-nightly = [ ]
+nightly = []
+parity-backend = [ "secp256kfun_parity_backend" ]
 
 [[bench]]
 name = "bench_ecmult"

--- a/secp256kfun/Cargo.toml
+++ b/secp256kfun/Cargo.toml
@@ -17,11 +17,11 @@ features = ["all"]
 
 [dependencies]
 digest = "0.9"
-subtle = { version = "2" }
+subtle = { package = "subtle-ng", version = "2" }
 rand_core = { version = "0.6" }
 serde_crate = { package = "serde", version = "1.0",  optional = true, default-features = false, features = ["derive"] }
-#secp256kfun_k256_backend = { path = "../../k256_backend/k256", features = ["expose-field"] }
-secp256kfun_k256_backend = {  version = "0.9.6", features = ["expose-field"] }
+# secp256kfun_k256_backend = { path = "../../k256_backend/k256", features = ["expose-field"] }
+secp256kfun_k256_backend = {  version = "1.0.0", features = ["expose-field"] }
 secp256kfun_parity_backend = { version = "0.1.5", optional = true }
 secp256k1 = { version = "0.20", optional = true, default-features = false }
 proptest = { version = "0.10", optional = true }

--- a/secp256kfun/Cargo.toml
+++ b/secp256kfun/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "secp256kfun"
-version = "0.6.3-alpha.0"
+version = "0.7.0-pre.0"
 authors = ["LLFourn <lloyd.fourn@gmail.com>"]
 license = "0BSD"
 homepage = "https://github.com/LLFourn/secp256kfun"

--- a/secp256kfun/benches/bench_ecmult.rs
+++ b/secp256kfun/benches/bench_ecmult.rs
@@ -5,9 +5,6 @@ use secp256kfun::{g, marker::*, Point, Scalar, G};
 fn scalar_mul_point(c: &mut Criterion) {
     let mut group = c.benchmark_group("ecmult");
 
-    group.sample_size(600);
-    group.measurement_time(std::time::Duration::from_secs(60));
-
     group.bench_function("scalar_mul_point:basepoint,secret", |b| {
         b.iter_batched(
             || Scalar::random(&mut rand::thread_rng()),
@@ -77,5 +74,67 @@ fn scalar_mul_point(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, scalar_mul_point);
+fn double_mul(c: &mut Criterion) {
+    let mut group = c.benchmark_group("double_mul");
+
+    group.bench_function("double_mul:normal,public", |b| {
+        b.iter_batched(
+            || {
+                (
+                    Scalar::random(&mut rand::thread_rng()).mark::<Public>(),
+                    Scalar::random(&mut rand::thread_rng()).mark::<Public>(),
+                    Point::random(&mut rand::thread_rng()),
+                    Point::random(&mut rand::thread_rng()),
+                )
+            },
+            |(x, y, A, B)| g!(x * A + y * B),
+            BatchSize::SmallInput,
+        )
+    });
+
+    group.bench_function("double_mul:normal,secret", |b| {
+        b.iter_batched(
+            || {
+                (
+                    Scalar::random(&mut rand::thread_rng()),
+                    Scalar::random(&mut rand::thread_rng()),
+                    Point::random(&mut rand::thread_rng()),
+                    Point::random(&mut rand::thread_rng()),
+                )
+            },
+            |(x, y, A, B)| g!(x * A + y * B),
+            BatchSize::SmallInput,
+        )
+    });
+
+    group.bench_function("double_mul:basepoint,public", |b| {
+        b.iter_batched(
+            || {
+                (
+                    Scalar::random(&mut rand::thread_rng()).mark::<Public>(),
+                    Scalar::random(&mut rand::thread_rng()).mark::<Public>(),
+                    Point::random(&mut rand::thread_rng()),
+                )
+            },
+            |(x, y, B)| g!(x * G + y * B),
+            BatchSize::SmallInput,
+        )
+    });
+
+    group.bench_function("double_mul:basepoint,secret", |b| {
+        b.iter_batched(
+            || {
+                (
+                    Scalar::random(&mut rand::thread_rng()),
+                    Scalar::random(&mut rand::thread_rng()),
+                    Point::random(&mut rand::thread_rng()),
+                )
+            },
+            |(x, y, B)| g!(x * G + y * B),
+            BatchSize::SmallInput,
+        )
+    });
+}
+
+criterion_group!(benches, scalar_mul_point, double_mul);
 criterion_main!(benches);

--- a/secp256kfun/build.rs
+++ b/secp256kfun/build.rs
@@ -1,71 +1,77 @@
 #![allow(non_snake_case)]
-use secp256kfun_parity_backend::{
-    ecmult::{ECMultContext, ECMultGenContext},
-    group::AffineStorage,
-};
-use std::{
-    env,
-    fs::File,
-    io::{self, Write},
-    path::Path,
-};
 
 fn main() {
-    // scratch: v0.1.2
-    println!("cargo:rerun-if-changed=build.rs");
-    let out_dir = env::var_os("OUT_DIR").unwrap();
-    let ecmult_path = Path::new(&out_dir).join("ecmult_table.rs");
-    let mut ecmult_file = File::create(&ecmult_path).expect("Create ecmult_table.rs file failed");
-    write_ecmult_table(&mut ecmult_file).expect("Write ecmult_table.rs file failed");
-    ecmult_file
-        .flush()
-        .expect("Flush ecmult_table.rs file failed");
-    let ecmult_gen_path = Path::new(&out_dir).join("ecmult_gen_table.rs");
-    let mut ecmult_gen_file =
-        File::create(&ecmult_gen_path).expect("Create ecmult_gen_table.rs file failed");
-    write_ecmult_gen_table(&mut ecmult_gen_file).expect("Write ecmult_gen_table.rs file failed");
-    ecmult_gen_file
-        .flush()
-        .expect("Flush ecmult_gen_table.rs file failed");
-}
+    #[cfg(feature = "secp256kfun_parity_backend")]
+    {
+        use secp256kfun_parity_backend::{
+            ecmult::{ECMultContext, ECMultGenContext},
+            group::AffineStorage,
+        };
+        use std::{
+            env,
+            fs::File,
+            io::{self, Write},
+            path::Path,
+        };
 
-fn write_ecmult_gen_table(file: &mut File) -> Result<(), io::Error> {
-    let context = ECMultGenContext::new_boxed();
-    let prec = context.inspect_raw().as_ref();
+        // scratch: v0.1.2
+        println!("cargo:rerun-if-changed=build.rs");
+        let out_dir = env::var_os("OUT_DIR").unwrap();
+        let ecmult_path = Path::new(&out_dir).join("ecmult_table.rs");
+        let mut ecmult_file =
+            File::create(&ecmult_path).expect("Create ecmult_table.rs file failed");
+        write_ecmult_table(&mut ecmult_file).expect("Write ecmult_table.rs file failed");
+        ecmult_file
+            .flush()
+            .expect("Flush ecmult_table.rs file failed");
+        let ecmult_gen_path = Path::new(&out_dir).join("ecmult_gen_table.rs");
+        let mut ecmult_gen_file =
+            File::create(&ecmult_gen_path).expect("Create ecmult_gen_table.rs file failed");
+        write_ecmult_gen_table(&mut ecmult_gen_file)
+            .expect("Write ecmult_gen_table.rs file failed");
+        ecmult_gen_file
+            .flush()
+            .expect("Flush ecmult_gen_table.rs file failed");
 
-    file.write_fmt(format_args!("["))?;
-    for j in 0..64 {
-        file.write_fmt(format_args!("    ["))?;
-        for i in 0..16 {
-            let pg: AffineStorage = prec[j][i].clone().into();
-            file.write_fmt(format_args!(
-                "        secp256kfun_parity_backend::group::AffineStorage::new(secp256kfun_parity_backend::field::FieldStorage::new({}, {}, {}, {}, {}, {}, {}, {}), secp256kfun_parity_backend::field::FieldStorage::new({}, {}, {}, {}, {}, {}, {}, {})),",
-                pg.x.0[7], pg.x.0[6], pg.x.0[5], pg.x.0[4], pg.x.0[3], pg.x.0[2], pg.x.0[1], pg.x.0[0],
-                pg.y.0[7], pg.y.0[6], pg.y.0[5], pg.y.0[4], pg.y.0[3], pg.y.0[2], pg.y.0[1], pg.y.0[0]
-            ))?;
+        fn write_ecmult_gen_table(file: &mut File) -> Result<(), io::Error> {
+            let context = ECMultGenContext::new_boxed();
+            let prec = context.inspect_raw().as_ref();
+
+            file.write_fmt(format_args!("["))?;
+            for j in 0..64 {
+                file.write_fmt(format_args!("    ["))?;
+                for i in 0..16 {
+                    let pg: AffineStorage = prec[j][i].clone().into();
+                    file.write_fmt(format_args!(
+                        "        secp256kfun_parity_backend::group::AffineStorage::new(secp256kfun_parity_backend::field::FieldStorage::new({}, {}, {}, {}, {}, {}, {}, {}), secp256kfun_parity_backend::field::FieldStorage::new({}, {}, {}, {}, {}, {}, {}, {})),",
+                        pg.x.0[7], pg.x.0[6], pg.x.0[5], pg.x.0[4], pg.x.0[3], pg.x.0[2], pg.x.0[1], pg.x.0[0],
+                        pg.y.0[7], pg.y.0[6], pg.y.0[5], pg.y.0[4], pg.y.0[3], pg.y.0[2], pg.y.0[1], pg.y.0[0]
+                    ))?;
+                }
+                file.write_fmt(format_args!("    ],"))?;
+            }
+            file.write_fmt(format_args!("]"))?;
+
+            Ok(())
         }
-        file.write_fmt(format_args!("    ],"))?;
+
+        fn write_ecmult_table(file: &mut File) -> Result<(), io::Error> {
+            let context = ECMultContext::new_boxed();
+            let pre_g = context.inspect_raw().as_ref();
+
+            file.write_fmt(format_args!("["))?;
+            for pg in pre_g {
+                file.write_fmt(
+                    format_args!(
+                        "    secp256kfun_parity_backend::group::AffineStorage::new(secp256kfun_parity_backend::field::FieldStorage::new({}, {}, {}, {}, {}, {}, {}, {}), secp256kfun_parity_backend::field::FieldStorage::new({}, {}, {}, {}, {}, {}, {}, {})),",
+                        pg.x.0[7], pg.x.0[6], pg.x.0[5], pg.x.0[4], pg.x.0[3], pg.x.0[2], pg.x.0[1], pg.x.0[0],
+                        pg.y.0[7], pg.y.0[6], pg.y.0[5], pg.y.0[4], pg.y.0[3], pg.y.0[2], pg.y.0[1], pg.y.0[0]
+                    )
+                )?;
+            }
+            file.write_fmt(format_args!("]"))?;
+
+            Ok(())
+        }
     }
-    file.write_fmt(format_args!("]"))?;
-
-    Ok(())
-}
-
-fn write_ecmult_table(file: &mut File) -> Result<(), io::Error> {
-    let context = ECMultContext::new_boxed();
-    let pre_g = context.inspect_raw().as_ref();
-
-    file.write_fmt(format_args!("["))?;
-    for pg in pre_g {
-        file.write_fmt(
-            format_args!(
-                "    secp256kfun_parity_backend::group::AffineStorage::new(secp256kfun_parity_backend::field::FieldStorage::new({}, {}, {}, {}, {}, {}, {}, {}), secp256kfun_parity_backend::field::FieldStorage::new({}, {}, {}, {}, {}, {}, {}, {})),",
-                pg.x.0[7], pg.x.0[6], pg.x.0[5], pg.x.0[4], pg.x.0[3], pg.x.0[2], pg.x.0[1], pg.x.0[0],
-                pg.y.0[7], pg.y.0[6], pg.y.0[5], pg.y.0[4], pg.y.0[3], pg.y.0[2], pg.y.0[1], pg.y.0[0]
-            )
-        )?;
-    }
-    file.write_fmt(format_args!("]"))?;
-
-    Ok(())
 }

--- a/secp256kfun/src/backend/k256.rs
+++ b/secp256kfun/src/backend/k256.rs
@@ -1,9 +1,6 @@
 use core::ops::{Add, Neg};
-
 pub use secp256kfun_k256_backend::Scalar;
-use secp256kfun_k256_backend::{
-    lincomb, AffinePoint, FieldBytes, FieldElement, ProjectivePoint,
-};
+use secp256kfun_k256_backend::{lincomb, AffinePoint, FieldBytes, FieldElement, ProjectivePoint};
 use subtle::{Choice, ConditionallyNegatable, ConditionallySelectable, ConstantTimeEq};
 
 use super::{BackendPoint, BackendScalar, BackendXOnly, TimeSensitive};
@@ -317,6 +314,7 @@ impl TimeSensitive for ConstantTime {
 
 pub struct VariableTime;
 
+// delegate everything to constant time for now
 impl TimeSensitive for VariableTime {
     fn scalar_mul_norm_point(lhs: &Scalar, rhs: &Point) -> Point {
         ConstantTime::scalar_mul_norm_point(lhs, rhs)

--- a/secp256kfun/src/backend/k256/mod.rs
+++ b/secp256kfun/src/backend/k256/mod.rs
@@ -2,11 +2,6 @@ use core::ops::{Add, Neg};
 
 pub use secp256kfun_k256_backend::Scalar;
 use secp256kfun_k256_backend::{
-    elliptic_curve::{
-        group::{ff::PrimeField, prime::PrimeCurveAffine},
-        weierstrass::DecompressPoint,
-        Group,
-    },
     lincomb, AffinePoint, FieldBytes, FieldElement, ProjectivePoint,
 };
 use subtle::{Choice, ConditionallyNegatable, ConditionallySelectable, ConstantTimeEq};

--- a/secp256kfun/src/backend/k256/mod.rs
+++ b/secp256kfun/src/backend/k256/mod.rs
@@ -1,0 +1,460 @@
+use core::ops::{Add, Neg};
+
+pub use secp256kfun_k256_backend::Scalar;
+use secp256kfun_k256_backend::{
+    elliptic_curve::{
+        group::{ff::PrimeField, prime::PrimeCurveAffine},
+        weierstrass::DecompressPoint,
+        Group,
+    },
+    lincomb, AffinePoint, FieldBytes, FieldElement, ProjectivePoint,
+};
+use subtle::{Choice, ConditionallyNegatable, ConditionallySelectable, ConstantTimeEq};
+
+use super::{BackendPoint, BackendScalar, BackendXOnly, TimeSensitive};
+pub type Point = ProjectivePoint;
+pub type BasePoint = ProjectivePoint;
+
+pub const G_JACOBIAN: ProjectivePoint = ProjectivePoint {
+    x: FieldElement::from_bytes_unchecked(&[
+        0x79, 0xbe, 0x66, 0x7e, 0xf9, 0xdc, 0xbb, 0xac, 0x55, 0xa0, 0x62, 0x95, 0xce, 0x87, 0x0b,
+        0x07, 0x02, 0x9b, 0xfc, 0xdb, 0x2d, 0xce, 0x28, 0xd9, 0x59, 0xf2, 0x81, 0x5b, 0x16, 0xf8,
+        0x17, 0x98,
+    ]),
+    y: FieldElement::from_bytes_unchecked(&[
+        0x48, 0x3a, 0xda, 0x77, 0x26, 0xa3, 0xc4, 0x65, 0x5d, 0xa4, 0xfb, 0xfc, 0x0e, 0x11, 0x08,
+        0xa8, 0xfd, 0x17, 0xb4, 0x48, 0xa6, 0x85, 0x54, 0x19, 0x9c, 0x47, 0xd0, 0x8f, 0xfb, 0x10,
+        0xd4, 0xb8,
+    ]),
+    z: FieldElement::one(),
+};
+
+pub static G_TABLE: ProjectivePoint = G_JACOBIAN;
+
+impl BackendScalar for Scalar {
+    fn minus_one() -> Self {
+        -Scalar::one()
+    }
+
+    fn from_u32(int: u32) -> Self {
+        Self::from(int)
+    }
+
+    fn zero() -> Self {
+        Scalar::zero()
+    }
+
+    fn from_bytes_mod_order(bytes: [u8; 32]) -> Self {
+        Scalar::from_bytes_reduced(&FieldBytes::from(bytes))
+    }
+
+    fn from_bytes(bytes: [u8; 32]) -> Option<Self> {
+        Scalar::from_repr(FieldBytes::from(bytes))
+    }
+
+    fn to_bytes(&self) -> [u8; 32] {
+        self.to_bytes().into()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Copy, Eq, Hash)]
+pub struct XOnly([u8; 32]);
+
+impl BackendXOnly for XOnly {
+    fn from_bytes(bytes: [u8; 32]) -> Option<Self> {
+        let bytes = FieldBytes::from(bytes);
+        let option: Option<AffinePoint> = AffinePoint::decompress(&bytes, 0u8.into()).into();
+        option.map(|_| XOnly(bytes.into()))
+    }
+
+    fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+
+    fn into_bytes(self) -> [u8; 32] {
+        self.0
+    }
+
+    fn into_norm_point_even_y(self) -> Point {
+        let bytes = FieldBytes::from(self.0);
+        let affine = AffinePoint::decompress(&bytes, 0u8.into()).unwrap();
+        affine.into()
+    }
+}
+
+impl XOnly {
+    fn to_field_elem(&self) -> FieldElement {
+        FieldElement::from_bytes_unchecked(&self.0)
+    }
+}
+
+impl BackendPoint for Point {
+    fn zero() -> Point {
+        ProjectivePoint::identity()
+    }
+
+    fn is_zero(&self) -> bool {
+        ProjectivePoint::is_identity(self).into()
+    }
+
+    fn norm_to_coordinates(&self) -> ([u8; 32], [u8; 32]) {
+        (self.x.to_bytes().into(), self.y.to_bytes().into())
+    }
+
+    fn norm_to_xonly(&self) -> XOnly {
+        XOnly(self.x.to_bytes().into())
+    }
+
+    fn norm_from_bytes_y_oddness(x_bytes: [u8; 32], y_odd: bool) -> Option<Point> {
+        let x_bytes = FieldBytes::from(x_bytes);
+        let option: Option<AffinePoint> =
+            AffinePoint::decompress(&x_bytes, (y_odd as u8).into()).into();
+        option.map(|affine| affine.into())
+    }
+
+    fn norm_from_coordinates(x: [u8; 32], y: [u8; 32]) -> Option<Point> {
+        let x = Option::from(FieldElement::from_bytes(&FieldBytes::from(x)))?;
+        let y = Option::from(FieldElement::from_bytes(&FieldBytes::from(y)))?;
+        Some(
+            AffinePoint {
+                x,
+                y,
+                infinity: Choice::from(0u8),
+            }
+            .into(),
+        )
+    }
+}
+
+pub struct ConstantTime;
+
+impl TimeSensitive for ConstantTime {
+    fn scalar_mul_norm_point(lhs: &Scalar, rhs: &Point) -> Point {
+        rhs * lhs
+    }
+
+    fn scalar_mul_point(lhs: &Scalar, rhs: &Point) -> Point {
+        rhs * lhs
+    }
+
+    fn scalar_eq(lhs: &Scalar, rhs: &Scalar) -> bool {
+        lhs.ct_eq(rhs).into()
+    }
+
+    fn point_normalize(point: &mut Point) {
+        let zinv_opt = point.z.invert();
+        let was_zero = zinv_opt.is_none();
+        let zinv = zinv_opt.unwrap_or(FieldElement::one());
+        point.x *= zinv;
+        point.y *= zinv;
+        point.x = point.x.normalize();
+        point.y = point.y.normalize();
+        point.z.conditional_assign(&FieldElement::one(), !was_zero);
+    }
+
+    fn point_eq_point(lhs: &Point, rhs: &Point) -> bool {
+        // The points are stored internally in projective coordinates:
+        // lhs: (x₁z₁, y₁z₁, z₁), rhs: (x₂z₂, y₂z₂, z₂)
+        // we want to know if x₁ == x₂ and y₁ == y₂
+        // So we transform these both to
+        // lhs: (x₁z₁z₂, y₁z₁z₂) rhs: (x₂z₁z₂, y₂z₁z₂)
+        let only_one_is_infinity = lhs.is_identity() ^ rhs.is_identity();
+        let both_infinity = lhs.is_identity() & rhs.is_identity();
+
+        let lhs_x = lhs.x * &rhs.z;
+        let rhs_x = rhs.x * &lhs.z;
+        let x_eq = rhs_x.negate(1).add(&lhs_x).normalizes_to_zero();
+
+        let lhs_y = lhs.y * &rhs.z;
+        let rhs_y = rhs.y * &lhs.z;
+        let y_eq = rhs_y.negate(1).add(&lhs_y).normalizes_to_zero();
+
+        (both_infinity | (!only_one_is_infinity & x_eq & y_eq)).into()
+    }
+
+    fn point_eq_norm_point(lhs: &Point, rhs: &Point) -> bool {
+        let only_one_is_infinity = lhs.is_identity() ^ rhs.is_identity();
+        let both_infinity = lhs.is_identity() & rhs.is_identity();
+
+        let rhs_x = &rhs.x * &lhs.z;
+        let x_eq = rhs_x.negate(1).add(&lhs.x).normalizes_to_zero();
+
+        let rhs_y = &rhs.y * &lhs.z;
+        let y_eq = rhs_y.negate(1).add(&lhs.y).normalizes_to_zero();
+
+        (both_infinity | (!only_one_is_infinity & x_eq & y_eq)).into()
+    }
+
+    fn point_eq_xonly(lhs: &Point, rhs: &XOnly) -> bool {
+        let mut lhs = lhs.clone();
+        Self::point_normalize(&mut lhs);
+        Self::norm_point_eq_xonly(&lhs, rhs)
+    }
+
+    fn norm_point_eq_xonly(point: &Point, xonly: &XOnly) -> bool {
+        let are_equal = point.x.ct_eq(&xonly.to_field_elem());
+        let y_is_even = !point.y.is_odd();
+        (are_equal & y_is_even).into()
+    }
+
+    fn point_add_point(lhs: &Point, rhs: &Point) -> Point {
+        lhs + rhs
+    }
+
+    fn point_add_norm_point(lhs: &Point, rhs: &Point) -> Point {
+        // use more efficient version for affine
+        let rhs = AffinePoint::conditional_select(
+            &AffinePoint {
+                x: rhs.x,
+                y: rhs.y,
+                infinity: Choice::from(0),
+            },
+            &AffinePoint::identity(),
+            rhs.is_identity(),
+        );
+        lhs + &rhs
+    }
+
+    fn any_point_neg(point: &mut Point) {
+        point.y = point.y.negate(1).normalize()
+    }
+
+    fn any_point_conditional_negate(point: &mut Point, cond: bool) {
+        point.conditional_negate(Choice::from(cond as u8));
+        point.y = point.y.normalize()
+    }
+
+    fn point_neg(point: &mut Point) {
+        point.y = point.y.negate(1).normalize_weak()
+    }
+
+    fn point_sub_norm_point(lhs: &Point, rhs: &Point) -> Point {
+        // use more efficient version for affine
+        let rhs = AffinePoint::conditional_select(
+            &AffinePoint {
+                x: rhs.x,
+                y: rhs.y,
+                infinity: Choice::from(0),
+            },
+            &AffinePoint::identity(),
+            rhs.is_identity(),
+        );
+        lhs + &rhs.neg()
+    }
+
+    fn point_conditional_negate(point: &mut Point, cond: bool) {
+        Self::any_point_conditional_negate(point, cond)
+    }
+
+    fn norm_point_sub_point(lhs: &Point, rhs: &Point) -> Point {
+        let lhs = AffinePoint::conditional_select(
+            &AffinePoint {
+                x: lhs.x,
+                y: lhs.y,
+                infinity: Choice::from(0),
+            },
+            &AffinePoint::identity(),
+            lhs.is_identity(),
+        );
+        &rhs.neg() + &lhs
+    }
+
+    fn norm_point_neg(point: &mut Point) {
+        Self::any_point_neg(point)
+    }
+
+    fn norm_point_eq_norm_point(lhs: &Point, rhs: &Point) -> bool {
+        lhs.ct_eq(rhs).into()
+    }
+
+    fn norm_point_is_y_even(point: &Point) -> bool {
+        (!point.y.is_odd()).into()
+    }
+
+    fn norm_point_conditional_negate(point: &mut Point, cond: bool) {
+        Self::any_point_conditional_negate(point, cond)
+    }
+
+    fn basepoint_double_mul(x: &Scalar, A: &BasePoint, y: &Scalar, B: &Point) -> Point {
+        Self::point_double_mul(x, A, y, B)
+    }
+
+    fn point_double_mul(x: &Scalar, A: &Point, y: &Scalar, B: &Point) -> Point {
+        lincomb(A, x, B, y)
+    }
+
+    fn scalar_add(lhs: &Scalar, rhs: &Scalar) -> Scalar {
+        lhs + rhs
+    }
+
+    fn scalar_sub(lhs: &Scalar, rhs: &Scalar) -> Scalar {
+        lhs - rhs
+    }
+
+    fn scalar_cond_negate(scalar: &mut Scalar, neg: bool) {
+        scalar.conditional_negate(Choice::from(neg as u8))
+    }
+
+    fn scalar_is_high(scalar: &Scalar) -> bool {
+        scalar.is_high().into()
+    }
+
+    fn scalar_is_zero(scalar: &Scalar) -> bool {
+        scalar.is_zero().into()
+    }
+
+    fn scalar_mul(lhs: &Scalar, rhs: &Scalar) -> Scalar {
+        lhs * rhs
+    }
+
+    fn scalar_invert(scalar: &Scalar) -> Scalar {
+        scalar.invert().unwrap()
+    }
+
+    fn scalar_mul_basepoint(scalar: &Scalar, base: &BasePoint) -> Point {
+        base * scalar
+    }
+
+    fn xonly_eq(lhs: &XOnly, rhs: &XOnly) -> bool {
+        lhs.0.ct_eq(&rhs.0).into()
+    }
+}
+
+pub struct VariableTime;
+
+impl TimeSensitive for VariableTime {
+    fn scalar_mul_norm_point(lhs: &Scalar, rhs: &Point) -> Point {
+        ConstantTime::scalar_mul_norm_point(lhs, rhs)
+    }
+
+    fn scalar_mul_point(lhs: &Scalar, rhs: &Point) -> Point {
+        ConstantTime::scalar_mul_point(lhs, rhs)
+    }
+
+    fn scalar_eq(lhs: &Scalar, rhs: &Scalar) -> bool {
+        ConstantTime::scalar_eq(lhs, rhs)
+    }
+
+    fn point_eq_point(lhs: &Point, rhs: &Point) -> bool {
+        ConstantTime::point_eq_point(lhs, rhs)
+    }
+
+    fn point_normalize(point: &mut Point) {
+        ConstantTime::point_normalize(point)
+    }
+
+    fn point_eq_norm_point(lhs: &Point, rhs: &Point) -> bool {
+        ConstantTime::point_eq_norm_point(lhs, rhs)
+    }
+
+    fn point_eq_xonly(lhs: &Point, rhs: &XOnly) -> bool {
+        ConstantTime::point_eq_xonly(lhs, rhs)
+    }
+
+    fn point_add_point(lhs: &Point, rhs: &Point) -> Point {
+        ConstantTime::point_add_point(lhs, rhs)
+    }
+
+    fn point_add_norm_point(lhs: &Point, rhs: &Point) -> Point {
+        ConstantTime::point_add_norm_point(lhs, rhs)
+    }
+
+    fn any_point_neg(point: &mut Point) {
+        ConstantTime::any_point_neg(point)
+    }
+
+    fn any_point_conditional_negate(point: &mut Point, cond: bool) {
+        ConstantTime::any_point_conditional_negate(point, cond)
+    }
+
+    fn point_neg(point: &mut Point) {
+        ConstantTime::point_neg(point)
+    }
+
+    fn point_sub_norm_point(lhs: &Point, rhs: &Point) -> Point {
+        ConstantTime::point_sub_norm_point(lhs, rhs)
+    }
+
+    fn point_conditional_negate(point: &mut Point, cond: bool) {
+        ConstantTime::point_conditional_negate(point, cond)
+    }
+
+    fn norm_point_sub_point(lhs: &Point, rhs: &Point) -> Point {
+        ConstantTime::norm_point_sub_point(lhs, rhs)
+    }
+
+    fn norm_point_neg(point: &mut Point) {
+        ConstantTime::norm_point_neg(point)
+    }
+
+    fn norm_point_eq_xonly(point: &Point, xonly: &XOnly) -> bool {
+        ConstantTime::norm_point_eq_xonly(point, xonly)
+    }
+
+    fn norm_point_eq_norm_point(lhs: &Point, rhs: &Point) -> bool {
+        ConstantTime::norm_point_eq_norm_point(lhs, rhs)
+    }
+
+    fn norm_point_is_y_even(point: &Point) -> bool {
+        ConstantTime::norm_point_is_y_even(point)
+    }
+
+    fn norm_point_conditional_negate(point: &mut Point, cond: bool) {
+        ConstantTime::norm_point_conditional_negate(point, cond)
+    }
+
+    fn basepoint_double_mul(x: &Scalar, A: &BasePoint, y: &Scalar, B: &Point) -> Point {
+        Self::point_double_mul(x, A, y, B)
+    }
+
+    fn scalar_add(lhs: &Scalar, rhs: &Scalar) -> Scalar {
+        ConstantTime::scalar_add(lhs, rhs)
+    }
+
+    fn scalar_sub(lhs: &Scalar, rhs: &Scalar) -> Scalar {
+        ConstantTime::scalar_sub(lhs, rhs)
+    }
+
+    fn scalar_cond_negate(scalar: &mut Scalar, neg: bool) {
+        ConstantTime::scalar_cond_negate(scalar, neg)
+    }
+
+    fn scalar_is_high(scalar: &Scalar) -> bool {
+        ConstantTime::scalar_is_high(scalar)
+    }
+
+    fn scalar_is_zero(scalar: &Scalar) -> bool {
+        ConstantTime::scalar_is_zero(scalar)
+    }
+
+    fn scalar_mul(lhs: &Scalar, rhs: &Scalar) -> Scalar {
+        ConstantTime::scalar_mul(lhs, rhs)
+    }
+
+    fn scalar_invert(scalar: &Scalar) -> Scalar {
+        ConstantTime::scalar_invert(scalar)
+    }
+
+    fn scalar_mul_basepoint(scalar: &Scalar, base: &BasePoint) -> Point {
+        ConstantTime::scalar_mul_basepoint(scalar, base)
+    }
+
+    fn xonly_eq(lhs: &XOnly, rhs: &XOnly) -> bool {
+        ConstantTime::xonly_eq(lhs, rhs)
+    }
+
+    fn point_double_mul(x: &Scalar, A: &Point, y: &Scalar, B: &Point) -> Point {
+        ConstantTime::point_double_mul(x, A, y, B)
+    }
+}
+
+impl VariableTime {
+    pub fn point_x_eq_scalar(point: &Point, scalar: &Scalar) -> bool {
+        if point.is_identity().into() {
+            return false;
+        }
+        let mut point = point.clone();
+        Self::point_normalize(&mut point);
+        Scalar::from_bytes_reduced(&point.x.to_bytes()).eq(scalar)
+    }
+}

--- a/secp256kfun/src/backend/mod.rs
+++ b/secp256kfun/src/backend/mod.rs
@@ -1,4 +1,11 @@
+#[cfg(not(feature = "parity-backend"))]
+mod k256;
+#[cfg(not(feature = "parity-backend"))]
+pub use k256::*;
+
+#[cfg(feature = "parity-backend")]
 mod parity;
+#[cfg(feature = "parity-backend")]
 pub use parity::*;
 
 pub trait BackendScalar: Sized {
@@ -55,6 +62,11 @@ pub trait TimeSensitive {
     fn norm_point_is_y_even(point: &Point) -> bool;
     fn norm_point_conditional_negate(point: &mut Point, cond: bool);
     fn basepoint_double_mul(x: &Scalar, A: &BasePoint, y: &Scalar, B: &Point) -> Point;
+    fn point_double_mul(x: &Scalar, A: &Point, y: &Scalar, B: &Point) -> Point {
+        let xA = Self::scalar_mul_point(x, A);
+        let yB = Self::scalar_mul_point(y, B);
+        Self::point_add_point(&xA, &yB)
+    }
     fn scalar_add(lhs: &Scalar, rhs: &Scalar) -> Scalar;
     fn scalar_sub(lhs: &Scalar, rhs: &Scalar) -> Scalar;
     fn scalar_cond_negate(scalar: &mut Scalar, neg: bool);

--- a/secp256kfun/src/lib.rs
+++ b/secp256kfun/src/lib.rs
@@ -2,7 +2,7 @@
 #![cfg_attr(feature = "nightly", feature(min_specialization, rustc_attrs))]
 #![no_std]
 #![allow(non_snake_case)]
-#![deny(missing_docs, warnings)]
+#![deny(missing_docs)]
 #![doc = include_str!("../README.md")]
 
 #[cfg(all(feature = "alloc", not(feature = "std")))]

--- a/secp256kfun/src/point.rs
+++ b/secp256kfun/src/point.rs
@@ -1,5 +1,5 @@
 use crate::{
-    backend::{self, BackendPoint},
+    backend::{self, BackendPoint, TimeSensitive},
     hash::HashInto,
     marker::*,
     op, Scalar, XOnly,
@@ -310,12 +310,8 @@ impl<S, T: Normalized> Point<T, S, NonZero> {
     /// [_Standards for Efficient Cryptography_]: https://www.secg.org/sec1-v2.pdf
     /// [`from_bytes`]: crate::Point::from_bytes
     pub fn to_bytes(&self) -> [u8; 33] {
-        let mut bytes = [0u8; 33];
         let (x, y) = self.coordinates();
-        bytes[0] = y[31] & 0x01;
-        bytes[0] |= 0x02;
-        bytes[1..].copy_from_slice(&x[..]);
-        bytes
+        coords_to_bytes(x, y)
     }
 
     /// Encodes a point as its compressed encoding as specified by [_Standards for Efficient Cryptography_].
@@ -376,11 +372,24 @@ where
     }
 }
 
+fn coords_to_bytes(x: [u8; 32], y: [u8; 32]) -> [u8; 33] {
+    let mut bytes = [0u8; 33];
+    bytes[0] = y[31] & 0x01;
+    bytes[0] |= 0x02;
+    bytes[1..].copy_from_slice(&x[..]);
+    bytes
+}
+
 crate::impl_debug! {
-    fn to_bytes<T: PointType, S,Z>(point: &Point<T, S, Z>) -> Result<[u8;33], &str> {
-        match Clone::clone(*point).mark::<(Normal,NonZero)>() {
-            Some(nzpoint) => Ok(nzpoint.to_bytes()),
-            None => Err("Zero"),
+    fn to_bytes<T, S,Z>(point: &Point<T, S, Z>) -> Result<[u8;33], &str> {
+        let mut p = point.0.clone();
+        backend::VariableTime::point_normalize(&mut p);
+        if backend::Point::is_zero(&p) {
+            Err("Zero")
+        }
+        else {
+            let (x, y) = backend::Point::norm_to_coordinates(&p);
+            Ok(coords_to_bytes(x,y))
         }
     }
 }

--- a/secp256kfun/src/point.rs
+++ b/secp256kfun/src/point.rs
@@ -270,7 +270,7 @@ impl<T: PointType, S, Z> core::ops::Neg for &Point<T, S, Z> {
 
 impl<T1, S1, Z1, T2, S2, Z2> PartialEq<Point<T2, S2, Z2>> for Point<T1, S1, Z1> {
     fn eq(&self, rhs: &Point<T2, S2, Z2>) -> bool {
-        op::PointBinary::eq((self, rhs))
+        op::PointBinary::eq(self, rhs)
     }
 }
 
@@ -494,6 +494,36 @@ mod test {
         );
         operations_test!(&p);
         operations_test!(p.mark::<Public>())
+    }
+
+    macro_rules! mixed_operations_test {
+        ($P:expr, $Q:expr) => {{
+            let p = $P;
+            let q = $Q;
+            let i = Point::zero();
+            expression_eq!([p] == [q]);
+            expression_eq!([p + p + p] == [q + q + q]);
+            expression_eq!([p + q] == [q + p]);
+            expression_eq!([p - q] == [i]);
+            expression_eq!([p - q] == [q - p]);
+            expression_eq!([p - q - q] == [q - p - p]);
+        }};
+    }
+
+    #[test]
+    fn mixed_operations() {
+        mixed_operations_test!(G.clone(), G.clone().mark::<Jacobian>());
+        mixed_operations_test!(
+            G.clone().mark::<Secret>(),
+            G.clone().mark::<(Secret, Jacobian)>()
+        );
+        let p = g!(42 * G);
+        mixed_operations_test!(p, p);
+        mixed_operations_test!(p, p.mark::<Normal>());
+        mixed_operations_test!(p.mark::<Normal>(), p);
+        mixed_operations_test!(p.mark::<Normal>(), p);
+        mixed_operations_test!(p.mark::<Secret>(), p);
+        mixed_operations_test!(p, p.mark::<Secret>());
     }
 
     #[test]

--- a/secp256kfun/src/scalar.rs
+++ b/secp256kfun/src/scalar.rs
@@ -1,6 +1,5 @@
 //! Scalar arithmetic (integers mod the secp256k1 group order)
 use crate::{backend, hash::HashInto, marker::*, op};
-use backend::BackendScalar;
 use core::marker::PhantomData;
 use digest::{generic_array::typenum::U32, Digest};
 use rand_core::{CryptoRng, RngCore};
@@ -59,7 +58,7 @@ impl<Z> core::hash::Hash for Scalar<Public, Z> {
 impl<Z, S> Scalar<S, Z> {
     /// Serializes the scalar to its 32-byte big-endian representation
     pub fn to_bytes(&self) -> [u8; 32] {
-        backend::Scalar::to_bytes(&self.0)
+        backend::BackendScalar::to_bytes(&self.0)
     }
 
     /// Negates the scalar in-place if `cond` is true.
@@ -147,7 +146,7 @@ impl Scalar<Secret, NonZero> {
     ///
     /// [`NonZeroU32`]: core::num::NonZeroU32
     pub fn from_non_zero_u32(int: core::num::NonZeroU32) -> Self {
-        Self::from_inner(backend::Scalar::from_u32(int.get()))
+        Self::from_inner(backend::BackendScalar::from_u32(int.get()))
     }
 
     /// Returns the integer `1` as a `Scalar<Secret, NonZero>`.
@@ -157,7 +156,7 @@ impl Scalar<Secret, NonZero> {
 
     /// Returns the integer -1 (modulo the curve order) as a `Scalar<Secret, NonZero>`.
     pub fn minus_one() -> Self {
-        Self::from_inner(backend::Scalar::minus_one())
+        Self::from_inner(backend::BackendScalar::minus_one())
     }
 }
 
@@ -176,7 +175,7 @@ impl Scalar<Secret, Zero> {
     /// assert_eq!(scalar_overflowed, Scalar::one())
     /// ```
     pub fn from_bytes_mod_order(bytes: [u8; 32]) -> Self {
-        Self::from_inner(backend::Scalar::from_bytes_mod_order(bytes))
+        Self::from_inner(backend::BackendScalar::from_bytes_mod_order(bytes))
     }
 
     /// Exactly like [`from_bytes_mod_order`] except
@@ -214,7 +213,7 @@ impl Scalar<Secret, Zero> {
     /// assert!(Scalar::from_bytes([255u8; 32]).is_none());
     /// ```
     pub fn from_bytes(bytes: [u8; 32]) -> Option<Self> {
-        backend::Scalar::from_bytes(bytes).map(Self::from_inner)
+        backend::BackendScalar::from_bytes(bytes).map(Self::from_inner)
     }
 
     /// Creates a scalar from 32 big-endian encoded bytes in a slice. If the
@@ -238,7 +237,7 @@ impl Scalar<Secret, Zero> {
     /// assert_eq!(s!(zero * x), zero);
     /// assert_eq!(s!(x + zero), x);
     pub fn zero() -> Self {
-        Self::from_inner(backend::Scalar::zero())
+        Self::from_inner(backend::BackendScalar::zero())
     }
 }
 
@@ -250,7 +249,7 @@ impl<Z1, Z2, S1, S2> PartialEq<Scalar<S2, Z2>> for Scalar<S1, Z1> {
 
 impl From<u32> for Scalar<Secret, Zero> {
     fn from(int: u32) -> Self {
-        Self::from_inner(backend::Scalar::from_u32(int))
+        Self::from_inner(backend::BackendScalar::from_u32(int))
     }
 }
 

--- a/secp256kfun/src/xonly.rs
+++ b/secp256kfun/src/xonly.rs
@@ -1,5 +1,5 @@
 use crate::{
-    backend::{self, BackendXOnly, TimeSensitive},
+    backend::{self, BackendXOnly},
     hash::HashInto,
     marker::*,
     Point, Scalar,
@@ -124,6 +124,7 @@ impl HashInto for XOnly {
 
 impl PartialEq<XOnly> for XOnly {
     fn eq(&self, rhs: &XOnly) -> bool {
+        use crate::backend::TimeSensitive;
         // XOnly should have secrecy too so we can do it in vartime if public
         crate::backend::ConstantTime::xonly_eq(&self.0, &rhs.0)
     }

--- a/secp256kfun_parity_backend/Cargo.toml
+++ b/secp256kfun_parity_backend/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 
 [dependencies]
 crunchy = "0.2"
-subtle = { version = "2", package = "subtle-ng", default-features = false }
+subtle = { version = "2", default-features = false }
 
 
 [features]

--- a/sigma_fun/Cargo.toml
+++ b/sigma_fun/Cargo.toml
@@ -18,7 +18,7 @@ features = ["all"]
 generic-array = "0.14"
 digest = "0.9"
 secp256kfun = { path = "../secp256kfun", version = "0.7.0-pre.0", default-features = false, optional = true }
-curve25519-dalek = { version = "4.0.0-pre.1", default-features = false, optional = true, features = ["u64_backend"] }
+curve25519-dalek = { package = "curve25519-dalek-ng", version = "4", default-features = false, optional = true, features = ["u64_backend"] }
 serde_crate = { package = "serde", version = "1.0", optional = true, default-features = false, features = ["derive"] }
 rand_core = "0.6"
 

--- a/sigma_fun/Cargo.toml
+++ b/sigma_fun/Cargo.toml
@@ -17,13 +17,13 @@ features = ["all"]
 [dependencies]
 generic-array = "0.14"
 digest = "0.9"
-secp256kfun = { path = "../secp256kfun", version = "0.6.3-alpha.0", default-features = false, optional = true }
-curve25519-dalek = { package = "curve25519-dalek-ng", version = "4", default-features = false, optional = true, features = ["u64_backend"] }
+secp256kfun = { path = "../secp256kfun", version = "0.7.0-pre.0", default-features = false, optional = true }
+curve25519-dalek = { version = "4.0.0-pre.1", default-features = false, optional = true, features = ["u64_backend"] }
 serde_crate = { package = "serde", version = "1.0", optional = true, default-features = false, features = ["derive"] }
 rand_core = "0.6"
 
 [dev-dependencies]
-secp256kfun = { path = "../secp256kfun", version = "0.6.3-alpha.0", default-features = false, features = ["proptest"] }
+secp256kfun = { path = "../secp256kfun", version = "0.7.0-pre.0", default-features = false, features = ["proptest"] }
 rand = "0.8"
 sha2 = "0.9"
 bincode = "1"


### PR DESCRIPTION
This PR replaces the parity backend with one based on [k256](https://docs.rs/k256/0.9.6/k256/). You can find it [here](https://github.com/LLFourn/elliptic-curves/tree/secp256kfun).

In general this provides a major performance improvement and a better implementation of the underlying arithmetic. The main advantage is that on 64 bit platforms it will now use `u64` for the scalar and field arithmetic and so requires fewer operations. The only thing that is slower is doing single multiplications by `G` which is only about %20 slower. This is because `k256` doesn't yet have pre-computed multiplication tables for `G`.

It is also much faster in all respects when compiled for stable. Compiling with `--features nightly` will still give a small performace boost in some areas but no where near as much as before where it was pretty much mandatory to use `nightly` to have decent performance.

## --features nightly perf change
```
ecmult/scalar_mul_point:basepoint,secret
                        time:   [57.488 us 57.627 us 57.777 us]
                        change: [+35.394% +36.044% +36.663%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild
ecmult/scalar_mul_point:basepoint,public
                        time:   [56.789 us 56.932 us 57.141 us]
                        change: [+28.193% +31.325% +34.086%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 7 outliers among 100 measurements (7.00%)
  3 (3.00%) high mild
  4 (4.00%) high severe
ecmult/scalar_mul_point:normal,secret
                        time:   [57.445 us 57.877 us 58.353 us]
                        change: [-56.774% -55.838% -55.054%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  3 (3.00%) high mild
  8 (8.00%) high severe
ecmult/scalar_mul_point:normal,public
                        time:   [57.560 us 57.796 us 58.061 us]
                        change: [-40.680% -40.257% -39.877%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe
ecmult/scalar_mul_point:jacobian,secret
                        time:   [56.949 us 57.093 us 57.252 us]
                        change: [-58.797% -58.457% -58.166%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe
ecmult/scalar_mul_point:jacobian,public
                        time:   [59.594 us 60.955 us 62.594 us]
                        change: [-40.363% -39.336% -38.075%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  4 (4.00%) high mild
  5 (5.00%) high severe

double_mul/double_mul:normal,public
                        time:   [96.791 us 97.047 us 97.334 us]
                        change: [-50.696% -50.390% -50.104%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) high mild
  3 (3.00%) high severe
double_mul/double_mul:normal,secret
                        time:   [95.982 us 96.342 us 96.708 us]
                        change: [-62.244% -61.975% -61.731%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe
double_mul/double_mul:basepoint,public
                        time:   [100.22 us 100.45 us 100.69 us]
                        change: [-9.7466% -9.1646% -8.6505%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) low mild
  4 (4.00%) high mild
  1 (1.00%) high severe
double_mul/double_mul:basepoint,secret
                        time:   [100.48 us 100.68 us 100.91 us]
                        change: [-42.482% -41.706% -41.057%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe
```

## stable perf change
tl;dr everything is more than twice as fast as before
```
ecmult/scalar_mul_point:basepoint,secret
                        time:   [57.133 us 57.321 us 57.565 us]
                        change: [-56.568% -56.391% -56.222%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
ecmult/scalar_mul_point:basepoint,public
                        time:   [58.203 us 58.690 us 59.218 us]
                        change: [-57.578% -57.316% -57.047%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) high mild
  3 (3.00%) high severe
ecmult/scalar_mul_point:normal,secret
                        time:   [57.388 us 58.049 us 58.900 us]
                        change: [-59.145% -58.474% -57.812%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  4 (4.00%) high mild
  6 (6.00%) high severe
ecmult/scalar_mul_point:normal,public
                        time:   [56.891 us 57.060 us 57.222 us]
                        change: [-58.420% -58.021% -57.692%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild
ecmult/scalar_mul_point:jacobian,secret
                        time:   [57.055 us 57.325 us 57.659 us]
                        change: [-58.702% -57.976% -57.266%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  1 (1.00%) high mild
  7 (7.00%) high severe
ecmult/scalar_mul_point:jacobian,public
                        time:   [57.443 us 57.616 us 57.795 us]
                        change: [-57.807% -57.607% -57.421%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild

double_mul/double_mul:normal,public
                        time:   [96.867 us 97.233 us 97.664 us]
                        change: [-64.966% -64.576% -64.184%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe
double_mul/double_mul:normal,secret
                        time:   [96.986 us 97.777 us 98.682 us]
                        change: [-64.695% -64.324% -64.026%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  2 (2.00%) high mild
  5 (5.00%) high severe
double_mul/double_mul:basepoint,public
                        time:   [98.092 us 98.674 us 99.399 us]
                        change: [-62.889% -62.533% -62.190%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe
double_mul/double_mul:basepoint,secret
                        time:   [97.568 us 98.128 us 98.809 us]
                        change: [-63.956% -63.677% -63.360%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 14 outliers among 100 measurements (14.00%)
  7 (7.00%) high mild
  7 (7.00%) high severe
```

## Misc
During this PR I had to reluctantly move back from `subtle-ng` to `subtle` and make `sigma_fun` depend on pre-release version of curve25519 dalek. This is because `k256` indirectly depends on `subtle` and this is hard to change without a lot of effort.



