### PR TITLE
Clean up feature flags make things compile with alloc and --no-default-features

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: 1.60.0
           target: ${{ matrix.target }}
           override: true
       - uses: Swatinem/rust-cache@v2.0.0
@@ -105,7 +105,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --release --no-default-features --features alloc -p ${{ matrix.package }}
+          args: --release --no-default-features --features alloc,serde -p ${{ matrix.package }}
 
 
   doc-build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,25 +31,23 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        args: [ "--all-features" ]
-        rust: [stable]
         target: ["x86_64-unknown-linux-gnu", "armv7-unknown-linux-gnueabihf"]
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: ${{ matrix.rust }}
+          toolchain: stable
           target: ${{ matrix.target }}
           override: true
       - uses: Swatinem/rust-cache@v2.0.0
 
-      - name: cross test (armv7)
+      - name: test-on-target
         uses: actions-rs/cargo@v1
         with:
           use-cross:  ${{ matrix.target != 'x86_64-unknown-linux-gnu' }}
           command: test
-          args:  ${{ matrix.args }} --release --verbose --target ${{ matrix.target }}
+          args:  --all-features --release --target ${{ matrix.target }}
 
   # test nightly build/test
   test-nightly:
@@ -66,11 +64,14 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --release --verbose --all-features
+          args: --release --all-features
 
   # test without default features
   test-minimal:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        package: [ "secp256kfun", "sigma_fun", "ecdsa_fun", "schnorr_fun" ]
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -83,7 +84,29 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --release --verbose --no-default-features
+          args: --release --no-default-features -p ${{ matrix.package }}
+
+
+  # test with alloc feature only
+  test-alloc:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        package: [ "secp256kfun", "sigma_fun", "ecdsa_fun", "schnorr_fun" ]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          target: "x86_64-unknown-linux-gnu"
+          override: true
+      - uses: Swatinem/rust-cache@v2.0.0
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --release --no-default-features --features alloc -p ${{ matrix.package }}
+
 
   doc-build:
      name: doc-build

--- a/ecdsa_fun/Cargo.toml
+++ b/ecdsa_fun/Cargo.toml
@@ -3,7 +3,7 @@ name = "ecdsa_fun"
 version = "0.7.1"
 authors = ["LLFourn <lloyd.fourn@gmail.com>"]
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.60"
 license = "0BSD"
 homepage = "https://github.com/LLFourn/secp256kfun/tree/master/ecdsa_fun"
 repository = "https://github.com/LLFourn/secp256kfun"
@@ -13,12 +13,8 @@ readme = "README.md"
 categories = ["cryptography", "cryptography::cryptocurrencies"]
 keywords = ["bitcoin", "ecdsa", "secp256k1"]
 
-[package.metadata.docs.rs]
-features = ["all"]
-
 [dependencies]
 secp256kfun = { path = "../secp256kfun", version = "0.7.1", default-features = false }
-serde_crate = { package = "serde", version = "1.0", default-features = false, optional = true, features = ["derive", "alloc"] }
 sigma_fun = { path = "../sigma_fun", version = "0.4.1", features = ["secp256k1"], default-features = false, optional = true }
 rand_chacha = {  version = "0.3", optional = true }  # needed for adaptor signatures atm but would be nice to get rid of
 bincode = { version = "1.0", optional = true }
@@ -38,11 +34,13 @@ harness = false
 
 [features]
 default = ["std"]
-all = ["std", "serde", "libsecp_compat", "adaptor"]
 libsecp_compat = ["secp256kfun/libsecp_compat"]
 std = ["alloc"]
-alloc = ["secp256kfun/alloc" ]
-serde = ["secp256kfun/serde", "serde_crate"]
-# when https://github.com/rust-lang/cargo/issues/8832 is stabilized use the ? syntax to fix this
-adaptor = ["sigma_fun", "bincode", "rand_chacha", "sigma_fun/serde", "sigma_fun/alloc"]
+alloc = ["secp256kfun/alloc", "sigma_fun?/alloc" ]
+serde = ["secp256kfun/serde","sigma_fun?/serde"]
+adaptor = ["dep:sigma_fun", "dep:bincode", "rand_chacha"]
 proptest = ["secp256kfun/proptest"]
+
+
+[package.metadata.docs.rs]
+all-features = true

