### PR TITLE
Do some optimization of normal operations

### DIFF
--- a/schnorr_fun/src/schnorr.rs
+++ b/schnorr_fun/src/schnorr.rs
@@ -231,7 +231,7 @@ impl<NG, CH: Digest<OutputSize = U32> + Clone> Schnorr<CH, NG> {
         let X = public_key;
         let (R, s) = signature.as_tuple();
         let c = self.challenge(&R, X, message);
-        let R_implied = g!(s * G - c * X).normalize();
+        let R_implied = g!(s * G - c * X);
         R_implied == R
     }
 

--- a/secp256kfun/Cargo.toml
+++ b/secp256kfun/Cargo.toml
@@ -54,3 +54,7 @@ serde = [ "serde_crate" ]
 [[bench]]
 name = "bench_ecmult"
 harness = false
+
+[[bench]]
+name = "bench_point"
+harness = false

--- a/secp256kfun/benches/bench_point.rs
+++ b/secp256kfun/benches/bench_point.rs
@@ -1,0 +1,92 @@
+#![allow(non_snake_case)]
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+use secp256kfun::{g, Point, Scalar, G};
+
+fn point_add(c: &mut Criterion) {
+    let mut group = c.benchmark_group("point_add");
+
+    group.bench_function("normal,normal", |b| {
+        b.iter_batched(
+            || {
+                (
+                    Point::random(&mut rand::thread_rng()),
+                    Point::random(&mut rand::thread_rng()),
+                )
+            },
+            |(lhs, rhs)| g!(lhs + rhs),
+            BatchSize::SmallInput,
+        )
+    });
+
+    group.bench_function("non_normal,normal", |b| {
+        b.iter_batched(
+            || {
+                (
+                    g!({ Scalar::random(&mut rand::thread_rng()) } * G),
+                    Point::random(&mut rand::thread_rng()),
+                )
+            },
+            |(lhs, rhs)| g!(lhs + rhs),
+            BatchSize::SmallInput,
+        )
+    });
+
+    group.bench_function("non_normal,non_normal", |b| {
+        b.iter_batched(
+            || {
+                (
+                    g!({ Scalar::random(&mut rand::thread_rng()) } * G),
+                    g!({ Scalar::random(&mut rand::thread_rng()) } * G),
+                )
+            },
+            |(lhs, rhs)| g!(lhs + rhs),
+            BatchSize::SmallInput,
+        )
+    });
+}
+
+fn point_eq(c: &mut Criterion) {
+    let mut group = c.benchmark_group("point_eq");
+
+    group.bench_function("normal,normal", |b| {
+        b.iter_batched(
+            || {
+                (
+                    Point::random(&mut rand::thread_rng()),
+                    Point::random(&mut rand::thread_rng()),
+                )
+            },
+            |(lhs, rhs)| lhs == rhs,
+            BatchSize::SmallInput,
+        )
+    });
+
+    group.bench_function("non_normal,normal", |b| {
+        b.iter_batched(
+            || {
+                (
+                    g!({ Scalar::random(&mut rand::thread_rng()) } * G),
+                    Point::random(&mut rand::thread_rng()),
+                )
+            },
+            |(lhs, rhs)| lhs == rhs,
+            BatchSize::SmallInput,
+        )
+    });
+
+    group.bench_function("non_normal,non_normal", |b| {
+        b.iter_batched(
+            || {
+                (
+                    g!({ Scalar::random(&mut rand::thread_rng()) } * G),
+                    g!({ Scalar::random(&mut rand::thread_rng()) } * G),
+                )
+            },
+            |(lhs, rhs)| lhs == rhs,
+            BatchSize::SmallInput,
+        )
+    });
+}
+
+criterion_group!(benches, point_add, point_eq);
+criterion_main!(benches);

--- a/secp256kfun/src/marker/point_type.rs
+++ b/secp256kfun/src/marker/point_type.rs
@@ -11,6 +11,9 @@
 pub trait PointType: Sized + Clone + Copy + 'static {
     /// The point type returned from the negation of a point of this type.
     type NegationType: Default;
+
+    /// Whether the point type is normalized or not (i.e. not [`NonNormal`])
+    fn is_normalized() -> bool;
 }
 
 /// A Fully Normalized Point. Internally `Normal` points are represented using
@@ -70,8 +73,18 @@ impl NotBasePoint for Normal {}
 
 impl<N: Normalized> PointType for N {
     type NegationType = Normal;
+
+    #[inline(always)]
+    fn is_normalized() -> bool {
+        true
+    }
 }
 
 impl PointType for NonNormal {
     type NegationType = NonNormal;
+
+    #[inline(always)]
+    fn is_normalized() -> bool {
+        false
+    }
 }

--- a/secp256kfun/src/point.rs
+++ b/secp256kfun/src/point.rs
@@ -144,7 +144,7 @@ impl<Z: ZeroChoice> Point<Normal, Public, Z> {
     }
 }
 
-impl<T, S> Point<T, S, NonZero> {
+impl<T: PointType, S> Point<T, S, NonZero> {
     /// Converts this point into the point with the same x-coordinate but with
     /// an even y-coordinate. Returns a Point marked `EvenY` with a `bool`
     /// indicating whether the point had to be negated to make its y-coordinate
@@ -250,7 +250,10 @@ impl<T, S, Z> Point<T, S, Z> {
     /// [`NonNormal`]: crate::marker::NonNormal
     /// [`PointType`]: crate::marker::PointType
     /// [`Normal`]: crate::marker::Normal
-    pub fn normalize(self) -> Point<Normal, S, Z> {
+    pub fn normalize(self) -> Point<Normal, S, Z>
+    where
+        T: PointType,
+    {
         op::point_normalize(self)
     }
 
@@ -312,13 +315,17 @@ impl<T: PointType, S, Z> core::ops::Neg for &Point<T, S, Z> {
     }
 }
 
-impl<T1, S1, Z1, T2, S2, Z2> PartialEq<Point<T2, S2, Z2>> for Point<T1, S1, Z1> {
+impl<T1, S1, Z1, T2, S2, Z2> PartialEq<Point<T2, S2, Z2>> for Point<T1, S1, Z1>
+where
+    T1: PointType,
+    T2: PointType,
+{
     fn eq(&self, rhs: &Point<T2, S2, Z2>) -> bool {
         op::point_eq(self, rhs)
     }
 }
 
-impl<T, S, Z> Eq for Point<T, S, Z> {}
+impl<T: PointType, S, Z> Eq for Point<T, S, Z> {}
 
 impl core::hash::Hash for Point<Normal, Public, NonZero> {
     fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
@@ -705,6 +712,7 @@ mod test {
         let forty_two = s!(42);
         let forty_two_pub = s!(42).public();
         assert!(i.is_zero());
+        assert!((-i).is_zero());
         expression_eq!([i] == [i]);
         expression_eq!([i] == [-i]);
         expression_eq!([i + i] == [i]);


### PR DESCRIPTION
Some operations can be done faster if we know a point is Normal (e.g. addition). This demonstrates that we can specialize operations without using nightly features (nightly specialization was removed in #111).