### PR TITLE
Simplify hash/nonce_gen tagging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Replace `.mark` system with methods for changing each marker type.
 - Make `From<u32>` for `Scalar` regardless of secrecy
 - Merge `AddTag` and `Tagged` into one trait `Tag`
+- Add `NonceRng` impls for `RefCell` and `Mutex`
 
 ## 0.7.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Remove `XOnly` in favor of `Point<EvenY>`
 - Replace `.mark` system with methods for changing each marker type.
 - Make `From<u32>` for `Scalar` regardless of secrecy
+- Merge `AddTag` and `Tagged` into one trait `Tag`
 
 ## 0.7.1
 

--- a/ecdsa_fun/src/adaptor/mod.rs
+++ b/ecdsa_fun/src/adaptor/mod.rs
@@ -69,8 +69,8 @@ use secp256kfun::{
     digest::generic_array::typenum::U32,
     g,
     marker::*,
-    nonce::{AddTag, NonceGen},
-    s, Point, Scalar, G,
+    nonce::{NoNonces, NonceGen},
+    s, Point, Scalar, Tag, G,
 };
 pub use sigma_fun::HashTranscript;
 use sigma_fun::{secp256k1, Eq, FiatShamir, ProverTranscript, Transcript};
@@ -88,7 +88,7 @@ pub struct Adaptor<T, NonceGen> {
 
 impl<T, NG> Default for Adaptor<T, NG>
 where
-    NG: Default + AddTag,
+    NG: Default + Tag,
     T: Transcript<DLEQ> + Default,
 {
     fn default() -> Self {
@@ -96,7 +96,7 @@ where
     }
 }
 
-impl<T: Transcript<DLEQ> + Default, NG: AddTag> Adaptor<T, NG> {
+impl<T: Transcript<DLEQ> + Default, NG: Tag> Adaptor<T, NG> {
     pub fn new(nonce_gen: NG) -> Self {
         let sigma = DLEQ::default();
         Self {
@@ -106,7 +106,7 @@ impl<T: Transcript<DLEQ> + Default, NG: AddTag> Adaptor<T, NG> {
     }
 }
 
-impl<T: Transcript<DLEQ> + Default> Adaptor<T, ()> {
+impl<T: Transcript<DLEQ> + Default> Adaptor<T, NoNonces> {
     /// Create an `Adaptor` instance that can do verification only
     /// # Example
     /// ```
@@ -114,7 +114,7 @@ impl<T: Transcript<DLEQ> + Default> Adaptor<T, ()> {
     /// let adaptor = Adaptor::<HashTranscript<sha2::Sha256>, _>::verify_only();
     /// ```
     pub fn verify_only() -> Self {
-        Self::new(())
+        Self::new(NoNonces)
     }
 }
 
@@ -189,7 +189,7 @@ impl<T: Transcript<DLEQ>, NG> Adaptor<T, NG> {
     /// # Example
     /// ```
     /// # use ecdsa_fun::{ adaptor::{Adaptor, HashTranscript}, fun::Scalar };
-    /// # let adaptor = Adaptor::<HashTranscript::<sha2::Sha256>,()>::default();
+    /// # let adaptor = Adaptor::<HashTranscript::<sha2::Sha256>, _>::verify_only();
     /// let secret_decryption_key = Scalar::random(&mut rand::thread_rng());
     /// let public_encryption_key = adaptor.encryption_key_for(&secret_decryption_key);
     pub fn encryption_key_for(&self, decryption_key: &Scalar) -> Point {

--- a/ecdsa_fun/src/lib.rs
+++ b/ecdsa_fun/src/lib.rs
@@ -15,13 +15,9 @@ mod libsecp_compat;
 #[cfg(feature = "serde")]
 /// Rexport `serde`
 pub use fun::serde;
+use fun::Tag;
 
-use fun::{
-    derive_nonce, g,
-    marker::*,
-    nonce::{AddTag, NonceGen},
-    s, Point, Scalar, G,
-};
+use fun::{derive_nonce, g, marker::*, nonce::NonceGen, s, Point, Scalar, G};
 pub use secp256kfun as fun;
 pub use secp256kfun::nonce;
 mod signature;
@@ -71,10 +67,10 @@ impl<NG> ECDSA<NG> {
     /// [`NonceGen`]: crate::nonce::NonceGen
     pub fn new(nonce_gen: NG) -> Self
     where
-        NG: AddTag,
+        NG: Tag,
     {
         ECDSA {
-            nonce_gen: nonce_gen.add_tag("secp256kfun/ecdsa_fun"),
+            nonce_gen: nonce_gen.tag(b"secp256kfun/ecdsa_fun"),
             enforce_low_s: false,
         }
     }

--- a/ecdsa_fun/tests/adaptor_test_vectors.rs
+++ b/ecdsa_fun/tests/adaptor_test_vectors.rs
@@ -4,6 +4,7 @@ static DLC_SPEC_JSON: &'static str = include_str!("./test_vectors.json");
 use ecdsa_fun::{
     adaptor::{Adaptor, EncryptedSignature, HashTranscript},
     fun::{Point, Scalar},
+    nonce::NoNonces,
     serde, Signature,
 };
 use sha2::Sha256;
@@ -79,7 +80,10 @@ fn run_test_vectors() {
     }
 }
 
-fn run_test_vector(ecdsa_adaptor: &Adaptor<HashTranscript<Sha256>, ()>, t: &Verification) -> bool {
+fn run_test_vector(
+    ecdsa_adaptor: &Adaptor<HashTranscript<Sha256>, NoNonces>,
+    t: &Verification,
+) -> bool {
     if !ecdsa_adaptor.verify_encrypted_signature(
         &t.public_signing_key,
         &t.encryption_key,

--- a/schnorr_fun/benches/bench_schnorr.rs
+++ b/schnorr_fun/benches/bench_schnorr.rs
@@ -1,15 +1,17 @@
 //! This broken and just as a reference until we get proper bip340 benchmarks from proper rust lib
 #![allow(non_upper_case_globals)]
 use criterion::{criterion_group, criterion_main, Criterion};
-use schnorr_fun::{Message, Schnorr};
-use secp256kfun::{marker::*, nonce::Deterministic, Scalar};
+use schnorr_fun::{
+    fun::{marker::*, nonce, Scalar},
+    Message, Schnorr,
+};
 use sha2::Sha256;
 
 const MESSAGE: &'static [u8; 32] = b"hello world you are beautiful!!!";
 
 lazy_static::lazy_static! {
     static ref SK: Scalar<Secret, NonZero> = Scalar::from_bytes_mod_order(*b"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx").non_zero().unwrap();
-    static ref schnorr: Schnorr<Sha256, Deterministic<Sha256>> = Schnorr::new(Deterministic::default());
+    static ref schnorr: Schnorr<Sha256, nonce::Deterministic<Sha256>> = Schnorr::default();
 }
 
 // note schnorr runs against grin's secp256k1 library

--- a/schnorr_fun/src/adaptor/mod.rs
+++ b/schnorr_fun/src/adaptor/mod.rs
@@ -53,8 +53,7 @@ use crate::{
         digest::{generic_array::typenum::U32, Digest},
         g,
         marker::*,
-        nonce::NonceGen,
-        s, Point, Scalar, XOnlyKeyPair, G,
+        nonce, s, Point, Scalar, XOnlyKeyPair, G,
     },
     Message, Schnorr, Signature,
 };
@@ -81,7 +80,7 @@ pub trait EncryptedSign {
 impl<NG, CH> EncryptedSign for Schnorr<CH, NG>
 where
     CH: Digest<OutputSize = U32> + Clone,
-    NG: NonceGen,
+    NG: nonce::NonceGen,
 {
     fn encrypted_sign(
         &self,
@@ -275,7 +274,7 @@ where
 mod test {
 
     use super::*;
-    use crate::nonce::{Deterministic, GlobalRng, Synthetic};
+    use crate::nonce::{GlobalRng, Synthetic};
     use rand::rngs::ThreadRng;
     use secp256kfun::proptest::prelude::*;
     use sha2::Sha256;
@@ -285,7 +284,7 @@ mod test {
     proptest! {
         #[test]
         fn signing_tests_deterministic(secret_key in any::<Scalar>(), decryption_key in any::<Scalar>()) {
-            let schnorr = Schnorr::<Sha256, Deterministic<Sha256>>::default();
+            let schnorr = Schnorr::<Sha256, nonce::Deterministic<Sha256>>::default();
             test_it(schnorr, secret_key, decryption_key);
         }
 
@@ -297,7 +296,7 @@ mod test {
 
     }
 
-    fn test_it<NG: NonceGen>(
+    fn test_it<NG: nonce::NonceGen>(
         schnorr: Schnorr<Sha256, NG>,
         secret_key: Scalar,
         decryption_key: Scalar,

--- a/schnorr_fun/src/frost.rs
+++ b/schnorr_fun/src/frost.rs
@@ -442,7 +442,7 @@ impl<H: Digest<OutputSize = U32> + Clone, NG: NonceGen> Frost<H, NG> {
 
     /// Generate nonces for creating signatures shares.
     ///
-    /// ⚠ You must use a CAREFULLY CHOSEN nonce rng, see [`FrostKey::gen_nonce_rng`]
+    /// ⚠ You must use a CAREFULLY CHOSEN nonce rng, see [`Frost::gen_nonce_rng`]
     pub fn gen_nonce<R: RngCore>(&self, nonce_rng: &mut R) -> NonceKeyPair {
         NonceKeyPair::random(nonce_rng)
     }

--- a/schnorr_fun/src/frost.rs
+++ b/schnorr_fun/src/frost.rs
@@ -122,7 +122,7 @@
 //! that should make sense in most applications:
 //!
 //! ```
-//! use schnorr_fun::{frost, fun::{ Scalar, nonce::{self, AddTag}, derive_nonce_rng }};
+//! use schnorr_fun::{frost, fun::{ Scalar, nonce, Tag, derive_nonce_rng }};
 //! use sha2::Sha256;
 //! use rand_chacha::ChaCha20Rng;
 //!
@@ -130,7 +130,7 @@
 //! # Scalar::random(&mut rand::thread_rng());
 //! let mut poly_rng = derive_nonce_rng! {
 //!     // use Deterministic nonce gen so we reproduce it later
-//!     nonce_gen => nonce::Deterministic::<Sha256>::default().add_tag("my-app-name"),
+//!     nonce_gen => nonce::Deterministic::<Sha256>::default().tag(b"my-app-name/frost/keygen"),
 //!     secret => static_secret_key,
 //!     // session id must be unique for each key generation session
 //!     public => ["forst_key_session_1053"],
@@ -144,7 +144,6 @@
 //! ```
 //!
 //! Note that if a key generation sesssion fails you must always start a fresh session with a different session id.
-#![cfg(feature = "serde")]
 pub use crate::binonce::{Nonce, NonceKeyPair};
 use crate::{Message, Schnorr, Signature};
 use alloc::{collections::BTreeMap, vec::Vec};
@@ -152,9 +151,9 @@ use secp256kfun::{
     derive_nonce_rng,
     digest::{generic_array::typenum::U32, Digest},
     g,
-    hash::{HashAdd, Tagged},
+    hash::{HashAdd, Tag},
     marker::*,
-    nonce::{self, AddTag, NonceGen},
+    nonce::{self, NonceGen},
     rand_core::{RngCore, SeedableRng},
     s, Point, Scalar, G,
 };
@@ -175,15 +174,20 @@ pub struct Frost<H, NG> {
     keygen_id_hash: H,
 }
 
-impl<H: Default + Tagged + Digest<OutputSize = U32>, NG: Default + AddTag> Default
-    for Frost<H, NG>
+impl<H, NG> Default for Frost<H, NG>
+where
+    H: Default + Tag + Digest<OutputSize = U32>,
+    NG: Default + Tag,
 {
     fn default() -> Self {
         Frost::new(Schnorr::default())
     }
 }
 
-impl<H: Tagged, NG> Frost<H, NG> {
+impl<H, NG> Frost<H, NG>
+where
+    H: Tag + Default,
+{
     /// Generate a new Frost context from a Schnorr context.
     ///
     /// # Examples
@@ -197,8 +201,8 @@ impl<H: Tagged, NG> Frost<H, NG> {
     pub fn new(schnorr: Schnorr<H, NG>) -> Self {
         Self {
             schnorr,
-            binding_hash: H::default().tagged(b"frost/binding"),
-            keygen_id_hash: H::default().tagged(b"frost/keygenid"),
+            binding_hash: H::default().tag(b"frost/binding"),
+            keygen_id_hash: H::default().tag(b"frost/keygenid"),
         }
     }
 }
@@ -891,8 +895,10 @@ fn lagrange_lambda(x_j: u32, x_ms: &[u32]) -> Scalar {
 /// use schnorr_fun::frost;
 /// let frost = frost::new_with_deterministic_nonces::<sha2::Sha256>();
 /// ```
-pub fn new_with_deterministic_nonces<H: Tagged + Digest<OutputSize = U32>>(
-) -> Frost<H, nonce::Deterministic<H>> {
+pub fn new_with_deterministic_nonces<H>() -> Frost<H, nonce::Deterministic<H>>
+where
+    H: Tag + Digest<OutputSize = U32> + Default,
+{
     Frost::default()
 }
 
@@ -909,7 +915,7 @@ pub fn new_with_deterministic_nonces<H: Tagged + Digest<OutputSize = U32>>(
 /// ```
 pub fn new_with_synthetic_nonces<H, R>() -> Frost<H, nonce::Synthetic<H, nonce::GlobalRng<R>>>
 where
-    H: Tagged + Digest<OutputSize = U32>,
+    H: Tag + Digest<OutputSize = U32> + Default,
     R: RngCore + Default,
 {
     Frost::default()
@@ -918,9 +924,9 @@ where
 /// Create a Frost instance which does not handle nonce generation.
 ///
 /// You can still sign with this instance but you you will have to generate nonces in your own way.
-pub fn new_without_nonce_generation<H>() -> Frost<H, ()>
+pub fn new_without_nonce_generation<H>() -> Frost<H, nonce::NoNonces>
 where
-    H: Tagged + Digest<OutputSize = U32>,
+    H: Tag + Digest<OutputSize = U32> + Default,
 {
     Frost::default()
 }

--- a/schnorr_fun/src/lib.rs
+++ b/schnorr_fun/src/lib.rs
@@ -43,8 +43,6 @@ mod libsecp_compat;
 #[doc(hidden)]
 macro_rules! test_instance {
     () => {
-        $crate::Schnorr::<sha2::Sha256, _>::new(
-            $crate::nonce::Deterministic::<sha2::Sha256>::default(),
-        )
+        $crate::Schnorr::<sha2::Sha256, secp256kfun::nonce::Deterministic<sha2::Sha256>>::default()
     };
 }

--- a/secp256kfun/Cargo.toml
+++ b/secp256kfun/Cargo.toml
@@ -15,9 +15,9 @@ keywords = ["bitcoin", "secp256k1"]
 
 
 [dependencies]
-digest = "0.10"
-subtle = { package = "subtle-ng", version = "2" }
-rand_core = { version = "0.6" }
+digest = { version = "0.10", default-features = false }
+subtle = { package = "subtle-ng", version = "2", default-features = false }
+rand_core = { version = "0.6", default-features = false }
 
 # optional
 serde = { version = "1.0",  optional = true, default-features = false, features = ["derive"] }
@@ -42,8 +42,8 @@ wasm-bindgen-test = "0.3"
 
 [features]
 default = ["std"]
-alloc = ["serde?/alloc"]
-std = ["alloc"]
+alloc = ["serde?/alloc", "digest/alloc"]
+std = ["alloc", "subtle/std", "digest/std"]
 libsecp_compat = ["secp256k1"]
 serde = [ "dep:serde", "secp256k1?/serde" ]
 

--- a/secp256kfun/examples/quick_bip340.rs
+++ b/secp256kfun/examples/quick_bip340.rs
@@ -3,7 +3,7 @@
 use rand::thread_rng;
 use secp256kfun::{
     g,
-    hash::{HashAdd, Tagged},
+    hash::{HashAdd, Tag},
     marker::*,
     s, Point, Scalar, G,
 };
@@ -16,7 +16,7 @@ pub struct Signature {
 }
 
 lazy_static::lazy_static! {
-    pub static ref BIP340_CHALLENGE: Sha256 = Sha256::default().tagged(b"BIP0340/challenge");
+    pub static ref BIP340_CHALLENGE: Sha256 = Sha256::default().tag(b"BIP0340/challenge");
 }
 
 pub fn keygen() -> (Scalar, Point<EvenY>) {

--- a/secp256kfun/src/lib.rs
+++ b/secp256kfun/src/lib.rs
@@ -43,7 +43,7 @@ pub use slice::Slice;
 pub extern crate secp256k1;
 
 /// Re-export `serde`
-#[cfg_attr(docsrs, doc(cfg(feature = "ed25519")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 #[cfg(feature = "serde")]
 pub use serde;
 
@@ -69,3 +69,6 @@ pub extern crate proptest;
 ///[`BasePoint`]: crate::marker::BasePoint
 pub static G: &'static Point<marker::BasePoint, marker::Public, marker::NonZero> =
     &Point::from_inner(backend::G_POINT, marker::BasePoint(backend::G_TABLE));
+
+// it is applied to nonce generators too so export at root
+pub use hash::Tag;

--- a/secp256kfun/src/macros.rs
+++ b/secp256kfun/src/macros.rs
@@ -296,10 +296,10 @@ macro_rules! g {
 /// on the cryptographic scheme and is crucial to get right.
 ///
 /// ```
-/// use secp256kfun::{Scalar, derive_nonce, nonce::AddTag, nonce::{NonceGen,Deterministic}};
+/// use secp256kfun::{Scalar, derive_nonce, Tag, nonce};
 /// use sha2::Sha256;
 /// let secret_scalar = Scalar::random(&mut rand::thread_rng());
-/// let nonce_gen = Deterministic::<Sha256>::default().add_tag("my-protocol");
+/// let nonce_gen = nonce::Deterministic::<Sha256>::default().tag(b"my-protocol");
 /// let r = derive_nonce!(
 ///     nonce_gen => nonce_gen,
 ///     secret => &secret_scalar,
@@ -331,10 +331,10 @@ macro_rules! derive_nonce {
 /// # Examples
 ///
 /// ```
-/// use secp256kfun::{Scalar, derive_nonce_rng, nonce::AddTag, nonce::{NonceGen,Deterministic}};
+/// use secp256kfun::{Scalar, derive_nonce_rng, Tag, nonce};
 /// use sha2::Sha256;
 /// let secret_scalar = Scalar::random(&mut rand::thread_rng());
-/// let nonce_gen = Deterministic::<Sha256>::default().add_tag("my-protocol");
+/// let nonce_gen = nonce::Deterministic::<Sha256>::default().tag(b"my-protocol");
 /// let mut rng = derive_nonce_rng!(
 ///     nonce_gen => nonce_gen,
 ///     secret => &secret_scalar,

--- a/secp256kfun/src/nonce.rs
+++ b/secp256kfun/src/nonce.rs
@@ -121,14 +121,12 @@ pub struct GlobalRng<R> {
 ///
 /// ```
 /// use secp256kfun::{
-///     nonce::AddTag,
 ///     nonce::{Deterministic, NonceGen},
+///     Tag,
 /// };
 /// use sha2::Sha256;
-/// let nonce_gen = Deterministic::<Sha256>::default()
-///     .add_tag("BIP0340"); // To create [BIP-340] signatures.
+/// let nonce_gen = Deterministic::<Sha256>::default().tag(b"BIP0340");
 /// ```
-/// [BIP-340]: https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki
 /// [`Synthetic`]: crate::nonce::Synthetic
 #[derive(Clone, Debug, Default)]
 pub struct Deterministic<H> {
@@ -159,26 +157,36 @@ pub trait NonceGen {
     fn begin_derivation(&self, secret: &Scalar) -> Self::Hash;
 }
 
-impl<H: Tagged + Digest<OutputSize = U32> + Clone> NonceGen for Deterministic<H> {
+impl<H: Digest<OutputSize = U32> + Clone> NonceGen for Deterministic<H> {
     type Hash = H;
     fn begin_derivation(&self, secret: &Scalar) -> Self::Hash {
         self.nonce_hash.clone().add(secret)
     }
 }
 
-impl<H: Tagged> AddTag for Deterministic<H> {
-    fn add_tag(self, tag: &str) -> Self {
+#[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Default)]
+/// Convenience type that is [`Tag`] but is not a [`NonceGen`].
+pub struct NoNonces;
+
+impl<H: Tag> Tag for Deterministic<H> {
+    fn tag_vectored<'a>(self, tag: impl Iterator<Item = &'a [u8]> + Clone) -> Self {
         Self {
             nonce_hash: self
                 .nonce_hash
-                .tagged(&[tag.as_bytes(), b"/nonce"].concat()),
+                .tag_vectored(tag.chain(core::iter::once(b"/nonce".as_slice()))),
         }
+    }
+}
+
+impl Tag for NoNonces {
+    fn tag_vectored<'a>(self, _tag: impl IntoIterator<Item = &'a [u8]>) -> Self {
+        self
     }
 }
 
 impl<H, R> NonceGen for Synthetic<H, R>
 where
-    H: Tagged + Digest<OutputSize = U32> + Clone,
+    H: Tag + Digest<OutputSize = U32> + Clone,
     R: NonceRng,
 {
     type Hash = H;
@@ -200,37 +208,17 @@ where
     }
 }
 
-impl<H: Tagged, R> AddTag for Synthetic<H, R> {
-    fn add_tag(self, tag: &str) -> Self {
+impl<H: Tag, R> Tag for Synthetic<H, R> {
+    fn tag_vectored<'a>(self, tag: impl Iterator<Item = &'a [u8]> + Clone) -> Self {
         Self {
             nonce_hash: self
                 .nonce_hash
-                .tagged(&[tag.as_bytes(), b"/nonce"].concat()),
-            aux_hash: self.aux_hash.tagged(&[tag.as_bytes(), b"/aux"].concat()),
+                .tag_vectored(tag.clone().chain(core::iter::once(b"/nonce".as_slice()))),
+            aux_hash: self
+                .aux_hash
+                .tag_vectored(tag.chain(core::iter::once(b"/aux".as_slice()))),
             rng: self.rng,
         }
-    }
-}
-
-/// Trait for things that can domain separate themselves.
-pub trait AddTag {
-    /// Tells the invocant to return a new version of itself modified with the
-    /// tag. This is to ensure that a `NonceGen` does not produce the
-    /// same outputs for two different tags even if they have the same
-    /// public inputs.
-    ///
-    /// Internally, the implementations provided in this library use the scheme described in [BIP-340].
-    ///
-    /// [BIP-340]: https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki
-    fn add_tag(self, tag: &str) -> Self;
-}
-
-/// AddTag is implemented for () so you can use implement things generically for
-/// `AddTag` even for things that have some field set to () (for example
-/// `NonceGen` when you're doing verification only).
-impl AddTag for () {
-    fn add_tag(self, _tag: &str) -> Self {
-        ()
     }
 }
 
@@ -254,8 +242,8 @@ mod test {
     #[test]
     fn deterministic_tests() {
         use core::str::FromStr;
-        let nonce_gen_1 = Deterministic::<Sha256>::default().add_tag("PROTO_ONE");
-        let nonce_gen_2 = Deterministic::<Sha256>::default().add_tag("PROTO_TWO");
+        let nonce_gen_1 = Deterministic::<Sha256>::default().tag(b"PROTO_ONE");
+        let nonce_gen_2 = Deterministic::<Sha256>::default().tag(b"PROTO_TWO");
 
         let one = s!(1);
         let two = s!(2);
@@ -264,8 +252,8 @@ mod test {
         assert_ne!(get_nonce!(nonce_gen_1, one), get_nonce!(nonce_gen_1, two));
         assert_ne!(get_nonce!(nonce_gen_1, one), get_nonce!(nonce_gen_2, one));
 
-        let app_nonce_gen_1 = nonce_gen_1.clone().add_tag("MY_APP");
-        let app_nonce_gen_2 = nonce_gen_2.clone().add_tag("MY_APP");
+        let app_nonce_gen_1 = nonce_gen_1.clone().tag(b"MY_APP");
+        let app_nonce_gen_2 = nonce_gen_2.clone().tag(b"MY_APP");
 
         assert_ne!(
             get_nonce!(nonce_gen_1, one),
@@ -288,7 +276,7 @@ mod test {
 
     #[test]
     fn synthetic_nonce_gen_is_random() {
-        let nonce_gen_1 = Synthetic::<Sha256, GlobalRng<ThreadRng>>::default().add_tag("PROTO_ONE");
+        let nonce_gen_1 = Synthetic::<Sha256, GlobalRng<ThreadRng>>::default().tag(b"PROTO_ONE");
 
         let one = s!(1);
         assert_ne!(get_nonce!(nonce_gen_1, one), get_nonce!(nonce_gen_1, one));


### PR DESCRIPTION
-  Before there was two traits `AddTag` and `Tagged` that did basically the same thing. `AddTag` was used for `NonceGen`s while `Tagged` was used for hashes. Merging them into one `Tag` trait seems to have solved more friction than it created and seems to be less confusing.
- secp256kfun will now actually compile without an allocator. A dependency was loading `alloc` even when we didn't. Fixing this revealed that we *were* actually using `alloc` features without intendeding to.
- Also added some new `NonceRng` implementations for `RefCell`s and `Mutex`s of rngs while I was around in this code.