### PR TITLE
Schnorr libsecp compat

### DIFF
--- a/schnorr_fun/Cargo.toml
+++ b/schnorr_fun/Cargo.toml
@@ -24,7 +24,8 @@ rand = { version = "0.8" }
 lazy_static = "1.4"
 bincode = "1.0"
 sha2 = "0.9"
-secp256kfun = { path = "../secp256kfun", version = "0.7.0-pre.0", default-features = false, features = ["alloc"] }
+secp256kfun = { path = "../secp256kfun", version = "0.7.0-pre.0", default-features = false, features = ["alloc", "libsecp_compat", "proptest"] }
+secp256k1 = { version = "0.20", features = ["std", "global-context-less-secure"]}
 
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
@@ -40,7 +41,7 @@ harness = false
 
 [features]
 default = ["std"]
-all = ["std","serde", "libsecp_compat"]
+all = ["std","serde", "libsecp_compat", "proptest"]
 alloc = ["secp256kfun/alloc"]
 std = ["alloc", "secp256kfun/std"]
 serde = ["serde_crate", "secp256kfun/serde"]

--- a/schnorr_fun/README.md
+++ b/schnorr_fun/README.md
@@ -51,6 +51,7 @@ assert!(schnorr.verify(&verification_key, message, &signature));
 
 - BIP-340 compliant signing and verification
 - Adaptor signatures
+- compatibility with `rust-secp256k1`'s `schnorrsig` module with `libsecp_compat` feature.
 
 [1]: https://d-nb.info/1156214580/34
 [BIP-340]: https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki

--- a/schnorr_fun/src/lib.rs
+++ b/schnorr_fun/src/lib.rs
@@ -26,6 +26,9 @@ pub use schnorr::*;
 mod message;
 pub use message::*;
 
