### PR TITLE
Remove .borrow from derive_nonce_rng

### DIFF
--- a/secp256kfun/src/macros.rs
+++ b/secp256kfun/src/macros.rs
@@ -312,7 +312,7 @@ macro_rules! derive_nonce {
     (
         nonce_gen => $nonce_gen:expr,
         secret => $secret:expr,
-        public => [$($public:expr),+]
+        public => [$($public:expr),+]$(,)?
     ) => {{
         use $crate::hash::HashAdd;
         use core::borrow::Borrow;
@@ -352,7 +352,7 @@ macro_rules! derive_nonce_rng {
         nonce_gen => $nonce_gen:expr,
         secret => $secret:expr,
         public => [$($public:expr),+],
-        seedable_rng => $rng:ty
+        seedable_rng => $rng:ty$(,)?
     ) => {{
         use $crate::hash::HashAdd;
         use core::borrow::Borrow;
@@ -360,7 +360,7 @@ macro_rules! derive_nonce_rng {
         use $crate::rand_core::SeedableRng;
         use $crate::digest::Digest;
 
-        let hash = $nonce_gen.begin_derivation($secret.borrow())$(.add($public.borrow()))+;
+        let hash = $nonce_gen.begin_derivation($secret.borrow())$(.add($public))+;
         <$rng>::from_seed(hash.finalize().into())
     }}
 }

--- a/secp256kfun/src/nonce.rs
+++ b/secp256kfun/src/nonce.rs
@@ -293,4 +293,20 @@ mod test {
         let one = s!(1);
         assert_ne!(get_nonce!(nonce_gen_1, one), get_nonce!(nonce_gen_1, one));
     }
+
+    #[test]
+    fn derive_nonce_macros_work_with_fixed_length_data() {
+        let _ = crate::derive_nonce_rng! {
+            nonce_gen => Deterministic::<Sha256>::default(),
+            secret => Scalar::random(&mut rand::thread_rng()),
+            public => [b"a fixed length array"],
+            seedable_rng => rand::rngs::StdRng,
+        };
+
+        let _ = crate::derive_nonce! {
+            nonce_gen => Deterministic::<Sha256>::default(),
+            secret => Scalar::random(&mut rand::thread_rng()),
+            public => [b"a fixed length array"],
+        };
+    }
 }


### PR DESCRIPTION
It breaks type inference and is unnecessary.