--- a/ecdsa_fun/src/adaptor/encrypted_signature.rs
+++ b/ecdsa_fun/src/adaptor/encrypted_signature.rs
@@ -31,9 +31,10 @@ secp256kfun::impl_display_debug_serialize! {
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(
     feature = "serde",
-    derive(crate::serde::Deserialize, crate::serde::Serialize)
+    derive(crate::serde::Deserialize, crate::serde::Serialize),
+    serde(crate = "crate::serde")
 )]
-#[serde(crate = "crate::serde")]
+#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 pub(crate) struct EncryptedSignatureInternal {
     pub R: PointNonce,
     pub R_hat: Point,

--- a/ecdsa_fun/src/adaptor/encrypted_signature.rs
+++ b/ecdsa_fun/src/adaptor/encrypted_signature.rs
@@ -31,9 +31,9 @@ secp256kfun::impl_display_debug_serialize! {
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(
     feature = "serde",
-    derive(serde::Deserialize, serde::Serialize),
-    serde(crate = "serde_crate")
+    derive(crate::serde::Deserialize, crate::serde::Serialize)
 )]
+#[serde(crate = "crate::serde")]
 pub(crate) struct EncryptedSignatureInternal {
     pub R: PointNonce,
     pub R_hat: Point,

--- a/ecdsa_fun/src/lib.rs
+++ b/ecdsa_fun/src/lib.rs
@@ -13,6 +13,7 @@ extern crate std;
 mod libsecp_compat;
 
 #[cfg(feature = "serde")]
+/// Rexport `serde`
 pub use fun::serde;
 
 use fun::{
@@ -26,6 +27,7 @@ pub use secp256kfun::nonce;
 mod signature;
 pub use signature::Signature;
 #[cfg(feature = "adaptor")]
+#[cfg_attr(docsrs, doc(cfg(feature = "adaptor")))]
 pub mod adaptor;
 
 /// An instance of the ECDSA signature scheme.

--- a/ecdsa_fun/src/lib.rs
+++ b/ecdsa_fun/src/lib.rs
@@ -2,8 +2,7 @@
 #![no_std]
 #![allow(non_snake_case)]
 
-#[cfg(all(feature = "alloc", not(feature = "std")))]
-#[macro_use]
+#[cfg(feature = "alloc")]
 extern crate alloc;
 
 #[cfg(feature = "std")]

--- a/ecdsa_fun/src/lib.rs
+++ b/ecdsa_fun/src/lib.rs
@@ -13,7 +13,7 @@ extern crate std;
 mod libsecp_compat;
 
 #[cfg(feature = "serde")]
-extern crate serde_crate as serde;
+pub use fun::serde;
 
 use fun::{
     derive_nonce, g,

--- a/ecdsa_fun/tests/adaptor_test_vectors.rs
+++ b/ecdsa_fun/tests/adaptor_test_vectors.rs
@@ -1,33 +1,23 @@
 #![cfg(all(feature = "serde", feature = "alloc", feature = "adaptor"))]
-extern crate serde_crate as serde;
 
 static DLC_SPEC_JSON: &'static str = include_str!("./test_vectors.json");
 use ecdsa_fun::{
     adaptor::{Adaptor, EncryptedSignature, HashTranscript},
     fun::{Point, Scalar},
-    Signature,
+    serde, Signature,
 };
 use sha2::Sha256;
 
-#[derive(Clone, Debug)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde::Deserialize, serde::Serialize),
-    serde(crate = "serde_crate")
-)]
-#[serde(tag = "kind", rename_all = "snake_case")]
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case", crate = "self::serde")]
 enum TestVector {
     Verification(Verification),
     Recovery(Recovery),
     Serialization(Serialization),
 }
 
-#[derive(Clone, Debug)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde::Deserialize, serde::Serialize),
-    serde(crate = "serde_crate")
-)]
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
+#[serde(crate = "self::serde")]
 struct Recovery {
     encryption_key: Point,
     signature: Signature,
@@ -35,12 +25,8 @@ struct Recovery {
     decryption_key: Option<Scalar>,
 }
 
-#[derive(Clone, Debug)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde::Deserialize, serde::Serialize),
-    serde(crate = "serde_crate")
-)]
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
+#[serde(crate = "self::serde")]
 struct Verification {
     adaptor_sig: EncryptedSignature,
     public_signing_key: Point,
@@ -51,12 +37,8 @@ struct Verification {
     error: Option<String>,
 }
 
-#[derive(Clone, Debug)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde::Deserialize, serde::Serialize),
-    serde(crate = "serde_crate")
-)]
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
+#[serde(crate = "self::serde")]
 struct Serialization {
     adaptor_sig: String,
     error: Option<String>,

--- a/ecdsa_fun/tests/against_c_lib.rs
+++ b/ecdsa_fun/tests/against_c_lib.rs
@@ -3,6 +3,7 @@ use ecdsa_fun::{
     self,
     fun::{
         hex,
+        marker::*,
         secp256k1::{self, ecdsa, Message, PublicKey, SecretKey},
         Point, Scalar,
     },
@@ -68,7 +69,8 @@ fn ecdsa_verify_high_message() {
             .unwrap();
     let c_message = Message::from_slice(&message[..]).unwrap();
     let c_signature = secp.sign_ecdsa(&c_message, &c_secret_key);
-    let signature = ecdsa_fun::Signature::from_bytes(c_signature.serialize_compact()).unwrap();
+    let signature =
+        ecdsa_fun::Signature::<Public>::from_bytes(c_signature.serialize_compact()).unwrap();
 
     assert!(ecdsa.verify(&verification_key, &message, &signature));
 }

--- a/schnorr_fun/Cargo.toml
+++ b/schnorr_fun/Cargo.toml
@@ -4,7 +4,7 @@ name = "schnorr_fun"
 version = "0.7.1"
 authors = ["LLFourn <lloyd.fourn@gmail.com>"]
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.60"
 license = "0BSD"
 homepage = "https://github.com/LLFourn/secp256kfun/tree/master/schnorr_fun"
 repository = "https://github.com/LLFourn/secp256kfun"
@@ -13,12 +13,8 @@ description = "BIP340 Schnorr signatures based on secp256kfun"
 categories = ["cryptography", "cryptography::cryptocurrencies"]
 keywords = ["bitcoin", "schnorr"]
 
-[package.metadata.docs.rs]
-features = ["all"]
-
 [dependencies]
 secp256kfun = { path = "../secp256kfun", version = "0.7.1",  default-features = false }
-serde_crate = { package = "serde", version = "1.0", default-features = false, optional = true, features = ["derive", "alloc"] }
 
 [dev-dependencies]
 rand = { version = "0.8" }
@@ -44,9 +40,11 @@ harness = false
 
 [features]
 default = ["std"]
-all = ["std", "serde", "libsecp_compat", "proptest"]
-alloc = ["secp256kfun/alloc"]
+alloc = ["secp256kfun/alloc" ]
 std = ["alloc", "secp256kfun/std"]
-serde = ["serde_crate", "secp256kfun/serde"]
+serde = ["secp256kfun/serde"]
 libsecp_compat = ["secp256kfun/libsecp_compat"]
 proptest = ["secp256kfun/proptest"]
+
+[package.metadata.docs.rs]
+all-features = true

--- a/schnorr_fun/src/adaptor/encrypted_signature.rs
+++ b/schnorr_fun/src/adaptor/encrypted_signature.rs
@@ -7,8 +7,8 @@ use secp256kfun::{marker::*, Point, Scalar};
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(
     feature = "serde",
-    derive(serde::Deserialize, serde::Serialize),
-    serde(crate = "serde_crate")
+    derive(crate::serde::Deserialize, crate::serde::Serialize),
+    serde(crate = "crate::serde")
 )]
 pub struct EncryptedSignature<S = Public> {
     /// The `R` point in the signature

--- a/schnorr_fun/src/adaptor/encrypted_signature.rs
+++ b/schnorr_fun/src/adaptor/encrypted_signature.rs
@@ -10,6 +10,7 @@ use secp256kfun::{marker::*, Point, Scalar};
     derive(crate::serde::Deserialize, crate::serde::Serialize),
     serde(crate = "crate::serde")
 )]
