### PR TITLE
build(deps): update secp256k1 to 0.24

### DIFF
--- a/ecdsa_fun/Cargo.toml
+++ b/ecdsa_fun/Cargo.toml
@@ -24,7 +24,7 @@ rand_chacha = {  version = "0.3", optional = true }  # needed for adaptor signat
 bincode = { version = "1.0", optional = true }
 
 [dev-dependencies]
-secp256k1 = { default-features = false, version = "0.22", features = ["std"] }
+secp256k1 = { default-features = false, version = "0.24", features = ["std"] }
 secp256kfun = { path = "../secp256kfun", version = "0.7.1", default-features = false, features = ["libsecp_compat"] }
 rand = "0.8"
 criterion = "0.3"

--- a/schnorr_fun/Cargo.toml
+++ b/schnorr_fun/Cargo.toml
@@ -26,7 +26,7 @@ lazy_static = "1.4"
 bincode = "1.0"
 sha2 = "0.10"
 secp256kfun = { path = "../secp256kfun", version = "0.7.1", default-features = false, features = ["alloc", "libsecp_compat", "proptest"] }
-secp256k1 = { version = "0.22", features = ["std", "global-context"]}
+secp256k1 = { version = "0.24", features = ["std", "global-context"]}
 serde_json = "1"
 rand_chacha = { version = "0.3" }
 

--- a/schnorr_fun/benches/bench_schnorr.rs
+++ b/schnorr_fun/benches/bench_schnorr.rs
@@ -8,7 +8,7 @@ use sha2::Sha256;
 const MESSAGE: &'static [u8; 32] = b"hello world you are beautiful!!!";
 
 lazy_static::lazy_static! {
-    static ref SK: Scalar<Secret,NonZero> = Scalar::from_bytes_mod_order(*b"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx").non_zero().unwrap();
+    static ref SK: Scalar<Secret, NonZero> = Scalar::from_bytes_mod_order(*b"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx").non_zero().unwrap();
     static ref schnorr: Schnorr<Sha256, Deterministic<Sha256>> = Schnorr::new(Deterministic::default());
 }
 
@@ -25,7 +25,7 @@ fn sign_schnorr(c: &mut Criterion) {
     {
         use secp256k1::{KeyPair, Message, Secp256k1};
         let secp = Secp256k1::new();
-        let kp = KeyPair::from_secret_key(&secp, SK.clone().into());
+        let kp = KeyPair::from_secret_key(&secp, &SK.clone().into());
         let msg = Message::from_slice(&MESSAGE[..]).unwrap();
         group.bench_function("secp::schnorrsig_sign_no_aux_rand", |b| {
             b.iter(|| {
@@ -57,8 +57,8 @@ fn verify_schnorr(c: &mut Criterion) {
     {
         use secp256k1::{KeyPair, Message, Secp256k1, XOnlyPublicKey};
         let secp = Secp256k1::new();
-        let kp = KeyPair::from_secret_key(&secp, SK.clone().into());
-        let pk = XOnlyPublicKey::from_keypair(&kp);
+        let kp = KeyPair::from_secret_key(&secp, &SK.clone().into());
+        let pk = XOnlyPublicKey::from_keypair(&kp).0;
         let msg = Message::from_slice(&MESSAGE[..]).unwrap();
         let sig = secp.sign_schnorr_no_aux_rand(&msg, &kp);
         group.bench_function("secp::schnorrsig_verify", |b| {

--- a/schnorr_fun/tests/against_c_lib.rs
+++ b/schnorr_fun/tests/against_c_lib.rs
@@ -51,14 +51,13 @@ impl AddTag for Bip340NoAux {
 }
 
 proptest! {
-
     #[test]
     fn deterministic_sigs_are_the_same(
         key in any::<Scalar>(),
         msg in any::<[u8;32]>(),
     ) {
         let secp = SECP256K1;
-        let keypair = secp256k1::KeyPair::from_secret_key(&secp, key.clone().into());
+        let keypair = secp256k1::KeyPair::from_secret_key(&secp, &key.clone().into());
         let secp_msg = secp256k1::Message::from_slice(&msg).unwrap();
         let sig = secp.sign_schnorr_no_aux_rand(&secp_msg, &keypair);
         let schnorr = Schnorr::<Sha256,_>::new(Bip340NoAux::default());
@@ -72,8 +71,8 @@ proptest! {
     #[test]
     fn verify_secp_sigs(key in any::<Scalar>(), msg in any::<[u8;32]>(), aux_rand in any::<[u8;32]>()) {
         let secp = SECP256K1;
-        let keypair = secp256k1::KeyPair::from_secret_key(&secp, key.clone().into());
-        let fun_pk = secp256k1::XOnlyPublicKey::from_keypair(&keypair).into();
+        let keypair = secp256k1::KeyPair::from_secret_key(&secp, &key.clone().into());
+        let fun_pk = secp256k1::XOnlyPublicKey::from_keypair(&keypair).0.into();
         let secp_msg = secp256k1::Message::from_slice(&msg).unwrap();
         let sig = secp.sign_schnorr_with_aux_rand(&secp_msg, &keypair, &aux_rand);
         let schnorr = Schnorr::<Sha256,_>::verify_only();

--- a/secp256kfun/Cargo.toml
+++ b/secp256kfun/Cargo.toml
@@ -23,7 +23,7 @@ rand_core = { version = "0.6" }
 
 # optional
 serde_crate = { package = "serde", version = "1.0",  optional = true, default-features = false, features = ["derive"] }
-secp256k1 = { version = "0.22", optional = true, default-features = false }
+secp256k1 = { version = "0.24", optional = true, default-features = false }
 proptest = { version = "1", optional = true }
 
 [dev-dependencies]
@@ -32,10 +32,10 @@ rand = { version = "0.8" }
 lazy_static = "1.4"
 sha2 = "0.10"
 proptest = "1"
-secp256k1 = { version = "0.22", features = ["std", "global-context"]}
+secp256k1 = { version = "0.24", features = ["std", "global-context"]}
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-secp256k1 = { default-features = false, version = "0.22", features = ["std"] }
+secp256k1 = { version = "0.24", default-features = false, features = ["std"] }
 bincode = "1.0"
 criterion = "0.3"
 


### PR DESCRIPTION
Updates secp256k1 dependency to 0.24, which is the version used in rust-bitcoin 0.29