+#[cfg(feature = "libsecp_compat")]
+mod libsecp_compat;
+
 #[macro_export]
 #[doc(hidden)]
 macro_rules! test_instance {

--- a/schnorr_fun/src/libsecp_compat.rs
+++ b/schnorr_fun/src/libsecp_compat.rs
@@ -1,0 +1,13 @@
+use secp256kfun::secp256k1::schnorrsig;
+
+impl From<crate::Signature> for schnorrsig::Signature {
+    fn from(sig: crate::Signature) -> Self {
+        schnorrsig::Signature::from_slice(sig.to_bytes().as_ref()).unwrap()
+    }
+}
+
+impl From<schnorrsig::Signature> for crate::Signature {
+    fn from(sig: schnorrsig::Signature) -> Self {
+        crate::Signature::from_bytes(sig.as_ref().clone()).unwrap()
+    }
+}

--- a/schnorr_fun/tests/against_c_lib.rs
+++ b/schnorr_fun/tests/against_c_lib.rs
@@ -1,0 +1,42 @@
+#![cfg(feature = "libsecp_compat")]
+use proptest::prelude::*;
+use schnorr_fun::{
+    fun::{marker::*, proptest, Scalar},
+    nonce::Deterministic,
+    Message, Schnorr,
+};
+use secp256k1::global::SECP256K1;
+use secp256kfun::secp256k1;
+use sha2::Sha256;
+
+proptest! {
+
+    #[test]
+    fn deterministic_sigs_are_the_same(
+        key in any::<Scalar>(),
+        msg in any::<[u8;32]>(),
+    ) {
+        let secp = &SECP256K1;
+        let keypair = secp256k1::schnorrsig::KeyPair::from_secret_key(&secp, key.clone().into());
+        let secp_msg = secp256k1::Message::from_slice(&msg).unwrap();
+        let sig = secp.schnorrsig_sign_no_aux_rand(&secp_msg, &keypair);
+        let schnorr = Schnorr::<Sha256,_>::new(Deterministic::<Sha256>::default());
+        let fun_keypair = schnorr.new_keypair(key);
+        let fun_msg = Message::<Public>::raw(&msg);
+        let fun_sig: secp256k1::schnorrsig::Signature = schnorr.sign(&fun_keypair, fun_msg).into();
+        prop_assert_eq!(fun_sig, sig, "they produce the same signatures");
+    }
+
+
+    #[test]
+    fn verify_secp_sigs(key in any::<Scalar>(), msg in any::<[u8;32]>(), aux_rand in any::<[u8;32]>()) {
+        let secp = &SECP256K1;
+        let keypair = secp256k1::schnorrsig::KeyPair::from_secret_key(&secp, key.clone().into());
+        let fun_pk = secp256k1::schnorrsig::PublicKey::from_keypair(&secp,&keypair).into();
+        let secp_msg = secp256k1::Message::from_slice(&msg).unwrap();
+        let sig = secp.schnorrsig_sign_with_aux_rand(&secp_msg, &keypair, &aux_rand);
+        let schnorr = Schnorr::<Sha256,_>::verify_only();
+        let fun_msg = Message::<Public>::raw(&msg);
+        prop_assert!(schnorr.verify(&fun_pk, fun_msg, &sig.into()));
+    }
+}

--- a/secp256kfun/src/lib.rs
+++ b/secp256kfun/src/lib.rs
@@ -45,7 +45,9 @@ pub extern crate serde_crate as serde;
 #[cfg(feature = "libsecp_compat")]
 mod libsecp_compat;
 #[cfg(any(feature = "proptest", test))]
-pub mod proptest;
+mod proptest_impls;
+#[cfg(feature = "proptest")]
+pub extern crate proptest;
 /// The main basepoint for secp256k1 as specified in [_SEC 2: Recommended Elliptic Curve Domain Parameters_] and used in Bitcoin.
 ///
 /// At the moment, [`G`] is the only [`BasePoint`] in the library.

--- a/secp256kfun/src/libsecp_compat.rs
+++ b/secp256kfun/src/libsecp_compat.rs
@@ -1,7 +1,7 @@
 use crate::{
     marker::*,
-    secp256k1::{PublicKey, SecretKey},
-    Point, Scalar,
+    secp256k1::{schnorrsig, PublicKey, SecretKey},
+    Point, Scalar, XOnly,
 };
 
 impl From<Scalar> for SecretKey {
@@ -28,6 +28,30 @@ impl From<PublicKey> for Point {
 impl<T: Normalized> From<Point<T>> for PublicKey {
     fn from(pk: Point<T>) -> Self {
         PublicKey::from_slice(pk.to_bytes().as_ref()).unwrap()
+    }
+}
+
+impl From<schnorrsig::PublicKey> for XOnly {
+    fn from(pk: schnorrsig::PublicKey) -> Self {
+        XOnly::from_bytes(pk.serialize()).unwrap()
+    }
+}
+
+impl From<XOnly> for schnorrsig::PublicKey {
+    fn from(xonly: XOnly) -> Self {
+        schnorrsig::PublicKey::from_slice(xonly.as_bytes()).unwrap()
+    }
+}
+
+impl From<Point<EvenY>> for schnorrsig::PublicKey {
+    fn from(point: Point<EvenY>) -> Self {
+        point.to_xonly().into()
+    }
+}
+
+impl From<schnorrsig::PublicKey> for Point<EvenY> {
+    fn from(pk: schnorrsig::PublicKey) -> Self {
+        XOnly::from(pk).to_point()
     }
 }
 

--- a/secp256kfun/src/proptest_impls.rs
+++ b/secp256kfun/src/proptest_impls.rs
@@ -14,7 +14,7 @@ impl<S: Secrecy> Arbitrary for Scalar<S, NonZero> {
             // insert some pathological cases
             1 => Just(Scalar::one().mark::<S>()),
             1 => Just(Scalar::minus_one().mark::<S>()),
-            18 => any::<[u8;32]>().prop_map(|bytes| Scalar::from_bytes_mod_order(bytes).mark::<(S, NonZero)>().unwrap()),
+            18 => any::<[u8;32]>().prop_filter_map("zero bytes not acceptable", |bytes| Scalar::from_bytes_mod_order(bytes).mark::<(S,NonZero)>()),
         ].boxed()
     }
 }


### PR DESCRIPTION
- Add `From` implementations for the `schnorrsig` module of `rust-secp256k1`.
- Make benchmarks work again.