+#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 pub struct EncryptedSignature<S = Public> {
     /// The `R` point in the signature
     pub R: Point<EvenY, Public>,

--- a/schnorr_fun/src/frost.rs
+++ b/schnorr_fun/src/frost.rs
@@ -146,7 +146,8 @@
 //! Note that if a key generation sesssion fails you must always start a fresh session with a different session id.
 #![cfg(feature = "serde")]
 pub use crate::binonce::{Nonce, NonceKeyPair};
-use crate::{Message, Schnorr, Signature, Vec};
+use crate::{Message, Schnorr, Signature};
+use alloc::{collections::BTreeMap, vec::Vec};
 use secp256kfun::{
     derive_nonce_rng,
     digest::{generic_array::typenum::U32, Digest},
@@ -157,7 +158,6 @@ use secp256kfun::{
     rand_core::{RngCore, SeedableRng},
     s, Point, Scalar, G,
 };
-use std::collections::BTreeMap;
 
 /// The FROST context.
 ///

--- a/schnorr_fun/src/frost.rs
+++ b/schnorr_fun/src/frost.rs
@@ -282,14 +282,14 @@ impl std::error::Error for FinishKeyGenError {}
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(
     feature = "serde",
-    derive(serde::Deserialize, serde::Serialize),
-    serde(crate = "serde_crate")
+    derive(crate::serde::Deserialize, crate::serde::Serialize),
+    serde(crate = "crate::serde")
 )]
 pub struct FrostKey<T: PointType> {
     /// The joint public key of the frost multisignature.
     #[serde(bound(
-        deserialize = "Point<T>: serde::de::Deserialize<'de>",
-        serialize = "Point<T>: serde::Serialize"
+        deserialize = "Point<T>: crate::serde::de::Deserialize<'de>",
+        serialize = "Point<T>: crate::serde::Serialize"
     ))]
     public_key: Point<T>,
     /// Everyone else's point polynomial evaluated at your index, used in partial signature validation.

