### PR TITLE
Update musig spec tests

### DIFF
--- a/schnorr_fun/tests/musig/sign_verify_vectors.json
+++ b/schnorr_fun/tests/musig/sign_verify_vectors.json
@@ -6,7 +6,10 @@
         "02DFF1D77F2A671C5F36183726DB2341BE58FEAE1DA2DECED843240F7B502BA661",
         "020000000000000000000000000000000000000000000000000000000000000007"
     ],
-    "secnonce": "508B81A611F100A6B2B6B29656590898AF488BCF2E1F55CF22E5CFB84421FE61FA27FD49B1D50085B481285E1CA205D55C82CC1B31FF5CD54A489829355901F7",
+    "secnonces": [
+        "508B81A611F100A6B2B6B29656590898AF488BCF2E1F55CF22E5CFB84421FE61FA27FD49B1D50085B481285E1CA205D55C82CC1B31FF5CD54A489829355901F703935F972DA013F80AE011890FA89B67A27B7BE6CCB24D3274D18B2D4067F261A9",
+        "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003935F972DA013F80AE011890FA89B67A27B7BE6CCB24D3274D18B2D4067F261A9"
+    ],
     "pnonces": [
         "0337C87821AFD50A8644D820A8F3E02E499C931865C2360FB43D0A0D20DAFE07EA0287BF891D2A6DEAEBADC909352AA9405D1428C15F4B75F04DAE642A95C2548480",
         "0279BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F817980279BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798",
@@ -23,7 +26,8 @@
     ],
     "msgs": [
         "F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF",
-        ""
+        "",
+        "2626262626262626262626262626262626262626262626262626262626262626262626262626"
     ],
     "valid_test_cases": [
         {
@@ -67,13 +71,34 @@
             "signer_index": 0,
             "expected": "D7D63FFD644CCDA4E62BC2BC0B1D02DD32A1DC3030E155195810231D1037D82D",
             "comment": "Empty message"
+        },
+        {
+            "key_indices": [0, 1, 2],
+            "nonce_indices": [0, 1, 2],
+            "aggnonce_index": 0,
+            "msg_index": 2,
+            "signer_index": 0,
+            "expected": "E184351828DA5094A97C79CABDAAA0BFB87608C32E8829A4DF5340A6F243B78C",
+            "comment": "38-byte message"
         }
     ],
     "sign_error_test_cases": [
         {
+            "key_indices": [1, 2],
+            "aggnonce_index": 0,
+            "msg_index": 0,
+            "secnonce_index": 0,
+            "error": {
+                "type": "value",
+                "message": "The signer's pubkey must be included in the list of pubkeys."
+            },
+            "comment": "The signers pubkey is not in the list of pubkeys"
+        },
+        {
             "key_indices": [1, 0, 3],
             "aggnonce_index": 0,
             "msg_index": 0,
+            "secnonce_index": 0,
             "error": {
                 "type": "invalid_contribution",
                 "signer": 2,
@@ -85,6 +110,7 @@
             "key_indices": [1, 2, 0],
             "aggnonce_index": 2,
             "msg_index": 0,
+            "secnonce_index": 0,
             "error": {
                 "type": "invalid_contribution",
                 "signer": null,
@@ -96,6 +122,7 @@
             "key_indices": [1, 2, 0],
             "aggnonce_index": 3,
             "msg_index": 0,
+            "secnonce_index": 0,
             "error": {
                 "type": "invalid_contribution",
                 "signer": null,
@@ -107,12 +134,25 @@
             "key_indices": [1, 2, 0],
             "aggnonce_index": 4,
             "msg_index": 0,
+            "secnonce_index": 0,
             "error": {
                 "type": "invalid_contribution",
                 "signer": null,
                 "contrib": "aggnonce"
             },
             "comment": "Aggregate nonce is invalid because second half exceeds field size"
+        },
+        {
+            "key_indices": [0, 1, 2],
+            "aggnonce_index": 0,
+            "msg_index": 0,
+            "signer_index": 0,
+            "secnonce_index": 1,
+            "error": {
+                "type": "value",
+                "message": "first secnonce value is out of range."
+            },
+            "comment": "Secnonce is invalid which may indicate nonce reuse"
         }
     ],
     "verify_fail_test_cases": [

--- a/schnorr_fun/tests/musig/tweak_vectors.json
+++ b/schnorr_fun/tests/musig/tweak_vectors.json
@@ -5,7 +5,7 @@
         "02F9308A019258C31049344F85F89D5229B531C845836F99B08601F113BCE036F9",
         "02DFF1D77F2A671C5F36183726DB2341BE58FEAE1DA2DECED843240F7B502BA659"
     ],
-    "secnonce": "508B81A611F100A6B2B6B29656590898AF488BCF2E1F55CF22E5CFB84421FE61FA27FD49B1D50085B481285E1CA205D55C82CC1B31FF5CD54A489829355901F7",
+    "secnonce": "508B81A611F100A6B2B6B29656590898AF488BCF2E1F55CF22E5CFB84421FE61FA27FD49B1D50085B481285E1CA205D55C82CC1B31FF5CD54A489829355901F703935F972DA013F80AE011890FA89B67A27B7BE6CCB24D3274D18B2D4067F261A9",
     "pnonces": [
         "0337C87821AFD50A8644D820A8F3E02E499C931865C2360FB43D0A0D20DAFE07EA0287BF891D2A6DEAEBADC909352AA9405D1428C15F4B75F04DAE642A95C2548480",
         "0279BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F817980279BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798",
@@ -52,10 +52,19 @@
             "key_indices": [1, 2, 0],
             "nonce_indices": [1, 2, 0],
             "tweak_indices": [0, 1, 2, 3],
+            "is_xonly": [false, false, true, true],
+            "signer_index": 2,
+            "expected": "45ABD206E61E3DF2EC9E264A6FEC8292141A633C28586388235541F9ADE75435",
+            "comment": "Four tweaks: plain, plain, x-only, x-only."
+        },
+        {
+            "key_indices": [1, 2, 0],
+            "nonce_indices": [1, 2, 0],
+            "tweak_indices": [0, 1, 2, 3],
             "is_xonly": [true, false, true, false],
             "signer_index": 2,
             "expected": "B255FDCAC27B40C7CE7848E2D3B7BF5EA0ED756DA81565AC804CCCA3E1D5D239",
-            "comment": "Four tweaks: x-only, plain, x-only, plain"
+            "comment": "Four tweaks: x-only, plain, x-only, plain. If an implementation prohibits applying plain tweaks after x-only tweaks, it can skip this test vector or return an error."
         }
     ],
     "error_test_cases": [


### PR DESCRIPTION
to the latest version of the draft

This only updates the ones we were using. See #141 