### PR TITLE
Frost and MuSig joint key Point type parameter

### DIFF
--- a/schnorr_fun/Cargo.toml
+++ b/schnorr_fun/Cargo.toml
@@ -17,6 +17,7 @@ keywords = ["bitcoin", "schnorr"]
 features = ["all"]
 
 [dependencies]
+rand = "0.8"
 secp256kfun = { path = "../secp256kfun", version = "0.7.1",  default-features = false }
 serde_crate = { package = "serde", version = "1.0", default-features = false, optional = true, features = ["derive", "alloc"] }
 
@@ -44,7 +45,7 @@ harness = false
 
 [features]
 default = ["std"]
-all = ["std","serde", "libsecp_compat", "proptest"]
+all = ["std", "serde", "libsecp_compat", "proptest"]
 alloc = ["secp256kfun/alloc"]
 std = ["alloc", "secp256kfun/std"]
 serde = ["serde_crate", "secp256kfun/serde"]

--- a/schnorr_fun/Cargo.toml
+++ b/schnorr_fun/Cargo.toml
@@ -17,7 +17,6 @@ keywords = ["bitcoin", "schnorr"]
 features = ["all"]
 
 [dependencies]
-rand = "0.8"
 secp256kfun = { path = "../secp256kfun", version = "0.7.1",  default-features = false }
 serde_crate = { package = "serde", version = "1.0", default-features = false, optional = true, features = ["derive", "alloc"] }
 

--- a/schnorr_fun/tests/frost_prop.rs
+++ b/schnorr_fun/tests/frost_prop.rs
@@ -1,4 +1,5 @@
 #![cfg(feature = "alloc")]
+#![cfg(feature = "serde")]
 use rand::seq::SliceRandom;
 use rand_chacha::ChaCha20Rng;
 use schnorr_fun::{

--- a/schnorr_fun/tests/frost_prop.rs
+++ b/schnorr_fun/tests/frost_prop.rs
@@ -58,9 +58,9 @@ proptest! {
 
         let mut nonce_rngs: Vec<ChaCha20Rng> = secret_shares.iter().map(|secret_share| {
             proto.gen_nonce_rng(
+                &frost_key,
                 secret_share,
                 sid,
-                Some(frost_key.public_key()),
                 Some(message),
             )
         }).collect();

--- a/schnorr_fun/tests/frost_prop.rs
+++ b/schnorr_fun/tests/frost_prop.rs
@@ -1,5 +1,6 @@
 #![cfg(feature = "alloc")]
 use rand::seq::SliceRandom;
+use rand_chacha::ChaCha20Rng;
 use schnorr_fun::{
     frost::*,
     fun::{marker::*, Scalar},
@@ -54,13 +55,18 @@ proptest! {
         let sid = b"frost-prop-test".as_slice();
         let message = Message::plain("test", b"test");
 
-        let nonces: Vec<_> = signer_indexes.iter().map(|i|
-            proto.gen_nonce(
-                &secret_shares[*i],
+        let mut nonce_rngs: Vec<ChaCha20Rng> = secret_shares.iter().map(|secret_share| {
+            proto.gen_nonce_rng(
+                secret_share,
                 sid,
                 Some(frost_key.public_key()),
-                Some(message))
-            ).collect();
+                Some(message),
+            )
+        }).collect();
+
+        let nonces: Vec<_> = signer_indexes.iter().map(|i|
+            proto.gen_nonce(
+                &mut nonce_rngs[*i])).collect();
 
         let mut received_nonces: Vec<_> = vec![];
         for (i, nonce) in signer_indexes.iter().zip(nonces.clone()) {


### PR DESCRIPTION
Recreating https://github.com/LLFourn/secp256kfun/pull/128 minus the cherry-picked commit from https://github.com/LLFourn/secp256kfun/pull/129/
* Change musig and frost keys to allow for any point type
* keygen creates Normal points
* signing operations are done with EvenY points