--- a/schnorr_fun/src/lib.rs
+++ b/schnorr_fun/src/lib.rs
@@ -4,17 +4,14 @@
 #![doc = include_str!("../README.md")]
 #![warn(missing_docs)]
 
-#[cfg(all(feature = "alloc", not(feature = "std")))]
+#[cfg(feature = "alloc")]
+#[allow(unused)]
 #[macro_use]
 extern crate alloc;
-#[cfg(all(feature = "alloc", not(feature = "std")))]
-pub(crate) use alloc::vec::Vec;
 
 #[cfg(feature = "std")]
 #[macro_use]
 extern crate std;
-#[cfg(feature = "std")]
-pub(crate) use std::vec::Vec;
 
 #[cfg(feature = "serde")]
 extern crate serde_crate as serde;

--- a/schnorr_fun/src/lib.rs
+++ b/schnorr_fun/src/lib.rs
@@ -13,11 +13,11 @@ extern crate alloc;
 #[macro_use]
 extern crate std;
 
-#[cfg(feature = "serde")]
-extern crate serde_crate as serde;
-
 pub use secp256kfun as fun;
 pub use secp256kfun::nonce;
+
+#[cfg(feature = "serde")]
+pub use secp256kfun::serde;
 
 /// binonces for Musig and FROST
 pub mod binonce;

--- a/schnorr_fun/src/musig.rs
+++ b/schnorr_fun/src/musig.rs
@@ -61,7 +61,8 @@
 //! [the excellent paper]: https://eprint.iacr.org/2020/1261.pdf
 //! [secp256k1-zkp]: https://github.com/ElementsProject/secp256k1-zkp/pull/131
 pub use crate::binonce::{Nonce, NonceKeyPair};
-use crate::{adaptor::EncryptedSignature, Message, Schnorr, Signature, Vec};
+use crate::{adaptor::EncryptedSignature, Message, Schnorr, Signature};
+use alloc::vec::Vec;
 use secp256kfun::{
     digest::{generic_array::typenum::U32, Digest},
     g,

--- a/schnorr_fun/src/musig.rs
+++ b/schnorr_fun/src/musig.rs
@@ -320,8 +320,8 @@ impl<H: Digest<OutputSize = U32> + Clone, NG: NonceGen> MuSig<H, Schnorr<H, NG>>
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(
     feature = "serde",
-    derive(serde::Deserialize, serde::Serialize),
-    serde(crate = "serde_crate")
+    derive(crate::serde::Deserialize, crate::serde::Serialize),
+    serde(crate = "crate::serde")
 )]
 pub struct Ordinary;
 
