### PR TITLE
FROST Implementation

### DIFF
--- a/schnorr_fun/README.md
+++ b/schnorr_fun/README.md
@@ -54,6 +54,7 @@ assert!(schnorr.verify(&verification_key, message, &signature));
 - Adaptor signatures
 - compatibility with `rust-secp256k1`'s `schnorrsig` module with `libsecp_compat` feature.
 - [MuSig2] implementation compatible with [this PR](https://github.com/jonasnick/bips/pull/37) of the spec.
+- [FROST] implementation
 - Feature flags
   - `serde`: for serde implementations for signatures
   - `libsecp_compat`: for `From` implementations between `rust-secp256k1`'s Schnorr signatures.
@@ -64,3 +65,4 @@ assert!(schnorr.verify(&verification_key, message, &signature));
 [secp256kfun]: https://docs.rs/secp256kfun
 [secp256k1-zkp]: https://github.com/ElementsProject/secp256k1-zkp/pull/131
 [MuSig2]: https://eprint.iacr.org/2020/1261.pdf
+[FROST]: https://eprint.iacr.org/2020/852.pdf

--- a/schnorr_fun/src/frost.rs
+++ b/schnorr_fun/src/frost.rs
@@ -76,6 +76,20 @@ impl ScalarPoly {
         ScalarPoly((0..n_coefficients).map(|_| Scalar::random(rng)).collect())
     }
 
+    /// Create a scalar polynomial where the first coefficient is a specified secret and
+    /// the remaining coefficients are random.
+    pub fn random_using_secret(
+        n_coefficients: u32,
+        secret: Scalar,
+        rng: &mut (impl RngCore + CryptoRng),
+    ) -> Self {
+        let mut coeffs = vec![secret];
+        for _ in 1..n_coefficients {
+            coeffs.push(Scalar::random(rng))
+        }
+        ScalarPoly(coeffs)
+    }
+
     /// The number of terms in the polynomial (t).
     pub fn poly_len(&self) -> usize {
         self.0.len()
@@ -787,7 +801,6 @@ mod test {
 
         // TODO USE PROPER SID
         // public => [ b"r2-frost", my_index.to_be_bytes(), frost_key.joint_public_key, &frost_key.verification_shares[..], sid]
-
         let sid = frost_key.joint_public_key.to_bytes();
         // for share in frost_key.verification_shares {
         //     // [sid, share].concat(share.to_bytes());

--- a/schnorr_fun/src/frost.rs
+++ b/schnorr_fun/src/frost.rs
@@ -1,0 +1,243 @@
+#![allow(missing_docs, unused)]
+use core::{char::from_u32_unchecked, iter};
+
+use crate::{KeyPair, Message, Schnorr, Signature, Vec};
+use rand_core::{CryptoRng, RngCore};
+use secp256kfun::{
+    digest::{generic_array::typenum::U32, Digest},
+    g,
+    marker::*,
+    nonce::NonceGen,
+    rand_core, s, Point, Scalar, XOnly, G,
+};
+
+pub struct Dkg<S> {
+    pub schnorr: S,
+}
+
+#[derive(Clone, Debug)]
+pub struct LocalPoly(Vec<Scalar>);
+
+#[derive(Clone, Debug)]
+pub struct DkgMessage1 {
+    public_poly: PublicPoly,
+}
+
+#[derive(Clone, Debug)]
+pub struct DkgState1 {
+    local_poly: LocalPoly,
+}
+
+impl LocalPoly {
+    pub fn eval(&self, x: u32) -> Scalar<Secret, Zero> {
+        let x = Scalar::from(x)
+            .expect_nonzero("must be non-zero")
+            .mark::<Public>();
+        let mut xpow = s!(1).mark::<Public>();
+        self.0
+            .iter()
+            .skip(1)
+            .fold(self.0[0].clone().mark::<Zero>(), move |sum, coeff| {
+                xpow = s!(xpow * x).mark::<Public>();
+                s!(sum + xpow * coeff)
+            })
+    }
+
+    fn to_public_poly(&self) -> PublicPoly {
+        PublicPoly(self.0.iter().map(|a| g!(a * G).normalize()).collect())
+    }
+
+    pub fn random(n_coefficients: usize, rng: &mut (impl RngCore + CryptoRng)) -> Self {
+        LocalPoly((0..n_coefficients).map(|_| Scalar::random(rng)).collect())
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct PublicPoly<Z = NonZero>(Vec<Point<Normal, Public, Z>>);
+
+impl<Z> PublicPoly<Z> {
+    pub fn eval(&self, x: u32) -> Point<Jacobian, Public, Zero> {
+        let x = Scalar::from(x)
+            .expect_nonzero("must be non-zero")
+            .mark::<Public>();
+        let xpows = iter::successors(Some(s!(1).mark::<Public>()), |xpow| {
+            Some(s!(x * xpow).mark::<Public>())
+        })
+        .take(self.0.len())
+        .collect::<Vec<_>>();
+        crate::fun::op::lincomb(&xpows, &self.0)
+    }
+
+    fn combine(mut polys: impl Iterator<Item = Self>) -> PublicPoly<Zero> {
+        let mut combined_poly = polys
+            .next()
+            .expect("cannot combine empty list of polys")
+            .0
+            .into_iter()
+            .map(|p| p.mark::<(Jacobian, Zero)>())
+            .collect::<Vec<_>>();
+        for poly in polys {
+            for (combined_point, point) in combined_poly.iter_mut().zip(poly.0) {
+                *combined_point = g!({ *combined_point } + point);
+            }
+        }
+        PublicPoly(combined_poly.into_iter().map(|p| p.normalize()).collect())
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct DkgMessage2 {
+    secret_share: Scalar<Secret, Zero>,
+    proof_of_possession: Signature,
+}
+
+#[derive(Clone, Debug)]
+pub struct DkgState2 {
+    public_polys: Vec<PublicPoly>,
+    index: usize,
+    local_share: Scalar<Secret, Zero>,
+    joint_key: Point<EvenY>,
+}
+
+#[derive(Debug, Clone)]
+pub enum FirstRoundError {
+    TooFewParticipants,
+    ZeroJointKey,
+}
+
+#[derive(Debug, Clone)]
+pub enum SecondRoundError {
+    InvalidPoP(usize),
+    InvalidShare(usize),
+    TooFewShares,
+}
+
+#[derive(Clone, Debug)]
+pub struct JointKey {
+    joint_public_key: Point<EvenY>,
+    verification_shares: Vec<Point<Normal, Public, Zero>>,
+}
+
+impl<H: Digest<OutputSize = U32> + Clone, NG: NonceGen> Dkg<Schnorr<H, NG>> {
+    pub fn start_first_round(&self, local_poly: LocalPoly) -> (DkgMessage1, DkgState1) {
+        let public_poly = local_poly.to_public_poly();
+        (DkgMessage1 { public_poly }, DkgState1 { local_poly })
+    }
+
+    pub fn start_second_round(
+        &self,
+        mut state: DkgState1,
+        recieved: Vec<DkgMessage1>,
+        index: usize,
+    ) -> Result<(Vec<DkgMessage2>, DkgState2), FirstRoundError> {
+        let n_parties = recieved.len() + 1;
+        // TODO decide what happens if user uses own DkgMessage1 as recieved
+        if n_parties < state.local_poly.0.len() {
+            return Err(FirstRoundError::TooFewParticipants);
+        }
+
+        let mut joint_key = g!({ &state.local_poly.0[0] } * G).mark::<Zero>();
+        for message in recieved.iter() {
+            joint_key = g!(joint_key + { message.public_poly.0[0] });
+        }
+        let (joint_key, needs_negation) = joint_key
+            .normalize()
+            .mark::<NonZero>()
+            .ok_or(FirstRoundError::ZeroJointKey)?
+            .into_point_with_even_y();
+        state.local_poly.0[0].conditional_negate(needs_negation);
+
+        // TODO sign all commitments
+        let keypair = self.schnorr.new_keypair(state.local_poly.0[0].clone());
+        let proof_of_possession = self.schnorr.sign(&keypair, Message::<Public>::raw(b""));
+
+        let mut secret_shares = (0..n_parties)
+            .map(|i| DkgMessage2 {
+                secret_share: state.local_poly.eval(i as u32),
+                proof_of_possession: proof_of_possession.clone(),
+            })
+            .collect::<Vec<_>>();
+
+        let local_share = secret_shares.remove(index).secret_share;
+
+        let public_polys = recieved
+            .into_iter()
+            .map(|message| message.public_poly)
+            .collect();
+
+        Ok((secret_shares, DkgState2 {
+            public_polys,
+            index,
+            local_share,
+            joint_key,
+        }))
+    }
+
+    pub fn finish_second_round(
+        &self,
+        state: DkgState2,
+        messages: Vec<DkgMessage2>,
+    ) -> Result<(JointKey, Scalar<Secret, Zero>), SecondRoundError> {
+        let n_parties = state.public_polys.len() + 1;
+        assert_eq!(state.public_polys.len(), messages.len());
+
+        let mut total_secret_share = state.local_share;
+        for (i, message) in messages.iter().enumerate() {
+            if g!(message.secret_share * G) != state.public_polys[i].eval(state.index as u32 + 1) {
+                return Err(SecondRoundError::InvalidShare(i));
+            }
+            total_secret_share = s!(total_secret_share + message.secret_share);
+        }
+
+        for (i, message) in messages.iter().enumerate() {
+            let (verification_key, _) = state.public_polys[i].0[0].into_point_with_even_y();
+            if !self.schnorr.verify(
+                &verification_key,
+                Message::<Public>::raw(b""),
+                &message.proof_of_possession,
+            ) {
+                return Err(SecondRoundError::InvalidPoP(i));
+            }
+        }
+
+        let joint_poly = PublicPoly::combine(state.public_polys.into_iter());
+        let other_party_indexes = (1..n_parties).map(|i| if i >= state.index { i + 1 } else { i });
+        let verification_shares = other_party_indexes
+            .map(|i| joint_poly.eval(i as u32).normalize())
+            .collect();
+
+        let joint_key = JointKey {
+            joint_public_key: state.joint_key,
+            verification_shares,
+        };
+
+        Ok((joint_key, total_secret_share))
+    }
+}
+
+struct Sign<S, H> {
+    schnorr: S,
+    nonce_coeff_hash: H,
+}
+
+impl<S, H> Sign<S, H> {
+    fn sign(joint_key: &JointKey, message: Message, secret_share: Scalar) {}
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_dkg() {
+        let n_coefficients = 3;
+        let p1 = LocalPoly::random(n_coefficients, &mut rand::thread_rng());
+        let p2 = LocalPoly::random(n_coefficients, &mut rand::thread_rng());
+        let p3 = LocalPoly::random(n_coefficients, &mut rand::thread_rng());
+
+        // Dkg::start_first_round()
+
+        dbg!(p1);
+        panic!();
+    }
+}

--- a/schnorr_fun/src/frost.rs
+++ b/schnorr_fun/src/frost.rs
@@ -711,121 +711,121 @@ mod test {
     use super::*;
     use secp256kfun::{
         nonce::Deterministic,
-        proptest::{arbitrary::any, proptest},
+        proptest::{
+            arbitrary::any,
+            proptest,
+            strategy::{Just, Strategy},
+        },
     };
     use sha2::Sha256;
 
     proptest! {
         #[test]
-        fn frost_prop_test(n_parties in 3u32..8, threshold in 3u32..8, signers_mask_seed in any::<u32>(), tweak1 in any::<Scalar<Public, Zero>>(), tweak2 in any::<Scalar<Public, Zero>>(), use_tweak2 in any::<bool>()) {
-            // Two tweaks
+        fn frost_prop_test((n_parties, threshold) in (3u32..8).prop_flat_map(|n| (Just(n), 3u32..=n)), signers_mask_seed in any::<u32>(), tweak1 in any::<Scalar<Public, Zero>>(), tweak2 in any::<Scalar<Public, Zero>>(), use_tweak2 in any::<bool>()) {
             let frost = Frost::new(Schnorr::<Sha256, Deterministic<Sha256>>::new(
                 Deterministic::<Sha256>::default(),
             ));
             dbg!(threshold, n_parties);
-            if n_parties < threshold {
-                dbg!("too few parties for this threshold");
-            } else {
-                // create some scalar poly for each party
-                let mut scalar_polys = vec![];
-                for i in 1..=n_parties {
-                    let scalar_poly = (1..=threshold).map(|j| Scalar::from_non_zero_u32(NonZeroU32::new(i*j).expect("starts from 1"))).collect();
-                    scalar_polys.push(ScalarPoly::new(scalar_poly));
+            assert!(threshold <= n_parties);
+
+            // create some scalar poly for each party
+            let mut scalar_polys = vec![];
+            for i in 1..=n_parties {
+                let scalar_poly = (1..=threshold).map(|j| Scalar::from_non_zero_u32(NonZeroU32::new(i*j).expect("starts from 1"))).collect();
+                scalar_polys.push(ScalarPoly::new(scalar_poly));
+            }
+            let point_polys: Vec<PointPoly> = scalar_polys.iter().map(|sp| sp.to_point_poly()).collect();
+
+            let KeyGen = frost.new_keygen(point_polys).unwrap();
+
+            let mut proofs_of_possession= vec![];
+            let mut shares_vec = vec![];
+            for sp in scalar_polys {
+                let (shares, pop) = frost.create_shares(&KeyGen, sp);
+                proofs_of_possession.push(pop);
+                shares_vec.push(shares);
+            }
+
+            // collect the recieved shares for each party
+            let mut recieved_shares: Vec<Vec<_>> = vec![];
+            for party_index in 0..n_parties {
+                recieved_shares.push(vec![]);
+                for share_index in 0..n_parties {
+                    recieved_shares[party_index as usize].push(shares_vec[share_index as usize][party_index as usize].clone());
                 }
-                let point_polys: Vec<PointPoly> = scalar_polys.iter().map(|sp| sp.to_point_poly()).collect();
+            }
 
-                let KeyGen = frost.new_keygen(point_polys).unwrap();
-
-                let mut proofs_of_possession= vec![];
-                let mut shares_vec = vec![];
-                for sp in scalar_polys {
-                    let (shares, pop) = frost.create_shares(&KeyGen, sp);
-                    proofs_of_possession.push(pop);
-                    shares_vec.push(shares);
-                }
-
-                // collect the recieved shares for each party
-                let mut recieved_shares: Vec<Vec<_>> = vec![];
-                for party_index in 0..n_parties {
-                    recieved_shares.push(vec![]);
-                    for share_index in 0..n_parties {
-                        recieved_shares[party_index as usize].push(shares_vec[share_index as usize][party_index as usize].clone());
-                    }
-                }
-
-                // finish keygen for each party
-                let (secret_shares, frost_keys): (Vec<Scalar>, Vec<FrostKey>) = (0..n_parties).map(|i| {
-                    let (secret_share, mut frost_key) = frost.finish_keygen(
-                        KeyGen.clone(),
-                        i,
-                        recieved_shares[i as usize].clone(),
-                        proofs_of_possession.clone(),
-                    )
-                    .unwrap();
-                    frost_key = frost_key.tweak(tweak1.clone()).expect("applying tweak1");
-                    frost_key = if use_tweak2 {
-                        frost_key.tweak(tweak2.clone()).expect("applying tweak2")
-                    } else {
-                        frost_key
-                    };
-                    (secret_share, frost_key)
-                }).unzip();
-
-                // create a mask of signers
-                // use bytes from random u32 to determine whether a party is a signer or not
-                let mut signers_mask = vec![true];
-                while signers_mask.len() < n_parties as usize {
-                    for v in signers_mask_seed.to_be_bytes() {
-                        if v > 128 {
-                            signers_mask.push(true);
-                        } else {
-                            signers_mask.push(false);
-                        }
-                        if signers_mask.len() >= n_parties as usize {
-                            break
-                        }
-                    }
-                }
-                let mut signer_indexes = vec![];
-                for (index, included) in signers_mask.iter().enumerate() {
-                    if *included {
-                        signer_indexes.push(index);
-                    }
-                }
-                dbg!(&signer_indexes);
-
-                if signer_indexes.len() < threshold as usize {
-                    dbg!("less signers than threshold.. skipping");
+            // finish keygen for each party
+            let (secret_shares, frost_keys): (Vec<Scalar>, Vec<FrostKey>) = (0..n_parties).map(|i| {
+                let (secret_share, mut frost_key) = frost.finish_keygen(
+                    KeyGen.clone(),
+                    i,
+                    recieved_shares[i as usize].clone(),
+                    proofs_of_possession.clone(),
+                )
+                .unwrap();
+                frost_key = frost_key.tweak(tweak1.clone()).expect("applying tweak1");
+                frost_key = if use_tweak2 {
+                    frost_key.tweak(tweak2.clone()).expect("applying tweak2")
                 } else {
-                    let sid = frost_keys[0].joint_public_key.to_bytes();
-                    let nonces: Vec<NonceKeyPair> = signer_indexes.iter().map(|i| frost.gen_nonce(&secret_shares[*i as usize], &sid)).collect();
-                    // dbg!(&nonces);
+                    frost_key
+                };
+                (secret_share, frost_key)
+            }).unzip();
 
-                    let mut recieved_nonces: Vec<_> = vec![];
-                    for (i, nonce) in signer_indexes.iter().zip(nonces.clone()) {
-                        recieved_nonces.push((*i as u32, nonce.public()));
+            // create a mask of signers
+            // use bytes from random u32 to determine whether a party is a signer or not
+            let mut signers_mask = vec![true];
+            while signers_mask.len() < n_parties as usize {
+                for v in signers_mask_seed.to_be_bytes() {
+                    if v > 128 {
+                        signers_mask.push(true);
+                    } else {
+                        signers_mask.push(false);
                     }
-
-                    // Create Frost signing session
-                    let signing_session = frost.start_sign_session(&frost_keys[signer_indexes[0]], recieved_nonces.clone(), Message::plain("test", b"test"));
-
-                    let mut signatures = vec![];
-                    for i in 0..signer_indexes.len() {
-                        let signer_index = signer_indexes[i] as usize;
-                        let session = frost.start_sign_session(&frost_keys[signer_index], recieved_nonces.clone(), Message::plain("test", b"test"));
-                        let sig = frost.sign(&frost_keys[signer_index], &session, signer_index as u32, &secret_shares[signer_index], nonces[i].clone());
-                        assert!(frost.verify_signature_share(&frost_keys[signer_index], &session, signer_index as u32, sig));
-                        signatures.push(sig);
+                    if signers_mask.len() >= n_parties as usize {
+                        break
                     }
-                    let combined_sig = frost.combine_signature_shares(&frost_keys[signer_indexes[0] as usize], &signing_session, signatures);
-
-                    assert!(frost.schnorr.verify(
-                        &frost_keys[signer_indexes[0] as usize].joint_public_key,
-                        Message::<Public>::plain("test", b"test"),
-                        &combined_sig
-                    ));
-
                 }
+            }
+            let mut signer_indexes = vec![];
+            for (index, included) in signers_mask.iter().enumerate() {
+                if *included {
+                    signer_indexes.push(index);
+                }
+            }
+            dbg!(&signer_indexes);
+
+            if signer_indexes.len() < threshold as usize {
+                dbg!("pseudorandomly chose less signers than threshold.. skipping");
+            } else {
+                let sid = frost_keys[0].joint_public_key.to_bytes();
+                let nonces: Vec<NonceKeyPair> = signer_indexes.iter().map(|i| frost.gen_nonce(&secret_shares[*i as usize], &sid)).collect();
+                // dbg!(&nonces);
+
+                let mut recieved_nonces: Vec<_> = vec![];
+                for (i, nonce) in signer_indexes.iter().zip(nonces.clone()) {
+                    recieved_nonces.push((*i as u32, nonce.public()));
+                }
+
+                // Create Frost signing session
+                let signing_session = frost.start_sign_session(&frost_keys[signer_indexes[0]], recieved_nonces.clone(), Message::plain("test", b"test"));
+
+                let mut signatures = vec![];
+                for i in 0..signer_indexes.len() {
+                    let signer_index = signer_indexes[i] as usize;
+                    let session = frost.start_sign_session(&frost_keys[signer_index], recieved_nonces.clone(), Message::plain("test", b"test"));
+                    let sig = frost.sign(&frost_keys[signer_index], &session, signer_index as u32, &secret_shares[signer_index], nonces[i].clone());
+                    assert!(frost.verify_signature_share(&frost_keys[signer_index], &session, signer_index as u32, sig));
+                    signatures.push(sig);
+                }
+                let combined_sig = frost.combine_signature_shares(&frost_keys[signer_indexes[0] as usize], &signing_session, signatures);
+
+                assert!(frost.schnorr.verify(
+                    &frost_keys[signer_indexes[0] as usize].joint_public_key,
+                    Message::<Public>::plain("test", b"test"),
+                    &combined_sig
+                ));
             }
         }
     }

--- a/schnorr_fun/src/frost.rs
+++ b/schnorr_fun/src/frost.rs
@@ -18,7 +18,7 @@ use secp256kfun::{
 };
 
 #[derive(Clone, Debug, Default)]
-pub struct Frost<SS, H> {
+pub struct Frost<SS, H = ()> {
     schnorr: SS,
     nonce_coeff_hash: H,
 }

--- a/schnorr_fun/src/lib.rs
+++ b/schnorr_fun/src/lib.rs
@@ -28,6 +28,9 @@ pub mod binonce;
 #[cfg(feature = "alloc")]
 pub mod musig;
 
+#[cfg(feature = "alloc")]
+pub mod frost;
+
 mod signature;
 pub use signature::Signature;
 pub mod adaptor;

--- a/schnorr_fun/src/schnorr.rs
+++ b/schnorr_fun/src/schnorr.rs
@@ -27,7 +27,7 @@ pub struct Schnorr<CH, NG = ()> {
     /// [`NonceGen`]: crate::nonce::NonceGen
     nonce_gen: NG,
     /// The challenge hash
-    challenge_hash: CH,
+    pub challenge_hash: CH,
 }
 
 impl<H: Digest<OutputSize = U32> + Tagged> Schnorr<H, ()> {

--- a/schnorr_fun/src/schnorr.rs
+++ b/schnorr_fun/src/schnorr.rs
@@ -27,7 +27,7 @@ pub struct Schnorr<CH, NG = ()> {
     /// [`NonceGen`]: crate::nonce::NonceGen
     nonce_gen: NG,
     /// The challenge hash
-    pub challenge_hash: CH,
+    challenge_hash: CH,
 }
 
 impl<H: Digest<OutputSize = U32> + Tagged> Schnorr<H, ()> {


### PR DESCRIPTION
FROST (Flexible Round-Optimized Schnorr Threshold) implementation
* Only handles x-only tweaking (no ordinary tweaks)
* `t-of-n` keygen and signing proptest with random parties, threshold, and signers. Proptest carries out keygen and then uses a random mask to create a set of signers who create a combined signature.
* Docs mostly in synopsis, do we want to add usage docs to particular functions also?
* End-to-end test

This implementation has not yet been made compatible with other FROST implementations or forthcoming specifications.
https://github.com/ElementsProject/secp256k1-zkp/pull/138
https://github.com/isislovecruft/frost-dalek
https://github.com/cfrg/draft-irtf-cfrg-frost
