### PR TITLE
Point serialization improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## Unreleased
+
+- Added FROST implementation
+- Make Point<EvenY> serialization and hashing consistent (use 32 byte form)
+- Add `to_xonly_bytes` and `from_xonly_bytes` to `Point<EvenY>`
+- Allow `Zero` points to serialize
+
 ## 0.7.1
 
 - Fix critical bug in MuSig2 implementation where multiple tweaks would break it

--- a/schnorr_fun/src/adaptor/mod.rs
+++ b/schnorr_fun/src/adaptor/mod.rs
@@ -73,7 +73,7 @@ pub trait EncryptedSign {
     fn encrypted_sign(
         &self,
         signing_keypair: &XOnlyKeyPair,
-        encryption_key: &Point<impl Normalized, impl Secrecy>,
+        encryption_key: &Point<Normal, impl Secrecy>,
         message: Message<'_, impl Secrecy>,
     ) -> EncryptedSignature;
 }
@@ -86,7 +86,7 @@ where
     fn encrypted_sign(
         &self,
         signing_key: &XOnlyKeyPair,
-        encryption_key: &Point<impl Normalized, impl Secrecy>,
+        encryption_key: &Point<Normal, impl Secrecy>,
         message: Message<'_, impl Secrecy>,
     ) -> EncryptedSignature {
         let (x, X) = signing_key.as_tuple();

--- a/schnorr_fun/src/binonce.rs
+++ b/schnorr_fun/src/binonce.rs
@@ -15,64 +15,15 @@ use secp256kfun::{derive_nonce, g, marker::*, nonce::NonceGen, Point, Scalar, G}
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub struct Nonce<Z = NonZero>(pub [Point<Normal, Public, Z>; 2]);
 
-impl Nonce<Zero> {
+impl<Z: ZeroChoice> Nonce<Z> {
     /// Reads the pair of nonces from 66 bytes (two 33-byte serialized points).
     ///
     /// If either pair of 33 bytes is `[0u8;32]` that point is interpreted as `Zero`.
     pub fn from_bytes(bytes: [u8; 66]) -> Option<Self> {
-        fn deser(bytes: &[u8]) -> Option<Point<Normal, Public, Zero>> {
-            Point::from_slice(&bytes)
-                .map(|p| p.mark::<Zero>())
-                .or_else(|| {
-                    if bytes == [0u8; 33].as_slice() {
-                        Some(Point::zero())
-                    } else {
-                        None
-                    }
-                })
-        }
-
-        let R1 = deser(&bytes[33..])?;
-        let R2 = deser(&bytes[..33])?;
-
-        Some(Nonce([R1, R2]))
-    }
-
-    /// Serializes a public nonce as  as 66 bytes (two 33-byte serialized points).
-    ///
-    /// If either point is `Zero` it will be serialized as `[0u8;32]`.
-    pub fn to_bytes(self) -> [u8; 66] {
-        let mut bytes = [0u8; 66];
-        bytes[..33].copy_from_slice(
-            &self.0[0]
-                .mark::<NonZero>()
-                .map(|p| p.to_bytes())
-                .unwrap_or([0u8; 33]),
-        );
-        bytes[33..].copy_from_slice(
-            &self.0[1]
-                .mark::<NonZero>()
-                .map(|p| p.to_bytes())
-                .unwrap_or([0u8; 33]),
-        );
-        bytes
-    }
-}
-
-impl Nonce<NonZero> {
-    /// Reads the pair of nonces from 66 bytes (two 33-byte serialized points).
-    pub fn from_bytes(bytes: [u8; 66]) -> Option<Self> {
         let R1 = Point::from_slice(&bytes[..33])?;
         let R2 = Point::from_slice(&bytes[33..])?;
-        Some(Nonce([R1, R2]))
-    }
 
-    /// Serializes a public nonce as  as 66 bytes (two 33-byte serialized points).
-    pub fn to_bytes(&self) -> [u8; 66] {
-        let mut bytes = [0u8; 66];
-        bytes[..33].copy_from_slice(self.0[0].to_bytes().as_ref());
-        bytes[33..].copy_from_slice(self.0[1].to_bytes().as_ref());
-        bytes
+        Some(Nonce([R1, R2]))
     }
 }
 
@@ -82,30 +33,27 @@ impl<Z> Nonce<Z> {
         self.0[0] = self.0[0].conditional_negate(needs_negation);
         self.0[1] = self.0[1].conditional_negate(needs_negation);
     }
-}
 
-secp256kfun::impl_fromstr_deserialize! {
-    name => "public nonce pair",
-    fn from_bytes(bytes: [u8;66]) -> Option<Nonce<Zero>> {
-        Nonce::<Zero>::from_bytes(bytes)
-    }
-}
-
-secp256kfun::impl_display_serialize! {
-    fn to_bytes(nonce: &Nonce<Zero>) -> [u8;66] {
-        nonce.to_bytes()
+    /// Serializes a public nonce as  as 66 bytes (two 33-byte serialized points).
+    ///
+    /// If either point is `Zero` it will be serialized as `[0u8;32]`.
+    pub fn to_bytes(&self) -> [u8; 66] {
+        let mut bytes = [0u8; 66];
+        bytes[..33].copy_from_slice(self.0[0].to_bytes().as_ref());
+        bytes[33..].copy_from_slice(self.0[1].to_bytes().as_ref());
+        bytes
     }
 }
 
 secp256kfun::impl_fromstr_deserialize! {
     name => "public nonce pair",
-    fn from_bytes(bytes: [u8;66]) -> Option<Nonce<NonZero>> {
-        Nonce::<NonZero>::from_bytes(bytes)
+    fn from_bytes<Z: ZeroChoice>(bytes: [u8;66]) -> Option<Nonce<Z>> {
+        Nonce::from_bytes(bytes)
     }
 }
 
 secp256kfun::impl_display_serialize! {
-    fn to_bytes(nonce: &Nonce<NonZero>) -> [u8;66] {
+    fn to_bytes<Z>(nonce: &Nonce<Z>) -> [u8;66] {
         nonce.to_bytes()
     }
 }
@@ -192,7 +140,9 @@ impl NonceKeyPair {
         let message = message.unwrap_or(Message::raw(b""));
         let msg_len = (message.len() as u64).to_be_bytes();
         let sid_len = (session_id.len() as u64).to_be_bytes();
-        let pk_bytes = public_key.map(|p| p.to_bytes()).unwrap_or([0u8; 33]);
+        let pk_bytes = public_key
+            .map(|p| p.mark::<Normal>().to_bytes())
+            .unwrap_or([0u8; 33]);
         let r1 = derive_nonce!(
             nonce_gen => nonce_gen,
             secret => secret,

--- a/schnorr_fun/src/frost.rs
+++ b/schnorr_fun/src/frost.rs
@@ -1034,7 +1034,7 @@ mod test {
                 .collect();
 
             let sid = [
-                frost_keys[signer_indexes[0]].public_key().to_bytes().as_slice(),
+                frost_keys[signer_indexes[0]].public_key().to_xonly_bytes().as_slice(),
                 verification_shares_bytes.concat().as_slice(),
                 b"frost-prop-test".as_slice(),
             ]

--- a/secp256kfun/src/libsecp_compat.rs
+++ b/secp256kfun/src/libsecp_compat.rs
@@ -21,12 +21,12 @@ impl From<SecretKey> for Scalar {
 
 impl From<PublicKey> for Point {
     fn from(pk: PublicKey) -> Self {
-        Point::from_bytes(pk.serialize()).unwrap()
+        Point::<Normal, Public, NonZero>::from_bytes(pk.serialize()).unwrap()
     }
 }
 
-impl<T: Normalized> From<Point<T>> for PublicKey {
-    fn from(pk: Point<T>) -> Self {
+impl From<Point> for PublicKey {
+    fn from(pk: Point) -> Self {
         PublicKey::from_slice(pk.to_bytes().as_ref()).unwrap()
     }
 }

--- a/secp256kfun/src/marker/zero_choice.rs
+++ b/secp256kfun/src/marker/zero_choice.rs
@@ -15,10 +15,20 @@ pub struct NonZero;
 pub trait ZeroChoice:
     Default + Clone + PartialEq + Copy + DecideZero<NonZero> + DecideZero<Zero> + 'static
 {
+    /// Returns whether the type is `Zero`
+    fn is_zero() -> bool;
 }
 
-impl ZeroChoice for Zero {}
-impl ZeroChoice for NonZero {}
+impl ZeroChoice for Zero {
+    fn is_zero() -> bool {
+        true
+    }
+}
+impl ZeroChoice for NonZero {
+    fn is_zero() -> bool {
+        false
+    }
+}
 
 /// A trait to figure out whether the result of a multiplication should be [`Zero`] or [`NonZero`] at compile time.
 


### PR DESCRIPTION
- `EvenY` points have their only serialization methods (`to_xonly_bytes` and `from_xonly_bytes`).
- `EvenY` points have a different `HashInto` implementation now so you don't have to convert them to `XOnly`.
- `Zero` points can be serialized and deserialized to `[0u8;32]`.