### PR TITLE
update sha2 dep to 0.10

### DIFF
--- a/ecdsa_fun/Cargo.toml
+++ b/ecdsa_fun/Cargo.toml
@@ -29,7 +29,7 @@ secp256kfun = { path = "../secp256kfun", version = "0.7.1", default-features = f
 rand = "0.8"
 criterion = "0.3"
 lazy_static = "1.4"
-sha2 = "0.9"
+sha2 = "0.10"
 serde_json = "1"
 
 [[bench]]

--- a/ecdsa_fun/src/adaptor/mod.rs
+++ b/ecdsa_fun/src/adaptor/mod.rs
@@ -13,7 +13,12 @@
 //! ```
 //! use ecdsa_fun::{
 //!     adaptor::{Adaptor, EncryptedSignature, HashTranscript},
-//!     fun::{digest::Digest, g, marker::*, nonce, Scalar, G},
+//!     fun::{
+//!         digest::{Digest, Update},
+//!         g,
+//!         marker::*,
+//!         nonce, Scalar, G,
+//!     },
 //! };
 //! use rand::rngs::ThreadRng;
 //! use rand_chacha::ChaCha20Rng;

--- a/ecdsa_fun/src/lib.rs
+++ b/ecdsa_fun/src/lib.rs
@@ -138,7 +138,12 @@ impl<NG: NonceGen> ECDSA<NG> {
     ///
     /// ```
     /// use ecdsa_fun::{
-    ///     fun::{digest::Digest, g, marker::*, Scalar, G},
+    ///     fun::{
+    ///         digest::{Digest, Update},
+    ///         g,
+    ///         marker::*,
+    ///         Scalar, G,
+    ///     },
     ///     nonce, ECDSA,
     /// };
     /// use rand::rngs::ThreadRng;

--- a/schnorr_fun/Cargo.toml
+++ b/schnorr_fun/Cargo.toml
@@ -24,7 +24,7 @@ serde_crate = { package = "serde", version = "1.0", default-features = false, op
 rand = { version = "0.8" }
 lazy_static = "1.4"
 bincode = "1.0"
-sha2 = "0.9"
+sha2 = "0.10"
 secp256kfun = { path = "../secp256kfun", version = "0.7.1", default-features = false, features = ["alloc", "libsecp_compat", "proptest"] }
 secp256k1 = { version = "0.22", features = ["std", "global-context"]}
 serde_json = "1"

--- a/secp256kfun/Cargo.toml
+++ b/secp256kfun/Cargo.toml
@@ -17,7 +17,7 @@ keywords = ["bitcoin", "secp256k1"]
 features = ["all"]
 
 [dependencies]
-digest = "0.9"
+digest = "0.10"
 subtle = { package = "subtle-ng", version = "2" }
 rand_core = { version = "0.6" }
 serde_crate = { package = "serde", version = "1.0",  optional = true, default-features = false, features = ["derive"] }
@@ -31,7 +31,7 @@ proptest = { version = "1", optional = true }
 serde_json = "1"
 rand = { version = "0.8" }
 lazy_static = "1.4"
-sha2 = "0.9"
+sha2 = "0.10"
 proptest = "1"
 secp256k1 = { version = "0.22", features = ["std", "global-context"]}
 

--- a/secp256kfun/src/hash.rs
+++ b/secp256kfun/src/hash.rs
@@ -4,9 +4,8 @@
 //!
 //! [`Digest`]: digest::Digest
 //! [`RustCrypto`]: https://github.com/RustCrypto/hashes
-use digest::crypto_common::BlockSizeUser;
-
 use crate::digest::{
+    crypto_common::BlockSizeUser,
     generic_array::typenum::{PartialDiv, Unsigned},
     Digest,
 };

--- a/secp256kfun/src/hash.rs
+++ b/secp256kfun/src/hash.rs
@@ -4,9 +4,11 @@
 //!
 //! [`Digest`]: digest::Digest
 //! [`RustCrypto`]: https://github.com/RustCrypto/hashes
+use digest::crypto_common::BlockSizeUser;
+
 use crate::digest::{
     generic_array::typenum::{PartialDiv, Unsigned},
-    BlockInput, Digest,
+    Digest,
 };
 /// Extension trait to "tag" a hash as described in [BIP-340].
 ///
@@ -25,10 +27,10 @@ pub trait Tagged: Default + Clone {
     fn tagged(&self, tag: &[u8]) -> Self;
 }
 
-impl<H: BlockInput + Digest + Default + Clone> Tagged for H
+impl<H: BlockSizeUser + Digest + Default + Clone> Tagged for H
 where
-    <H as BlockInput>::BlockSize: PartialDiv<H::OutputSize>,
-    <<H as BlockInput>::BlockSize as PartialDiv<H::OutputSize>>::Output: Unsigned,
+    <H as BlockSizeUser>::BlockSize: PartialDiv<H::OutputSize>,
+    <<H as BlockSizeUser>::BlockSize as PartialDiv<H::OutputSize>>::Output: Unsigned,
 {
     fn tagged(&self, tag: &[u8]) -> Self {
         let hashed_tag = {

--- a/sigma_fun/Cargo.toml
+++ b/sigma_fun/Cargo.toml
@@ -17,7 +17,7 @@ features = ["all"]
 
 [dependencies]
 generic-array = "0.14"
-digest = "0.9"
+digest = "0.10"
 secp256kfun = { path = "../secp256kfun", version = "0.7.1", default-features = false, optional = true }
 curve25519-dalek = { package = "curve25519-dalek-ng", version = "4", default-features = false, optional = true, features = ["u64_backend"] }
 serde_crate = { package = "serde", version = "1.0", optional = true, default-features = false, features = ["derive"] }
@@ -26,7 +26,7 @@ rand_core = "0.6"
 [dev-dependencies]
 secp256kfun = { path = "../secp256kfun", version = "0.7.1", default-features = false, features = ["proptest"] }
 rand = "0.8"
-sha2 = "0.9"
+sha2 = "0.10"
 bincode = "1"
 proptest = "1"
 rand_chacha = "0.3"

--- a/sigma_fun/src/transcript.rs
+++ b/sigma_fun/src/transcript.rs
@@ -7,7 +7,7 @@ use crate::{
     },
     Sigma, Writable,
 };
-use digest::{BlockInput, FixedOutput, Update};
+use digest::{crypto_common::BlockSizeUser, FixedOutput, Update};
 use generic_array::GenericArray;
 
 /// A trait for a Fiat-Shamir proof transcript.
@@ -91,7 +91,7 @@ impl<H, S: Sigma, R: Clone> Transcript<S> for HashTranscript<H, R>
 where
     S::ChallengeLength: IsLessOrEqual<U32>,
     <S::ChallengeLength as IsLessOrEqual<U32>>::Output: NonZero,
-    H: BlockInput<BlockSize = U64> + FixedOutput<OutputSize = U32> + Update + Default + Clone,
+    H: BlockSizeUser<BlockSize = U64> + FixedOutput<OutputSize = U32> + Update + Default + Clone,
 {
     fn add_name<N: Writable + ?Sized>(&mut self, name: &N) {
         let hashed_tag = {
@@ -146,7 +146,7 @@ where
         if let Some(rng) = in_rng {
             let mut randomness = [0u8; 32];
             rng.fill_bytes(&mut randomness);
-            rng_hash.update(randomness);
+            rng_hash.update(&randomness);
         }
         let secret_seed = rng_hash.finalize_fixed();
         R::from_seed(secret_seed.into())


### PR DESCRIPTION
Hey @LLFourn !

I'm working on https://github.com/comit-network/xmr-btc-swap/pull/948 to update the sha2 dependency, which requires it is also updated in this library. 

Is this acceptable? 

~~Apologies for the autoformatting to markdown docs, please let me know if that's a showstopper.~~