### PR TITLE
Bump secp256k1 version to 0.22

### DIFF
--- a/ecdsa_fun/Cargo.toml
+++ b/ecdsa_fun/Cargo.toml
@@ -24,7 +24,7 @@ rand_chacha = {  version = "0.3", optional = true }  # needed for adaptor signat
 bincode = { version = "1.0", optional = true }
 
 [dev-dependencies]
-secp256k1 = { default-features = false, version = "0.21", features = ["std"] }
+secp256k1 = { default-features = false, version = "0.22", features = ["std"] }
 secp256kfun = { path = "../secp256kfun", version = "0.7.1", default-features = false, features = ["libsecp_compat"] }
 rand = "0.8"
 criterion = "0.3"

--- a/schnorr_fun/Cargo.toml
+++ b/schnorr_fun/Cargo.toml
@@ -26,7 +26,7 @@ lazy_static = "1.4"
 bincode = "1.0"
 sha2 = "0.9"
 secp256kfun = { path = "../secp256kfun", version = "0.7.1", default-features = false, features = ["alloc", "libsecp_compat", "proptest"] }
-secp256k1 = { version = "0.21.3", features = ["std", "global-context"]}
+secp256k1 = { version = "0.22", features = ["std", "global-context"]}
 
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]

--- a/schnorr_fun/src/schnorr.rs
+++ b/schnorr_fun/src/schnorr.rs
@@ -289,8 +289,8 @@ pub mod test {
         );
 
         // make sure deterministic signatures don't change
