### PR TITLE
alt: Bump secp256k1 version to 0.22

### DIFF
--- a/ecdsa_fun/Cargo.toml
+++ b/ecdsa_fun/Cargo.toml
@@ -24,7 +24,7 @@ rand_chacha = {  version = "0.3", optional = true }  # needed for adaptor signat
 bincode = { version = "1.0", optional = true }
 
 [dev-dependencies]
-secp256k1 = { default-features = false, version = "0.21", features = ["std"] }
+secp256k1 = { default-features = false, version = "0.22", features = ["std"] }
 secp256kfun = { path = "../secp256kfun", version = "0.7.1", default-features = false, features = ["libsecp_compat"] }
 rand = "0.8"
 criterion = "0.3"

--- a/schnorr_fun/Cargo.toml
+++ b/schnorr_fun/Cargo.toml
@@ -26,7 +26,7 @@ lazy_static = "1.4"
 bincode = "1.0"
 sha2 = "0.9"
 secp256kfun = { path = "../secp256kfun", version = "0.7.1", default-features = false, features = ["alloc", "libsecp_compat", "proptest"] }
-secp256k1 = { version = "0.21.3", features = ["std", "global-context"]}
+secp256k1 = { version = "0.22", features = ["std", "global-context"]}
 
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]

--- a/schnorr_fun/tests/against_c_lib.proptest-regressions
+++ b/schnorr_fun/tests/against_c_lib.proptest-regressions
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc beead27d454941f36638cd10f4302f480877c6a0d648acf6c9099153fd7ad1ff # shrinks to key = Scalar<Secret,NonZero>(0000000000000000000000000000000000000000000000000000000000000001), msg = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]

--- a/schnorr_fun/tests/against_c_lib.rs
+++ b/schnorr_fun/tests/against_c_lib.rs
@@ -2,11 +2,53 @@
 use proptest::prelude::*;
 use schnorr_fun::{
     fun::{marker::*, proptest, secp256k1, Scalar},
-    nonce::Deterministic,
     Message, Schnorr,
 };
 use secp256k1::SECP256K1;
+use secp256kfun::{
+    digest::Digest,
+    hash::{HashAdd, Tagged},
+    nonce::{AddTag, NonceGen},
+};
 use sha2::Sha256;
+
+/// Compliance type for no aux BIP340 libsecp256k1 implementation.
+///
+/// This type is expected to be used in [`Schnorr`] context and receive a tag "BIP0340" to be
+/// compatible with BIP 340 no auxiliary data, i.e. aux is set to null 32-bytes array.
+#[derive(Clone, Debug, Default)]
+struct Bip340NoAux {
+    nonce_hash: Sha256,
+    aux_hash: Sha256,
+}
+
+impl NonceGen for Bip340NoAux {
+    type Hash = Sha256;
+    fn begin_derivation(&self, secret: &Scalar) -> Self::Hash {
+        let sec_bytes = secret.to_bytes();
+        let mut bytes = [0u8; 32];
+        let zero_mask = self.aux_hash.clone().add(&[0u8; 32]);
+        bytes.copy_from_slice(zero_mask.finalize().as_ref());
+
+        // bitwise xor the zero mask with secret
+        for (i, byte) in bytes.iter_mut().enumerate() {
+            *byte ^= sec_bytes[i]
+        }
+
+        self.nonce_hash.clone().add(bytes.as_ref())
+    }
+}
+
+impl AddTag for Bip340NoAux {
+    fn add_tag(self, tag: &str) -> Self {
+        Self {
+            nonce_hash: self
+                .nonce_hash
+                .tagged(&[tag.as_bytes(), b"/nonce"].concat()),
+            aux_hash: self.aux_hash.tagged(&[tag.as_bytes(), b"/aux"].concat()),
+        }
+    }
+}
 
 proptest! {
 
@@ -19,7 +61,7 @@ proptest! {
         let keypair = secp256k1::KeyPair::from_secret_key(&secp, key.clone().into());
         let secp_msg = secp256k1::Message::from_slice(&msg).unwrap();
         let sig = secp.sign_schnorr_no_aux_rand(&secp_msg, &keypair);
-        let schnorr = Schnorr::<Sha256,_>::new(Deterministic::<Sha256>::default());
+        let schnorr = Schnorr::<Sha256,_>::new(Bip340NoAux::default());
         let fun_keypair = schnorr.new_keypair(key);
         let fun_msg = Message::<Public>::raw(&msg);
         let fun_sig: secp256k1::schnorr::Signature = schnorr.sign(&fun_keypair, fun_msg).into();

--- a/schnorr_fun/tests/against_c_lib.rs
+++ b/schnorr_fun/tests/against_c_lib.rs
@@ -81,3 +81,19 @@ proptest! {
         prop_assert!(schnorr.verify(&fun_pk, fun_msg, &sig.into()));
     }
 }
+
+#[test]
+fn bip340_zero_mask_tagged_hash_is_correct() {
+    let no_aux = Bip340NoAux::default().add_tag("BIP0340");
+    let no_aux_hash = no_aux.aux_hash.clone().add(&[0u8; 32]);
+    let mut zero_mask = [0u8; 32];
+    zero_mask.copy_from_slice(no_aux_hash.finalize().as_ref());
+    assert_eq!(
+        zero_mask,
+        /* Precomputed TaggedHash("BIP0340/aux", 0x0000...00); */
+        [
+            84u8, 241, 105, 207, 201, 226, 229, 114, 116, 128, 68, 31, 144, 186, 37, 196, 136, 244,
+            97, 199, 11, 94, 165, 220, 170, 247, 175, 105, 39, 10, 165, 20
+        ]
+    );
+}

--- a/secp256kfun/Cargo.toml
+++ b/secp256kfun/Cargo.toml
@@ -24,7 +24,7 @@ serde_crate = { package = "serde", version = "1.0",  optional = true, default-fe
 # secp256kfun_k256_backend = { path = "../../k256_backend/k256" }
 secp256kfun_k256_backend = {  version = "2.0.0" }
 secp256kfun_parity_backend = { version = "0.1.5", optional = true }
-secp256k1 = { version = "0.21", optional = true, default-features = false }
+secp256k1 = { version = "0.22", optional = true, default-features = false }
 proptest = { version = "1", optional = true }
 
 [dev-dependencies]
@@ -33,10 +33,10 @@ rand = { version = "0.8" }
 lazy_static = "1.4"
 sha2 = "0.9"
 proptest = "1"
-secp256k1 = { version = "0.21.3", features = ["std", "global-context"]}
+secp256k1 = { version = "0.22", features = ["std", "global-context"]}
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-secp256k1 = { default-features = false, version = "0.21", features = ["std"] }
+secp256k1 = { default-features = false, version = "0.22", features = ["std"] }
 bincode = "1.0"
 criterion = "0.3"
 


### PR DESCRIPTION
Based on #99

Alternative solution to #99 with new type `Bip340NoAux` for tests only. I created another PR to keep the first implementation visible for history, I let you close #99 when this get merged.

Do you want to keep the proptest generated failed test case seed? Or should I amend the commit and remove it?