### PR TITLE
Only tweak with the new tweak contribution

### DIFF
--- a/ecdsa_fun/src/libsecp_compat.rs
+++ b/ecdsa_fun/src/libsecp_compat.rs
@@ -1,13 +1,13 @@
-use crate::{fun::secp256k1, Signature};
+use crate::{fun::secp256k1::ecdsa, Signature};
 
-impl From<Signature> for secp256k1::Signature {
+impl From<Signature> for ecdsa::Signature {
     fn from(sig: Signature) -> Self {
-        secp256k1::Signature::from_compact(sig.to_bytes().as_ref()).unwrap()
+        ecdsa::Signature::from_compact(sig.to_bytes().as_ref()).unwrap()
     }
 }
 
-impl From<secp256k1::Signature> for Signature {
-    fn from(sig: secp256k1::Signature) -> Self {
+impl From<ecdsa::Signature> for Signature {
+    fn from(sig: ecdsa::Signature) -> Self {
         Signature::from_bytes(sig.serialize_compact()).unwrap()
     }
 }

--- a/ecdsa_fun/tests/against_c_lib.rs
+++ b/ecdsa_fun/tests/against_c_lib.rs
@@ -3,7 +3,7 @@ use ecdsa_fun::{
     self,
     fun::{
         hex,
-        secp256k1::{self, Message, PublicKey, SecretKey},
+        secp256k1::{self, ecdsa, Message, PublicKey, SecretKey},
         Point, Scalar, TEST_SOUNDNESS,
     },
 };
@@ -27,8 +27,10 @@ fn ecdsa_sign() {
         let message = rand_32_bytes();
         let signature = ecdsa.sign(&secret_key, &message);
         let c_message = Message::from_slice(&message[..]).unwrap();
-        let c_siganture = secp256k1::Signature::from_compact(&signature.to_bytes()).unwrap();
-        assert!(secp.verify(&c_message, &c_siganture, &c_public_key).is_ok());
+        let c_siganture = ecdsa::Signature::from_compact(&signature.to_bytes()).unwrap();
+        assert!(secp
+            .verify_ecdsa(&c_message, &c_siganture, &c_public_key)
+            .is_ok());
     }
 }
 
@@ -45,7 +47,7 @@ fn ecdsa_verify() {
         let public_key = Point::from(c_public_key);
         let message = rand_32_bytes();
         let c_message = Message::from_slice(&message[..]).unwrap();
-        let c_signature = secp.sign(&c_message, &c_secret_key);
+        let c_signature = secp.sign_ecdsa(&c_message, &c_secret_key);
         let signature = ecdsa_fun::Signature::from(c_signature);
         assert!(ecdsa.verify(&public_key, &message, &signature));
     }
@@ -63,7 +65,7 @@ fn ecdsa_verify_high_message() {
         hex::decode_array("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF")
             .unwrap();
     let c_message = Message::from_slice(&message[..]).unwrap();
-    let c_signature = secp.sign(&c_message, &c_secret_key);
+    let c_signature = secp.sign_ecdsa(&c_message, &c_secret_key);
     let signature = ecdsa_fun::Signature::from_bytes(c_signature.serialize_compact()).unwrap();
 
     assert!(ecdsa.verify(&verification_key, &message, &signature));
@@ -83,6 +85,8 @@ fn ecdsa_sign_high_message() {
             .unwrap();
     let signature = ecdsa.sign(&secret_key, &message);
     let c_message = Message::from_slice(&message[..]).unwrap();
-    let c_siganture = secp256k1::Signature::from_compact(&signature.to_bytes()).unwrap();
-    assert!(secp.verify(&c_message, &c_siganture, &c_public_key).is_ok());
+    let c_siganture = ecdsa::Signature::from_compact(&signature.to_bytes()).unwrap();
+    assert!(secp
+        .verify_ecdsa(&c_message, &c_siganture, &c_public_key)
+        .is_ok());
 }

--- a/schnorr_fun/Cargo.toml
+++ b/schnorr_fun/Cargo.toml
@@ -26,7 +26,7 @@ lazy_static = "1.4"
 bincode = "1.0"
 sha2 = "0.9"
 secp256kfun = { path = "../secp256kfun", version = "0.7.1-pre.0", default-features = false, features = ["alloc", "libsecp_compat", "proptest"] }
-secp256k1 = { version = "0.21", features = ["std", "global-context-less-secure"]}
+secp256k1 = { version = "0.21.3", features = ["std", "global-context"]}
 
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]

--- a/schnorr_fun/src/musig.rs
+++ b/schnorr_fun/src/musig.rs
@@ -209,11 +209,13 @@ impl KeyList {
     /// unusual case that the tweak is exactly equal to the negation of the aggregated secret key
     /// it returns `None`.
     pub fn tweak(&self, tweak: Scalar<impl Secrecy, impl ZeroChoice>) -> Option<Self> {
-        let mut tweak = s!(self.tweak + tweak).mark::<Public>();
-        let (agg_key, needs_negation) = g!(self.agg_key + tweak * G)
+        let new_tweak = s!(0 + tweak).mark::<Public>();
+        let (agg_key, needs_negation) = g!(self.agg_key + new_tweak * G)
             .mark::<NonZero>()?
             .into_point_with_even_y();
 
+        // Store accumulated tweak
+        let mut tweak = s!(self.tweak + tweak).mark::<Public>();
         tweak.conditional_negate(needs_negation);
 
         let needs_negation = self.needs_negation ^ needs_negation;

--- a/schnorr_fun/src/musig.rs
+++ b/schnorr_fun/src/musig.rs
@@ -208,9 +208,8 @@ impl KeyList {
     /// Returns a new keylist with the same parties but a different aggregated public key. In the
     /// unusual case that the tweak is exactly equal to the negation of the aggregated secret key
     /// it returns `None`.
-    pub fn tweak(&self, tweak: Scalar<impl Secrecy, impl ZeroChoice>) -> Option<Self> {
-        let new_tweak = s!(0 + tweak).mark::<Public>();
-        let (agg_key, needs_negation) = g!(self.agg_key + new_tweak * G)
+    pub fn tweak(&self, tweak: Scalar<impl Secrecy, impl DecideZero<NonZero>>) -> Option<Self> {
+        let (agg_key, needs_negation) = g!(self.agg_key + tweak * G)
             .mark::<NonZero>()?
             .into_point_with_even_y();
 

--- a/schnorr_fun/tests/against_c_lib.rs
+++ b/schnorr_fun/tests/against_c_lib.rs
@@ -5,7 +5,7 @@ use schnorr_fun::{
     nonce::Deterministic,
     Message, Schnorr,
 };
-use secp256k1::global::SECP256K1;
+use secp256k1::SECP256K1;
 use sha2::Sha256;
 
 proptest! {

--- a/secp256kfun/Cargo.toml
+++ b/secp256kfun/Cargo.toml
@@ -33,7 +33,7 @@ rand = { version = "0.8" }
 lazy_static = "1.4"
 sha2 = "0.9"
 proptest = "1"
-secp256k1 = { version = "0.21", features = ["std", "global-context-less-secure"]}
+secp256k1 = { version = "0.21.3", features = ["std", "global-context"]}
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 secp256k1 = { default-features = false, version = "0.21", features = ["std"] }

--- a/secp256kfun/tests/against_c_lib.rs
+++ b/secp256kfun/tests/against_c_lib.rs
@@ -2,7 +2,7 @@
 #[cfg(not(target_arch = "wasm32"))]
 mod against_c_lib {
     use proptest::prelude::*;
-    use secp256k1::{global::SECP256K1 as SECP, PublicKey, SecretKey};
+    use secp256k1::{PublicKey, SecretKey, SECP256K1 as SECP};
     use secp256kfun::{g, marker::*, op::double_mul, s, Scalar, G};
 
     proptest! {


### PR DESCRIPTION
`self.agg_key` already contains any previous `self.tweak` so we do not need to add `self.tweak + tweak`, just add the new `tweak`.

Tests for multiple tweak coming with FROST PR / MuSig rework PR.

There is probably a better way to do
```
let new_tweak = s!(0 + tweak).mark::<Public>();
```
which avoids 
 > the trait bound `impl ZeroChoice: DecideZero<_>` is not satisfied
the trait `DecideZero<_>` is not implemented for `impl ZeroChoice`