-        assert_eq!(schnorr.sign(&keypair, Message::<Public>::raw(b"foo")), Signature::<Public>::from_str("fe9e5d0319d5d221988d6fd7fe1c4bedd2fb4465f592f1002f461503332a266977bb4a0b00c00d07072c796212cbea0957ebaaa5139143761c45d997ebe36cbe").unwrap());
-        assert_eq!(schnorr.sign(&keypair, Message::<Public>::plain("one", b"foo")), Signature::<Public>::from_str("2fcf6fd140bbc4048e802c62f028e24f6534e0d15d450963265b67eead774d8b4aa7638bec9d70aa60b97e86bc4a60bf43ad2ff58e981ee1bba4f45ce02ff2c0").unwrap());
+        assert_eq!(schnorr.sign(&keypair, Message::<Public>::raw(b"foo")), Signature::<Public>::from_str("10a64055526a861cc78d491540e482c438b1124643fbd3619c01d2396c2869119b6254586f32bf4e0398f62367b0ce0697bb2a817c5c8eb5a440025ad6490ed1").unwrap());
+        assert_eq!(schnorr.sign(&keypair, Message::<Public>::plain("one", b"foo")), Signature::<Public>::from_str("c89bfd53789ca6620ff945c05a63e81b47bfd0da527d84628098adf5011e31f8be4fda39a1cf1cab57233235b43c95d4edf0e0cce5064c0270bd01a03fd448d0").unwrap());
     }
 
     proptest! {

--- a/schnorr_fun/tests/against_c_lib.proptest-regressions
+++ b/schnorr_fun/tests/against_c_lib.proptest-regressions
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc beead27d454941f36638cd10f4302f480877c6a0d648acf6c9099153fd7ad1ff # shrinks to key = Scalar<Secret,NonZero>(0000000000000000000000000000000000000000000000000000000000000001), msg = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]

--- a/secp256kfun/Cargo.toml
+++ b/secp256kfun/Cargo.toml
@@ -24,7 +24,7 @@ serde_crate = { package = "serde", version = "1.0",  optional = true, default-fe
 # secp256kfun_k256_backend = { path = "../../k256_backend/k256" }
 secp256kfun_k256_backend = {  version = "2.0.0" }
 secp256kfun_parity_backend = { version = "0.1.5", optional = true }
-secp256k1 = { version = "0.21", optional = true, default-features = false }
+secp256k1 = { version = "0.22", optional = true, default-features = false }
 proptest = { version = "1", optional = true }
 
 [dev-dependencies]
@@ -33,10 +33,10 @@ rand = { version = "0.8" }
 lazy_static = "1.4"
 sha2 = "0.9"
 proptest = "1"
-secp256k1 = { version = "0.21.3", features = ["std", "global-context"]}
+secp256k1 = { version = "0.22", features = ["std", "global-context"]}
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-secp256k1 = { default-features = false, version = "0.21", features = ["std"] }
+secp256k1 = { default-features = false, version = "0.22", features = ["std"] }
 bincode = "1.0"
 criterion = "0.3"
 

--- a/secp256kfun/src/hash.rs
+++ b/secp256kfun/src/hash.rs
@@ -122,3 +122,24 @@ impl<D: Digest> HashAdd for D {
         self
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use sha2::Sha256;
+
+    #[test]
+    fn bip340_zero_mask_tagged_hash_is_correct() {
+        let hash = Sha256::default().tagged(b"BIP0340/aux").add(&[0u8; 32]);
+        let mut zero_mask = [0u8; 32];
+        zero_mask.copy_from_slice(hash.finalize().as_ref());
+        assert_eq!(
+            zero_mask,
+            /* Precomputed TaggedHash("BIP0340/aux", 0x0000...00); */
+            [
+                84u8, 241, 105, 207, 201, 226, 229, 114, 116, 128, 68, 31, 144, 186, 37, 196, 136,
+                244, 97, 199, 11, 94, 165, 220, 170, 247, 175, 105, 39, 10, 165, 20
+            ]
+        );
+    }
+}


### PR DESCRIPTION
I tried to bump secp to version `0.22`. Looks like there is breaking changes in `no_aux` signature generation.

I tracked the changes down to this change:
https://github.com/rust-bitcoin/rust-secp256k1/commit/8294ea3f50f6de88f88b848c01eb60cab2a73241#diff-ca866735681590c6fc69b50b0a9100c0ea0c485b164e1dc508a14bf60496941b
in `src/schnorr.rs` (last file in diff).

```diff
impl<C: Signing> Secp256k1<C> {
    fn sign_schnorr_helper(
        &self,
        msg: &Message,
        keypair: &KeyPair,
-       nonce_data: *const ffi::types::c_void,
+       nonce_data: *const ffi::types::c_uchar,
    ) -> Signature {
        unsafe {
            let mut sig = [0u8; constants::SCHNORR_SIGNATURE_SIZE];
            assert_eq!(
                1,
                ffi::secp256k1_schnorrsig_sign(
                    self.ctx,
                    sig.as_mut_c_ptr(),
                    msg.as_c_ptr(),
                    keypair.as_ptr(),
-                   ffi::secp256k1_nonce_function_bip340,
-                   nonce_data
+                   nonce_data,
                )
            );

            Signature(sig)
        }
    }
```

Function `sign_schnorr_helper` is then used in `sign_schnorr_no_aux_rand`:

```
    /// Create a schnorr signature without using any auxiliary random data.
    pub fn sign_schnorr_no_aux_rand(
        &self,
        msg: &Message,
        keypair: &KeyPair,
    ) -> Signature {
        self.sign_schnorr_helper(msg, keypair, ptr::null())
    }
```

---

I created a small test project to confirm that `secp256k1` introduced that change at version `0.22.0`.

```toml
[package]
name = "secp-tests"
version = "0.1.0"
edition = "2021"

[dependencies]
secp256k1-0213 = { package = "secp256k1", version = "=0.21.3", features = ["std", "global-context"] }
secp256k1-0220 = { package = "secp256k1", version = "=0.22.0", features = ["std", "global-context"] }
```
Two signature are created for the same key (secret key `1`) and message (null array) as the failing test.

```rust
fn main() {
    let msg = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];

    let secp = secp256k1_0213::SECP256K1;
    let key = secp256k1_0213::ONE_KEY;
    let keypair = secp256k1_0213::KeyPair::from_secret_key(&secp, key);
    let secp_msg = secp256k1_0213::Message::from_slice(&msg).unwrap();
    let sig_0213 = secp.sign_schnorr_no_aux_rand(&secp_msg, &keypair);
    println!("{:#?}", sig_0213);

    let secp = secp256k1_0220::SECP256K1;
    let key = secp256k1_0220::ONE_KEY;
    let keypair = secp256k1_0220::KeyPair::from_secret_key(&secp, key);
    let secp_msg = secp256k1_0220::Message::from_slice(&msg).unwrap();
    let sig_0220 = secp.sign_schnorr_no_aux_rand(&secp_msg, &keypair);
    println!("{:#?}", sig_0220);

    assert_eq!(sig_0213.as_ref(), sig_0220.as_ref());
}
```
It crashes and confirms what was suspected
```
Signature(ea6d5771020d414e9a05a6393dfb793b6697f1e6686eb4269a99d29abc0efc95064a4b0eccac29c0809d411bfa6a66a31c26fd1d5c48174ea2277c904def2744)
Signature(d2bcee6a047e765467f3ed7c3e8f55edcfa4a5fd37a9bcd064c1b5041599b187c3f9f2be0665d539e38eb75989b4bc3f6dd2d9d18c5c123613615d1731e0523e)
thread 'main' panicked at 'assertion failed: `(left == right)`
  left: `[234, 109, 87, 113, 2, 13, 65, 78, 154, 5, 166, 57, 61, 251, 121, 59, 102, 151, 241, 230, 104, 110, 180, 38, 154, 153, 210, 154, 188, 14, 252, 149, 6, 74, 75, 14, 204, 172, 41, 192, 128, 157, 65, 27, 250, 106, 102, 163, 28, 38, 253, 29, 92, 72, 23, 78, 162, 39, 124, 144, 77, 239, 39, 68]`,
 right: `[210, 188, 238, 106, 4, 126, 118, 84, 103, 243, 237, 124, 62, 143, 85, 237, 207, 164, 165, 253, 55, 169, 188, 208, 100, 193, 181, 4, 21, 153, 177, 135, 195, 249, 242, 190, 6, 101, 213, 57, 227, 142, 183, 89, 137, 180, 188, 63, 109, 210, 217, 209, 140, 92, 18, 54, 19, 97, 93, 23, 49, 224, 82, 62]`', src/main.rs:18:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

I'll now investigate what changes are needed to update `schnorr_fun` and push a patch on this branch.

EDIT: explain ongoing investigation on deterministic schnorr signature breakage