### PR TITLE
Make ZeroChoice always DecideZero

### DIFF
--- a/schnorr_fun/src/musig.rs
+++ b/schnorr_fun/src/musig.rs
@@ -208,7 +208,7 @@ impl KeyList {
     /// Returns a new keylist with the same parties but a different aggregated public key. In the
     /// unusual case that the tweak is exactly equal to the negation of the aggregated secret key
     /// it returns `None`.
-    pub fn tweak(&self, tweak: Scalar<impl Secrecy, impl DecideZero<NonZero>>) -> Option<Self> {
+    pub fn tweak(&self, tweak: Scalar<impl Secrecy, impl ZeroChoice>) -> Option<Self> {
         let (agg_key, needs_negation) = g!(self.agg_key + tweak * G)
             .mark::<NonZero>()?
             .into_point_with_even_y();

--- a/secp256kfun/src/marker/zero_choice.rs
+++ b/secp256kfun/src/marker/zero_choice.rs
@@ -12,7 +12,10 @@ pub struct NonZero;
 ///
 /// Note it is rarely useful to define a function over any `Z: ZeroChoice`.
 /// This trait mostly just exists for consistency.
-pub trait ZeroChoice: Default + Clone + PartialEq + Copy + 'static {}
+pub trait ZeroChoice:
+    Default + Clone + PartialEq + Copy + DecideZero<NonZero> + DecideZero<Zero> + 'static
+{
+}
 
 impl ZeroChoice for Zero {}
 impl ZeroChoice for NonZero {}


### PR DESCRIPTION
Apparently the rust compiler can handle this kind of thing now so there's no need to make it explicit.