@@ -330,8 +330,8 @@ pub struct Ordinary;
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(
     feature = "serde",
-    derive(serde::Deserialize, serde::Serialize),
-    serde(crate = "serde_crate")
+    derive(crate::serde::Deserialize, crate::serde::Serialize),
+    serde(crate = "crate::serde")
 )]
 pub struct Adaptor {
     y_needs_negation: bool,
@@ -348,8 +348,8 @@ pub struct Adaptor {
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(
     feature = "serde",
-    derive(serde::Deserialize, serde::Serialize),
-    serde(crate = "serde_crate")
+    derive(crate::serde::Deserialize, crate::serde::Serialize),
+    serde(crate = "crate::serde")
 )]
 pub struct SignSession<T = Ordinary> {
     b: Scalar<Public, Zero>,

--- a/schnorr_fun/tests/musig_keyagg.rs
+++ b/schnorr_fun/tests/musig_keyagg.rs
@@ -1,13 +1,12 @@
 #![cfg(feature = "serde")]
 use schnorr_fun::{
     fun::{marker::*, Point, Scalar},
-    musig,
+    musig, serde,
 };
 static TEST_JSON: &'static str = include_str!("musig/key_agg_vectors.json");
-use serde_crate as serde;
 
 #[derive(serde::Deserialize, Clone, Copy, Debug)]
-#[serde(crate = "serde_crate", untagged)]
+#[serde(crate = "self::serde", untagged)]
 pub enum Maybe<T> {
     Valid(T),
     Invalid(&'static str),
@@ -21,8 +20,8 @@ impl<T> Maybe<T> {
         }
     }
 }
-#[derive(serde::Deserialize)]
-#[serde(crate = "serde_crate")]
+#[derive(crate::serde::Deserialize)]
+#[serde(crate = "self::serde")]
 pub struct TestCases {
     #[serde(bound(deserialize = "Maybe<Point>: serde::de::Deserialize<'de>"))]
     pubkeys: Vec<Maybe<Point>>,
@@ -33,8 +32,8 @@ pub struct TestCases {
     error_test_cases: Vec<TestCase>,
 }
 
-#[derive(serde::Deserialize)]
-#[serde(crate = "serde_crate")]
+#[derive(crate::serde::Deserialize)]
+#[serde(crate = "self::serde")]
 pub struct TestCase {
     key_indices: Vec<usize>,
     #[serde(default)]

--- a/schnorr_fun/tests/musig_sign_verify.rs
+++ b/schnorr_fun/tests/musig_sign_verify.rs
@@ -3,14 +3,13 @@ use schnorr_fun::{
     binonce,
     fun::{marker::*, Point, Scalar},
     musig::{self, NonceKeyPair},
-    Message,
+    serde, Message,
 };
 static TEST_JSON: &'static str = include_str!("musig/sign_verify_vectors.json");
 use secp256kfun::hex;
-use serde_crate as serde;
 
-#[derive(serde::Deserialize, Clone, Copy, Debug)]
-#[serde(crate = "serde_crate", untagged)]
+#[derive(schnorr_fun::serde::Deserialize, Clone, Copy, Debug)]
+#[serde(crate = "self::serde", untagged)]
 pub enum Maybe<T> {
     Valid(T),
     Invalid(&'static str),
@@ -25,7 +24,7 @@ impl<T> Maybe<T> {
     }
 }
 #[derive(serde::Deserialize)]
-#[serde(crate = "serde_crate")]
+#[serde(crate = "self::serde")]
 pub struct TestCases {
     sk: Scalar,
     secnonce: NonceKeyPair,
@@ -44,7 +43,7 @@ pub struct TestCases {
 }
 
 #[derive(serde::Deserialize)]
-#[serde(crate = "serde_crate")]
+#[serde(crate = "self::serde")]
 pub struct TestCase {
     #[serde(bound(deserialize = "Maybe<Scalar<Public, Zero>>: serde::de::Deserialize<'de>"))]
     sig: Option<Maybe<Scalar<Public, Zero>>>,

--- a/schnorr_fun/tests/musig_tweak.rs
+++ b/schnorr_fun/tests/musig_tweak.rs
@@ -6,14 +6,13 @@ use schnorr_fun::{
     binonce,
     fun::{marker::*, Point, Scalar},
     musig::{self, NonceKeyPair},
-    Message,
+    serde, Message,
 };
 static TEST_JSON: &'static str = include_str!("musig/tweak_vectors.json");
 use secp256kfun::hex;
-use serde_crate as serde;
 
 #[derive(serde::Deserialize, Clone, Debug)]
-#[serde(crate = "serde_crate", untagged)]
+#[serde(crate = "self::serde", untagged)]
 pub enum Maybe<T> {
     Valid(T),
     Invalid(&'static str),
@@ -30,7 +29,7 @@ impl<T> Maybe<T> {
 impl<T: Copy> Copy for Maybe<T> {}
 
 #[derive(serde::Deserialize)]
-#[serde(crate = "serde_crate")]
+#[serde(crate = "self::serde")]
 pub struct TestCases {
     sk: Scalar,
     secnonce: NonceKeyPair,
@@ -47,7 +46,7 @@ pub struct TestCases {
 }
 
 #[derive(serde::Deserialize)]
-#[serde(crate = "serde_crate")]
+#[serde(crate = "self::serde")]
 pub struct TestCase {
     #[serde(bound(deserialize = "Maybe<Scalar<Public,Zero>>: serde::de::Deserialize<'de>"))]
     sig: Option<Maybe<Scalar<Public, Zero>>>,

--- a/secp256kfun/Cargo.toml
+++ b/secp256kfun/Cargo.toml
@@ -8,13 +8,11 @@ repository = "https://github.com/LLFourn/secp256kfun"
 documentation = "https://docs.rs/secp256kfun"
 description = "A mid-level secp256k1 library optimized for fun!"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.60"
 categories = ["cryptography", "cryptography::cryptocurrencies"]
 readme = "README.md"
 keywords = ["bitcoin", "secp256k1"]
 
-[package.metadata.docs.rs]
-features = ["all"]
 
 [dependencies]
 digest = "0.10"
@@ -22,7 +20,7 @@ subtle = { package = "subtle-ng", version = "2" }
 rand_core = { version = "0.6" }
 
 # optional
-serde_crate = { package = "serde", version = "1.0",  optional = true, default-features = false, features = ["derive"] }
+serde = { version = "1.0",  optional = true, default-features = false, features = ["derive"] }
 secp256k1 = { version = "0.24", optional = true, default-features = false }
 proptest = { version = "1", optional = true }
 
@@ -42,14 +40,12 @@ criterion = "0.3"
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test = "0.3"
 
-
 [features]
 default = ["std"]
-all = ["std", "serde", "libsecp_compat"]
-alloc = ["serde_crate/alloc"]
+alloc = ["serde?/alloc"]
 std = ["alloc"]
 libsecp_compat = ["secp256k1"]
-serde = [ "serde_crate" ]
+serde = [ "dep:serde", "secp256k1?/serde" ]
 
 [[bench]]
 name = "bench_ecmult"
@@ -58,3 +54,7 @@ harness = false
 [[bench]]
 name = "bench_point"
 harness = false
+
+
+[package.metadata.docs.rs]
+all-features = true

--- a/secp256kfun/Cargo.toml
+++ b/secp256kfun/Cargo.toml
@@ -58,3 +58,4 @@ harness = false
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/secp256kfun/README.md
+++ b/secp256kfun/README.md
@@ -172,6 +172,10 @@ However this situation may improve in future versions.
 [4]: https://github.com/paritytech/libsecp256k1
 [k256]: https://docs.rs/k256/0.10.1/k256/
 
+## MSRV
+
+Minimum supported rust version is `v1.60`. Technically `rustc` only needs to be `v1.56` but we need features from `v.1.60` of cargo.
+
 ## LICENSE
 
 Code is licensed under [`0BSD`](https://opensource.org/licenses/0BSD) except for the code under `secp256kfun/src/vendor` where you will find the licenses for the vendor'd code.

--- a/secp256kfun/src/backend/k256_impl.rs
+++ b/secp256kfun/src/backend/k256_impl.rs
@@ -201,6 +201,7 @@ impl TimeSensitive for ConstantTime {
         base * scalar
     }
 
+    #[cfg(feature = "alloc")]
     fn lincomb_iter<'a, 'b, A: Iterator<Item = &'a Point>, B: Iterator<Item = &'b Scalar>>(
         points: A,
         scalars: B,

--- a/secp256kfun/src/hex.rs
+++ b/secp256kfun/src/hex.rs
@@ -1,13 +1,8 @@
 //! Utility module for hex encoding and decoding
-//XXX: is this actually meant to be this hard??
-#[cfg(all(feature = "alloc", not(feature = "std")))]
+#[cfg(feature = "alloc")]
 use alloc::string::String;
-#[cfg(all(feature = "alloc", not(feature = "std")))]
+#[cfg(feature = "alloc")]
 use alloc::vec::Vec;
-#[cfg(feature = "std")]
-use std::string::String;
-#[cfg(feature = "std")]
-use std::vec::Vec;
 
 use core::fmt;
 /// Error representing a failed conversion from hex into the bytes for the target type.

--- a/secp256kfun/src/lib.rs
+++ b/secp256kfun/src/lib.rs
@@ -42,7 +42,7 @@ pub use slice::Slice;
 #[cfg(feature = "secp256k1")]
 pub extern crate secp256k1;
 #[cfg(feature = "serde")]
-pub extern crate serde_crate as serde;
+pub use serde;
 #[cfg(feature = "libsecp_compat")]
 mod libsecp_compat;
 #[cfg(any(feature = "proptest", test))]

--- a/secp256kfun/src/lib.rs
+++ b/secp256kfun/src/lib.rs
@@ -41,13 +41,18 @@ pub use slice::Slice;
 
 #[cfg(feature = "secp256k1")]
 pub extern crate secp256k1;
+
+/// Re-export `serde`
+#[cfg_attr(docsrs, doc(cfg(feature = "ed25519")))]
 #[cfg(feature = "serde")]
 pub use serde;
+
 #[cfg(feature = "libsecp_compat")]
 mod libsecp_compat;
 #[cfg(any(feature = "proptest", test))]
 mod proptest_impls;
 #[cfg(feature = "proptest")]
+#[cfg_attr(docsrs, doc(cfg(feature = "proptest")))]
 pub extern crate proptest;
 /// The main basepoint for secp256k1 as specified in [_SEC 2: Recommended Elliptic Curve Domain Parameters_] and used in Bitcoin.
 ///

--- a/secp256kfun/src/macros.rs
+++ b/secp256kfun/src/macros.rs
@@ -420,6 +420,7 @@ macro_rules! impl_debug {
 macro_rules! impl_display_serialize {
     (fn to_bytes$(<$($tpl:ident  $(: $tcl:ident)?),*>)?($self:ident : &$type:path) -> $(&)?[u8;$len:literal] $block:block) => {
         #[cfg(feature = "serde")]
+        #[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
         impl$(<$($tpl $(:$tcl)?),*>)? $crate::serde::Serialize for $type {
             fn serialize<Ser: $crate::serde::Serializer>(&self, serializer: Ser) -> Result<Ser::Ok, Ser::Error> {
                 use $crate::serde::ser::SerializeTuple;
@@ -505,6 +506,7 @@ macro_rules! impl_fromstr_deserialize {
         }
 
         #[cfg(feature = "serde")]
+        #[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
         impl<'de, $($($tpl $(: $tcl)?),*)?> $crate::serde::Deserialize<'de> for $type  {
             fn deserialize<Deser: $crate::serde::Deserializer<'de>>(
                 deserializer: Deser,

--- a/secp256kfun/src/marker/secrecy.rs
+++ b/secp256kfun/src/marker/secrecy.rs
@@ -36,20 +36,12 @@ pub trait Secrecy: Default + Clone + PartialEq + Copy + 'static {}
 /// Indicates that the value is secret and therefore makes core operations
 /// executed on it to use  _constant time_ versions of the operations.
 #[derive(Debug, Clone, Default, PartialEq, Copy)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde::Deserialize, serde::Serialize),
-    serde(crate = "serde_crate")
-)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Secret;
 
 /// Indicates that variable time operations may be used on the value.
 #[derive(Debug, Clone, Default, PartialEq, Copy, Eq, Hash)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde::Deserialize, serde::Serialize),
-    serde(crate = "serde_crate")
-)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Public;
 
 impl Secrecy for Secret {}

--- a/sigma_fun/Cargo.toml
+++ b/sigma_fun/Cargo.toml
@@ -3,7 +3,7 @@ name = "sigma_fun"
 version = "0.4.1"
 authors = ["LLFourn <lloyd.fourn@gmail.com>"]
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.60"
 license = "0BSD"
 description = "A framework for making Sigma protocols fun!"
 homepage = "https://github.com/LLFourn/secp256kfun/tree/master/sigma_fun"
@@ -12,15 +12,13 @@ documentation = "https://docs.rs/sigma_fun"
 categories = ["cryptography"]
 readme = "README.md"
 
-[package.metadata.docs.rs]
-features = ["all"]
 
 [dependencies]
 generic-array = "0.14"
 digest = "0.10"
 secp256kfun = { path = "../secp256kfun", version = "0.7.1", default-features = false, optional = true }
 curve25519-dalek = { package = "curve25519-dalek-ng", version = "4", default-features = false, optional = true, features = ["u64_backend"] }
-serde_crate = { package = "serde", version = "1.0", optional = true, default-features = false, features = ["derive"] }
+serde = { package = "serde", version = "1.0", optional = true, default-features = false, features = ["derive"] }
 rand_core = "0.6"
 
 [dev-dependencies]
@@ -32,9 +30,11 @@ proptest = "1"
 rand_chacha = "0.3"
 
 [features]
-all = ["secp256k1", "ed25519", "alloc", "serde"]
 default = ["alloc", "secp256k1"]
-alloc = ["serde_crate/alloc", "secp256kfun/alloc"]
+alloc = ["serde?/alloc", "secp256kfun/alloc"]
 secp256k1 = ["secp256kfun"]
 ed25519 = ["curve25519-dalek"]
-serde = ["serde_crate", "secp256kfun/serde", "curve25519-dalek/serde", "generic-array/serde"]
+serde = ["dep:serde", "secp256kfun/serde", "curve25519-dalek/serde", "generic-array/serde"]
+
+[package.metadata.docs.rs]
+all-features = true

--- a/sigma_fun/src/ext/dl_secp256k1_ed25519_eq.rs
+++ b/sigma_fun/src/ext/dl_secp256k1_ed25519_eq.rs
@@ -63,11 +63,7 @@ pub type CoreProof = And<
 const COMMITMENT_BITS: usize = 252;
 
 /// The proof the a public key on secp256k1 and ed25519 have the same 252-bit secret key.
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_crate::Serialize, serde_crate::Deserialize),
-    serde(crate = "serde_crate")
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Clone, PartialEq)]
 pub struct CrossCurveDLEQProof {
     /// The sum of the Pedersen blindings

--- a/sigma_fun/src/fiat_shamir.rs
+++ b/sigma_fun/src/fiat_shamir.rs
@@ -89,11 +89,7 @@ impl<S: Sigma, T: Transcript<S>> FiatShamir<S, T> {
 /// the underlying group's Sigma protocol but this isn't implemented yet.
 ///
 /// [`FiatShamir`]: crate::FiatShamir
-#[cfg_attr(
-    feature = "serde",
-    derive(serde_crate::Serialize, serde_crate::Deserialize),
-    serde(crate = "serde_crate")
-)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Clone, PartialEq)]
 pub struct CompactProof<S: Sigma> {
     /// C

--- a/sigma_fun/src/lib.rs
+++ b/sigma_fun/src/lib.rs
@@ -21,9 +21,11 @@ extern crate std;
 extern crate alloc;
 
 #[cfg(feature = "secp256k1")]
+#[cfg_attr(docsrs, doc(cfg(feature = "secp256k1")))]
 pub mod secp256k1;
 
 #[cfg(feature = "ed25519")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ed25519")))]
 pub mod ed25519;
 
 mod and;
@@ -34,6 +36,7 @@ pub use eq::Eq;
 #[cfg(feature = "alloc")]
 mod eq_all;
 #[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub use eq_all::EqAll;
 mod or;
 pub use or::*;
@@ -41,6 +44,7 @@ pub use or::*;
 #[cfg(feature = "alloc")]
 mod all;
 #[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 pub use all::All;
 pub mod ext;
 mod transcript;


### PR DESCRIPTION
I've noticed that `secp256kfun` doesn't actually compile with `--no-default-features`. This is weird because we test it. The problem is that it works at the workspace root but if you cd into the directory and run the same command it breaks. According to https://github.com/rust-lang/cargo/issues/4753 this issue as been fixed ages ago but it's happening for me.

So this PR is for investigating this and cleaning up feature flags in general.