### PR TITLE
Add clippy and resolve suggestions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,10 @@ on:
       - master
   pull_request:
 
+# Make sure CI fails on all warnings, including Clippy lints
+env:
+    RUSTFLAGS: "-Dwarnings"
+
 jobs:
 
   fmt:
@@ -24,6 +28,14 @@ jobs:
         with:
           command: fmt
           args: --all -- --check
+
+  clippy_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Clippy
+        run: cargo clippy --all-targets --all-features
+
 
   # We want to test stable on multiple platforms with --all-features
   test:

--- a/ecdsa_fun/benches/bench_ecdsa.rs
+++ b/ecdsa_fun/benches/bench_ecdsa.rs
@@ -2,7 +2,7 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use secp256kfun::{marker::*, nonce::Deterministic, secp256k1, Scalar};
 use sha2::Sha256;
 
-const MESSAGE: &'static [u8; 32] = b"hello world you are beautiful!!!";
+const MESSAGE: &[u8; 32] = b"hello world you are beautiful!!!";
 
 lazy_static::lazy_static! {
     static ref SK: Scalar = Scalar::from_bytes_mod_order(*b"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx").non_zero().unwrap();

--- a/ecdsa_fun/src/adaptor/mod.rs
+++ b/ecdsa_fun/src/adaptor/mod.rs
@@ -143,7 +143,7 @@ impl<T: Transcript<DLEQ>, NG> Adaptor<T, NG> {
     {
         let x = signing_key;
         let Y = encryption_key;
-        let m = Scalar::<Public, _>::from_bytes_mod_order(message.clone());
+        let m = Scalar::<Public, _>::from_bytes_mod_order(*message);
         let mut rng = derive_nonce_rng!(
             nonce_gen => self.ecdsa.nonce_gen,
             secret => x,
@@ -210,7 +210,7 @@ impl<T: Transcript<DLEQ>, NG> Adaptor<T, NG> {
     ) -> bool {
         let X = verification_key;
         let Y = encryption_key;
-        let m = Scalar::<Public, _>::from_bytes_mod_order(message_hash.clone());
+        let m = Scalar::<Public, _>::from_bytes_mod_order(*message_hash);
         let EncryptedSignature(EncryptedSignatureInternal {
             R,
             R_hat,
@@ -220,7 +220,7 @@ impl<T: Transcript<DLEQ>, NG> Adaptor<T, NG> {
 
         if !self
             .dleq_proof_system
-            .verify(&(*R_hat, (*Y, R.point)), &proof)
+            .verify(&(*R_hat, (*Y, R.point)), proof)
         {
             return false;
         }
@@ -329,7 +329,7 @@ mod test {
             let signature = ecdsa_adaptor.decrypt_signature(&decryption_key, ciphertext.clone());
             assert!(ecdsa_adaptor
                 .ecdsa
-                .verify(&verification_key, &msg, &signature));
+                .verify(&verification_key, msg, &signature));
 
             let recoverd_decryption_sk = ecdsa_adaptor
                 .recover_decryption_key(&encryption_key, &signature, &ciphertext)

--- a/ecdsa_fun/src/lib.rs
+++ b/ecdsa_fun/src/lib.rs
@@ -120,7 +120,7 @@ impl<NG> ECDSA<NG> {
             return false;
         }
 
-        let m = Scalar::<Public, _>::from_bytes_mod_order(message.clone()).public();
+        let m = Scalar::<Public, _>::from_bytes_mod_order(*message).public();
         let s_inv = s.invert();
 
         g!((s_inv * m) * G + (s_inv * R_x) * verification_key)
@@ -162,7 +162,7 @@ impl<NG: NonceGen> ECDSA<NG> {
     /// ```
     pub fn sign(&self, secret_key: &Scalar, message_hash: &[u8; 32]) -> Signature {
         let x = secret_key;
-        let m = Scalar::<Public, _>::from_bytes_mod_order(message_hash.clone()).public();
+        let m = Scalar::<Public, _>::from_bytes_mod_order(*message_hash).public();
         let r = derive_nonce!(
             nonce_gen => self.nonce_gen,
             secret => x,

--- a/ecdsa_fun/tests/adaptor_test_vectors.rs
+++ b/ecdsa_fun/tests/adaptor_test_vectors.rs
@@ -1,6 +1,6 @@
 #![cfg(all(feature = "serde", feature = "alloc", feature = "adaptor"))]
 
-static DLC_SPEC_JSON: &'static str = include_str!("./test_vectors.json");
+static DLC_SPEC_JSON: &str = include_str!("./test_vectors.json");
 use ecdsa_fun::{
     adaptor::{Adaptor, EncryptedSignature, HashTranscript},
     fun::{Point, Scalar},

--- a/schnorr_fun/benches/bench_schnorr.rs
+++ b/schnorr_fun/benches/bench_schnorr.rs
@@ -7,7 +7,7 @@ use schnorr_fun::{
 };
 use sha2::Sha256;
 
-const MESSAGE: &'static [u8; 32] = b"hello world you are beautiful!!!";
+const MESSAGE: &[u8; 32] = b"hello world you are beautiful!!!";
 
 lazy_static::lazy_static! {
     static ref SK: Scalar<Secret, NonZero> = Scalar::from_bytes_mod_order(*b"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx").non_zero().unwrap();
@@ -45,13 +45,13 @@ fn verify_schnorr(c: &mut Criterion) {
         let sig = schnorr.sign(&keypair, message);
         let verification_key = &keypair.public_key();
         group.bench_function("fun::schnorr_verify", |b| {
-            b.iter(|| schnorr.verify(&verification_key, message, &sig))
+            b.iter(|| schnorr.verify(verification_key, message, &sig))
         });
 
         {
             let sig = sig.clone().set_secrecy::<Secret>();
             group.bench_function("fun::schnorr_verify_ct", |b| {
-                b.iter(|| schnorr.verify(&verification_key, message, &sig))
+                b.iter(|| schnorr.verify(verification_key, message, &sig))
             });
         }
     }

--- a/schnorr_fun/src/adaptor/mod.rs
+++ b/schnorr_fun/src/adaptor/mod.rs
@@ -216,7 +216,7 @@ where
         // !needs_negation => R_hat = R - Y
         let R_hat = g!(R + { Y.conditional_negate(!needs_negation) });
 
-        let c = self.challenge(R, &X, message);
+        let c = self.challenge(R, X, message);
 
         R_hat == g!(s_hat * G - c * X)
     }
@@ -317,8 +317,7 @@ mod test {
         ));
 
         let decryption_key = decryption_key.public();
-        let signature =
-            schnorr.decrypt_signature(decryption_key.clone(), encrypted_signature.clone());
+        let signature = schnorr.decrypt_signature(decryption_key, encrypted_signature.clone());
         assert!(schnorr.verify(&verification_key, message, &signature));
         let rec_decryption_key = schnorr
             .recover_decryption_key(&encryption_key, &encrypted_signature, &signature)

--- a/schnorr_fun/src/lib.rs
+++ b/schnorr_fun/src/lib.rs
@@ -6,7 +6,7 @@
 #![warn(missing_docs)]
 
 #[cfg(feature = "alloc")]
-#[allow(unused)]
+#[allow(unused_imports)]
 #[macro_use]
 extern crate alloc;
 

--- a/schnorr_fun/src/libsecp_compat.rs
+++ b/schnorr_fun/src/libsecp_compat.rs
@@ -8,6 +8,6 @@ impl From<crate::Signature> for schnorr::Signature {
 
 impl From<schnorr::Signature> for crate::Signature {
     fn from(sig: schnorr::Signature) -> Self {
-        crate::Signature::from_bytes(sig.as_ref().clone()).unwrap()
+        crate::Signature::from_bytes(*sig.as_ref()).unwrap()
     }
 }

--- a/schnorr_fun/src/message.rs
+++ b/schnorr_fun/src/message.rs
@@ -12,7 +12,7 @@ pub struct Message<'a, S = Public> {
     pub app_tag: Option<&'static str>,
 }
 
-impl<'a, 'b, S: Secrecy> Message<'a, S> {
+impl<'a, S: Secrecy> Message<'a, S> {
     /// Create a raw message with no `app_tag`. The message bytes will be passed straight into the
     /// challenge hash. Usually, you only use this when signing a pre-hashed message.
     pub fn raw(bytes: &'a [u8]) -> Self {
@@ -35,6 +35,11 @@ impl<'a, 'b, S: Secrecy> Message<'a, S> {
             bytes: Slice::from(bytes),
             app_tag: Some(app_tag),
         }
+    }
+
+    /// Check if the message is empty with zero length
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
     }
 
     /// Length of the message as it is hashed

--- a/schnorr_fun/src/schnorr.rs
+++ b/schnorr_fun/src/schnorr.rs
@@ -140,7 +140,7 @@ where
             public => [X, message]
         );
 
-        let R = Point::even_y_from_scalar_mul(&G, &mut r);
+        let R = Point::even_y_from_scalar_mul(G, &mut r);
         let c = self.challenge(&R, &X, message);
         let s = s!(r + c * x).public();
 
@@ -195,7 +195,7 @@ impl<NG, CH: Digest<OutputSize = U32> + Clone> Schnorr<CH, NG> {
         m: Message<'_, S>,
     ) -> Scalar<S, Zero> {
         let hash = self.challenge_hash.clone();
-        let challenge = Scalar::from_hash(hash.add(R).add(X).add(&m));
+        let challenge = Scalar::from_hash(hash.add(R).add(X).add(m));
 
         challenge
             // Since the challenge pre-image is adversarially controlled we

--- a/schnorr_fun/tests/musig_keyagg.rs
+++ b/schnorr_fun/tests/musig_keyagg.rs
@@ -3,7 +3,7 @@ use schnorr_fun::{
     fun::{marker::*, Point, Scalar},
     musig, serde,
 };
-static TEST_JSON: &'static str = include_str!("musig/key_agg_vectors.json");
+static TEST_JSON: &str = include_str!("musig/key_agg_vectors.json");
 
 #[derive(serde::Deserialize, Clone, Copy, Debug)]
 #[serde(crate = "self::serde", untagged)]
@@ -16,7 +16,7 @@ impl<T> Maybe<T> {
     fn unwrap(self) -> T {
         match self {
             Maybe::Valid(t) => t,
-            Maybe::Invalid(string) => panic!("unwrapped an invalid Maybe: {}", string),
+            Maybe::Invalid(string) => panic!("unwrapped an invalid Maybe: {string}"),
         }
     }
 }
@@ -80,14 +80,14 @@ fn run_test(test_cases: &TestCases, test_case: &TestCase) {
 
     let mut tweak_is_xonly = test_case.is_xonly.clone();
 
-    while tweak_is_xonly.get(0) == Some(&false) {
+    while tweak_is_xonly.first() == Some(&false) {
         tweak_is_xonly.remove(0);
         agg_key = agg_key.tweak(tweaks.next().unwrap()).unwrap();
     }
 
     let mut agg_key = agg_key.into_xonly_key();
 
-    while tweak_is_xonly.get(0) == Some(&true) {
+    while tweak_is_xonly.first() == Some(&true) {
         tweak_is_xonly.remove(0);
         agg_key = agg_key.tweak(tweaks.next().unwrap()).unwrap();
     }

--- a/schnorr_fun/tests/musig_sign_verify.rs
+++ b/schnorr_fun/tests/musig_sign_verify.rs
@@ -5,7 +5,7 @@ use schnorr_fun::{
     musig::{self, NonceKeyPair},
     serde, Message,
 };
-static TEST_JSON: &'static str = include_str!("musig/sign_verify_vectors.json");
+static TEST_JSON: &str = include_str!("musig/sign_verify_vectors.json");
 use secp256kfun::hex;
 
 #[derive(schnorr_fun::serde::Deserialize, Clone, Copy, Debug)]
@@ -19,7 +19,7 @@ impl<T> Maybe<T> {
     fn unwrap(self) -> T {
         match self {
             Maybe::Valid(t) => t,
-            Maybe::Invalid(string) => panic!("unwrapped an invalid Maybe: {}", string),
+            Maybe::Invalid(string) => panic!("unwrapped an invalid Maybe: {string}"),
         }
     }
 }

--- a/secp256kfun/examples/quick_bip340.rs
+++ b/secp256kfun/examples/quick_bip340.rs
@@ -29,7 +29,7 @@ pub fn sign(keypair: &(Scalar, Point<EvenY>), message: &[u8]) -> Signature {
     let (x, X) = keypair;
     let mut r = Scalar::random(&mut thread_rng());
     let R = Point::even_y_from_scalar_mul(G, &mut r);
-    let c = Scalar::from_hash(BIP340_CHALLENGE.clone().add(&R).add(X).add(message));
+    let c = Scalar::from_hash(BIP340_CHALLENGE.clone().add(R).add(X).add(message));
     let s = s!(r + c * x);
 
     Signature { R, s: s.public() }

--- a/secp256kfun/src/backend/k256_impl.rs
+++ b/secp256kfun/src/backend/k256_impl.rs
@@ -33,7 +33,7 @@ impl BackendScalar for Scalar {
     }
 
     fn to_bytes(&self) -> [u8; 32] {
-        self.to_bytes().into()
+        Scalar::to_bytes(self).into()
     }
 }
 

--- a/secp256kfun/src/backend/k256_impl.rs
+++ b/secp256kfun/src/backend/k256_impl.rs
@@ -133,7 +133,7 @@ impl TimeSensitive for ConstantTime {
 
     fn norm_point_sub_point(lhs: &Point, rhs: &Point) -> Point {
         let lhs = norm_point_to_affine(lhs);
-        &rhs.neg() + &lhs
+        rhs.neg() + lhs
     }
 
     fn norm_point_neg(point: &mut Point) {
@@ -340,7 +340,7 @@ impl VariableTime {
         if point.is_identity().into() {
             return false;
         }
-        let mut point = point.clone();
+        let mut point = *point;
         Self::point_normalize(&mut point);
         Scalar::from_bytes_reduced(&point.x.to_bytes()).eq(scalar)
     }

--- a/secp256kfun/src/backend/mod.rs
+++ b/secp256kfun/src/backend/mod.rs
@@ -29,7 +29,7 @@ pub trait TimeSensitive {
     fn point_add_point(lhs: &Point, rhs: &Point) -> Point;
     fn point_add_norm_point(lhs: &Point, rhs: &Point) -> Point;
     fn point_sub_point(lhs: &Point, rhs: &Point) -> Point {
-        let mut rhs = rhs.clone();
+        let mut rhs = *rhs;
         Self::point_neg(&mut rhs);
         Self::point_add_point(lhs, &rhs)
     }

--- a/secp256kfun/src/hash.rs
+++ b/secp256kfun/src/hash.rs
@@ -103,7 +103,7 @@ pub trait HashInto {
 
 impl HashInto for u8 {
     fn hash_into(self, hash: &mut impl digest::Digest) {
-        hash.update(&[self])
+        hash.update([self])
     }
 }
 

--- a/secp256kfun/src/hex.rs
+++ b/secp256kfun/src/hex.rs
@@ -52,7 +52,7 @@ pub fn encode(bytes: &[u8]) -> String {
     use core::fmt::Write;
     let mut hex = String::new();
     for byte in bytes {
-        write!(hex, "{:02x}", byte).unwrap()
+        write!(hex, "{byte:02x}").unwrap()
     }
     hex
 }

--- a/secp256kfun/src/keypair.rs
+++ b/secp256kfun/src/keypair.rs
@@ -85,7 +85,7 @@ impl XOnlyKeyPair {
     /// [`Point`]: crate::Point
     /// [`EvenY`]: crate::marker::EvenY
     pub fn new(mut secret_key: Scalar) -> Self {
-        let pk = Point::even_y_from_scalar_mul(&G, &mut secret_key);
+        let pk = Point::even_y_from_scalar_mul(G, &mut secret_key);
         Self { sk: secret_key, pk }
     }
 

--- a/secp256kfun/src/lib.rs
+++ b/secp256kfun/src/lib.rs
@@ -68,7 +68,7 @@ pub extern crate proptest;
 ///
 ///[_SEC 2: Recommended Elliptic Curve Domain Parameters_]: https://www.secg.org/sec2-v2.pdf
 ///[`BasePoint`]: crate::marker::BasePoint
-pub static G: &'static Point<marker::BasePoint, marker::Public, marker::NonZero> =
+pub static G: &Point<marker::BasePoint, marker::Public, marker::NonZero> =
     &Point::from_inner(backend::G_POINT, marker::BasePoint);
 
 // it is applied to nonce generators too so export at root

--- a/secp256kfun/src/macros.rs
+++ b/secp256kfun/src/macros.rs
@@ -472,7 +472,6 @@ macro_rules! impl_display_debug_serialize {
 /// Implements Display, FromStr, Serialize and Deserialize for something that
 /// can be represented as a fixed length byte array
 #[macro_export]
-#[cfg_attr(rustfmt, rustfmt::skip)]
 #[doc(hidden)]
 macro_rules! impl_fromstr_deserialize {
     (

--- a/secp256kfun/src/nonce.rs
+++ b/secp256kfun/src/nonce.rs
@@ -271,7 +271,7 @@ mod test {
         assert_ne!(get_nonce!(nonce_gen_1, one), get_nonce!(nonce_gen_2, one));
 
         let app_nonce_gen_1 = nonce_gen_1.clone().tag(b"MY_APP");
-        let app_nonce_gen_2 = nonce_gen_2.clone().tag(b"MY_APP");
+        let app_nonce_gen_2 = nonce_gen_2.tag(b"MY_APP");
 
         assert_ne!(
             get_nonce!(nonce_gen_1, one),

--- a/secp256kfun/src/op.rs
+++ b/secp256kfun/src/op.rs
@@ -86,7 +86,7 @@ pub fn scalar_eq<Z1, S1, Z2, S2>(x: &Scalar<S1, Z1>, y: &Scalar<S2, Z2>) -> bool
 /// Negate a scalar
 #[inline(always)]
 pub fn scalar_negate<Z, S>(x: &Scalar<S, Z>) -> Scalar<S, Z> {
-    let mut negated = x.0.clone();
+    let mut negated = x.0;
     ConstantTime::scalar_cond_negate(&mut negated, true);
     Scalar::from_inner(negated)
 }
@@ -151,7 +151,7 @@ where
 /// Negate a point
 #[inline(always)]
 pub fn point_negate<T: PointType, S, Z>(A: &Point<T, S, Z>) -> Point<T::NegationType, S, Z> {
-    let mut A = A.0.clone();
+    let mut A = A.0;
     ConstantTime::any_point_neg(&mut A);
     Point::from_inner(A, T::NegationType::default())
 }
@@ -162,7 +162,7 @@ pub fn point_conditional_negate<T: PointType, S, Z>(
     A: &Point<T, S, Z>,
     cond: bool,
 ) -> Point<T::NegationType, S, Z> {
-    let mut A = A.0.clone();
+    let mut A = A.0;
     ConstantTime::any_point_conditional_negate(&mut A, cond);
     Point::from_inner(A, T::NegationType::default())
 }

--- a/secp256kfun/src/point.rs
+++ b/secp256kfun/src/point.rs
@@ -55,7 +55,7 @@ pub struct Point<T = Normal, S = Public, Z = NonZero>(
 
 impl<Z, S, T: Clone> Clone for Point<T, S, Z> {
     fn clone(&self) -> Self {
-        Point::from_inner(self.0.clone(), self.1.clone())
+        Point::from_inner(self.0, self.1.clone())
     }
 }
 
@@ -485,7 +485,7 @@ fn coords_to_bytes(x: [u8; 32], y: [u8; 32]) -> [u8; 33] {
 
 crate::impl_debug! {
     fn to_bytes<T, S,Z>(point: &Point<T, S, Z>) -> Result<[u8;33], &str> {
-        let mut p = point.0.clone();
+        let mut p = point.0;
         backend::VariableTime::point_normalize(&mut p);
         let p: Point<Normal, S, Z> = Point::from_inner(p, Normal);
         Ok(p.to_bytes())
@@ -782,9 +782,9 @@ mod test {
     #[test]
     fn fmt_debug() {
         let random_point = Point::random(&mut rand::thread_rng());
-        assert!(format!("{:?}", random_point).starts_with("Point<Normal,Public,NonZero>"));
+        assert!(format!("{random_point:?}").starts_with("Point<Normal,Public,NonZero>"));
         let mult_point = g!({ Scalar::random(&mut rand::thread_rng()) } * G);
-        assert!(format!("{:?}", mult_point).starts_with("Point<NonNormal,Public,NonZero>"));
+        assert!(format!("{mult_point:?}").starts_with("Point<NonNormal,Public,NonZero>"));
     }
 
     #[test]
@@ -792,7 +792,7 @@ mod test {
         let a_orig = Point::random(&mut rand::thread_rng())
             .mark_zero()
             .non_normal();
-        let mut a = a_orig.clone();
+        let mut a = a_orig;
         let b = Point::random(&mut rand::thread_rng());
         a += b;
         assert_eq!(a, op::point_add(&a_orig, &b));

--- a/secp256kfun/src/scalar.rs
+++ b/secp256kfun/src/scalar.rs
@@ -55,7 +55,7 @@ impl<Z> Copy for Scalar<Public, Z> {}
 
 impl<S, Z> Clone for Scalar<S, Z> {
     fn clone(&self) -> Self {
-        Self(self.0.clone(), self.1.clone())
+        Self(self.0, self.1)
     }
 }
 
@@ -277,7 +277,7 @@ impl<S> Scalar<S, Zero> {
             return None;
         }
         let mut bytes = [0u8; 32];
-        bytes.copy_from_slice(&slice);
+        bytes.copy_from_slice(slice);
         Self::from_bytes(bytes)
     }
 }
@@ -334,7 +334,7 @@ impl<S, Z> core::ops::Neg for &Scalar<S, Z> {
 
 impl<S, Z> HashInto for Scalar<S, Z> {
     fn hash_into(self, hash: &mut impl digest::Digest) {
-        hash.update(&self.to_bytes())
+        hash.update(self.to_bytes())
     }
 }
 
@@ -358,49 +358,49 @@ where
 
 impl<SL, SR, ZR> AddAssign<Scalar<SR, ZR>> for Scalar<SL, Zero> {
     fn add_assign(&mut self, rhs: Scalar<SR, ZR>) {
-        *self = crate::op::scalar_add(&self, &rhs).set_secrecy::<SL>();
+        *self = crate::op::scalar_add(self, &rhs).set_secrecy::<SL>();
     }
 }
 
 impl<SL, SR, ZR> AddAssign<&Scalar<SR, ZR>> for Scalar<SL, Zero> {
     fn add_assign(&mut self, rhs: &Scalar<SR, ZR>) {
-        *self = crate::op::scalar_add(&self, rhs).set_secrecy::<SL>();
+        *self = crate::op::scalar_add(self, rhs).set_secrecy::<SL>();
     }
 }
 
 impl<SL, SR, ZR> SubAssign<&Scalar<SR, ZR>> for Scalar<SL, Zero> {
     fn sub_assign(&mut self, rhs: &Scalar<SR, ZR>) {
-        *self = crate::op::scalar_sub(&self, rhs).set_secrecy::<SL>();
+        *self = crate::op::scalar_sub(self, rhs).set_secrecy::<SL>();
     }
 }
 
 impl<SL, SR, ZR> SubAssign<Scalar<SR, ZR>> for Scalar<SL, Zero> {
     fn sub_assign(&mut self, rhs: Scalar<SR, ZR>) {
-        *self = crate::op::scalar_sub(&self, &rhs).set_secrecy::<SL>();
+        *self = crate::op::scalar_sub(self, &rhs).set_secrecy::<SL>();
     }
 }
 
 impl<SL, SR> MulAssign<Scalar<SR, NonZero>> for Scalar<SL, NonZero> {
     fn mul_assign(&mut self, rhs: Scalar<SR, NonZero>) {
-        *self = crate::op::scalar_mul(&self, &rhs).set_secrecy::<SL>();
+        *self = crate::op::scalar_mul(self, &rhs).set_secrecy::<SL>();
     }
 }
 
 impl<SL, SR> MulAssign<&Scalar<SR, NonZero>> for Scalar<SL, NonZero> {
     fn mul_assign(&mut self, rhs: &Scalar<SR, NonZero>) {
-        *self = crate::op::scalar_mul(&self, rhs).set_secrecy::<SL>();
+        *self = crate::op::scalar_mul(self, rhs).set_secrecy::<SL>();
     }
 }
 
 impl<SL, SR, ZR: ZeroChoice> MulAssign<Scalar<SR, ZR>> for Scalar<SL, Zero> {
     fn mul_assign(&mut self, rhs: Scalar<SR, ZR>) {
-        *self = crate::op::scalar_mul(&self, &rhs).set_secrecy::<SL>();
+        *self = crate::op::scalar_mul(self, &rhs).set_secrecy::<SL>();
     }
 }
 
 impl<SL, SR, ZR: ZeroChoice> MulAssign<&Scalar<SR, ZR>> for Scalar<SL, Zero> {
     fn mul_assign(&mut self, rhs: &Scalar<SR, ZR>) {
-        *self = crate::op::scalar_mul(&self, rhs).set_secrecy::<SL>();
+        *self = crate::op::scalar_mul(self, rhs).set_secrecy::<SL>();
     }
 }
 

--- a/secp256kfun/src/slice.rs
+++ b/secp256kfun/src/slice.rs
@@ -52,7 +52,7 @@ impl<'a, S> Slice<'a, S> {
 
     /// Gets the inner slice
     pub fn as_inner(self) -> &'a [u8] {
-        &self.inner
+        self.inner
     }
 
     /// Set the secrecy of the bytes to *public*.
@@ -87,7 +87,7 @@ impl<'a, S> HashInto for Slice<'a, S> {
 impl<S> core::fmt::Display for Slice<'_, S> {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         for byte in self.inner.iter() {
-            write!(f, "{:02x}", byte)?
+            write!(f, "{byte:02x}")?
         }
         Ok(())
     }

--- a/secp256kfun/src/vendor/mod.rs
+++ b/secp256kfun/src/vendor/mod.rs
@@ -1,1 +1,2 @@
+#![allow(clippy::all)]
 pub mod k256;

--- a/secp256kfun/tests/expression_macros.rs
+++ b/secp256kfun/tests/expression_macros.rs
@@ -157,7 +157,7 @@ fn g_expressions_give_correct_answers() {
     );
 
     let has_scalar = Has { has: s!(17) };
-    let has_point = Has { has: C.clone() };
+    let has_point = Has { has: C };
     let has_has_scalar = HasHas {
         has_has: has_scalar.clone(),
     };

--- a/secp256kfun/tests/serialization_macros.rs
+++ b/secp256kfun/tests/serialization_macros.rs
@@ -20,7 +20,7 @@ mod test {
         }
 
         fn to_six_bytes(&self) -> [u8; 6] {
-            self.0.clone()
+            self.0
         }
 
         #[allow(dead_code)]
@@ -56,7 +56,7 @@ mod test {
             parsed.to_six_bytes(),
             hex::decode_array("deadbeef0123").unwrap()
         );
-        assert_eq!(format!("{}", parsed).as_str(), "deadbeef0123");
+        assert_eq!(format!("{parsed}").as_str(), "deadbeef0123");
     }
 
     #[test]
@@ -129,10 +129,7 @@ mod test {
             SixBytes::<MyMarker>::from_six_bytes(hex::decode_array("deadbeef0123").unwrap())
                 .unwrap();
 
-        assert_eq!(format!("{}", six_bytes), "deadbeef0123");
-        assert_eq!(
-            format!("{:?}", six_bytes),
-            "SixBytes<MyMarker>(deadbeef0123)"
-        );
+        assert_eq!(format!("{six_bytes}"), "deadbeef0123");
+        assert_eq!(format!("{six_bytes:?}"), "SixBytes<MyMarker>(deadbeef0123)");
     }
 }

--- a/sigma_fun/src/all.rs
+++ b/sigma_fun/src/all.rs
@@ -44,14 +44,13 @@ impl<N: Unsigned, S: Sigma> Sigma for All<S, N> {
             .into_iter()
             .enumerate()
             .map(|(i, announce_secret)| {
-                let response = self.sigma.respond(
+                self.sigma.respond(
                     &witness[i],
                     &statement[i],
                     announce_secret,
                     &announce[i],
                     challenge,
-                );
-                response
+                )
             })
             .collect()
     }

--- a/sigma_fun/src/and.rs
+++ b/sigma_fun/src/and.rs
@@ -93,7 +93,7 @@ where
             .implied_announcement(lhs_statement, challenge, lhs_response)
             .and_then(|lhs_announcement| {
                 self.rhs
-                    .implied_announcement(&rhs_statement, challenge, rhs_response)
+                    .implied_announcement(rhs_statement, challenge, rhs_response)
                     .map(|rhs_announcement| (lhs_announcement, rhs_announcement))
             })
     }

--- a/sigma_fun/src/ed25519.rs
+++ b/sigma_fun/src/ed25519.rs
@@ -246,7 +246,7 @@ pub mod test {
             x in ed25519_scalar(),
         ) {
             let G = &Scalar::random(&mut rand::thread_rng()) * &ED25519_BASEPOINT_TABLE;
-            let xG = &x * G;
+            let xG = x * G;
             let proof_system = FiatShamir::<DL<U31>, Transcript>::default();
             let proof = proof_system.prove(&x, &(G, xG), Some(&mut rand::thread_rng()));
             assert!(proof_system.verify(&(G, xG), &proof));

--- a/sigma_fun/src/eq.rs
+++ b/sigma_fun/src/eq.rs
@@ -147,6 +147,7 @@ mod test {
         ) => {{
             let statement = &$statement;
             let witness = &$witness;
+            #[allow(clippy::upper_case_acronyms)]
             type DLEQ = Eq<$mod::DLG<$len>, $mod::DL<$len>>;
 
             let proof_system = FiatShamir::<DLEQ, HashTranscript<Sha256, ChaCha20Rng>>::default();
@@ -179,7 +180,7 @@ mod test {
                 secp256k1::DLG::<U32>::default(),
                 secp256k1::DL::<U32>::default(),
             );
-            assert_eq!(&format!("{}", dleq), "eq(DLG(secp256k1),DL(secp256k1))");
+            assert_eq!(&format!("{dleq}"), "eq(DLG(secp256k1),DL(secp256k1))");
         }
 
         proptest! {
@@ -199,7 +200,7 @@ mod test {
                     challenge_length => U32,
                     statement => statement,
                     witness => x,
-                    unrelated_point => unrelated_point.clone()
+                    unrelated_point => unrelated_point
                 );
                 run_dleq!(
                     secp256k1,

--- a/sigma_fun/src/or.rs
+++ b/sigma_fun/src/or.rs
@@ -56,7 +56,7 @@ impl<A: Sigma, B: Sigma<ChallengeLength = A::ChallengeLength>> Sigma for Or<A, B
             (Either::Left(witness), Either::Left((announce_secret, sim_response))) => (
                 (
                     self.lhs.respond(
-                        &witness,
+                        witness,
                         &statement.0,
                         announce_secret,
                         &announce.0,
@@ -69,7 +69,7 @@ impl<A: Sigma, B: Sigma<ChallengeLength = A::ChallengeLength>> Sigma for Or<A, B
             (Either::Right(witness), Either::Right((sim_response, announce_secret))) => (
                 (sim_response, fake_challenge),
                 self.rhs.respond(
-                    &witness,
+                    witness,
                     &statement.1,
                     announce_secret,
                     &announce.1,
@@ -89,12 +89,12 @@ impl<A: Sigma, B: Sigma<ChallengeLength = A::ChallengeLength>> Sigma for Or<A, B
             (Either::Left((ref announce_secret, ref sim_response)), sim_challenge) => (
                 self.lhs.announce(&statement.0, announce_secret),
                 self.rhs
-                    .implied_announcement(&statement.1, &sim_challenge, &sim_response)
+                    .implied_announcement(&statement.1, sim_challenge, sim_response)
                     .expect("computationally unreachable for any large language"),
             ),
             (Either::Right((ref sim_response, ref announce_secret)), sim_challenge) => (
                 self.lhs
-                    .implied_announcement(&statement.0, &sim_challenge, &sim_response)
+                    .implied_announcement(&statement.0, sim_challenge, sim_response)
                     .expect("computationally unreachable for any large language"),
                 self.rhs.announce(&statement.1, announce_secret),
             ),
@@ -146,10 +146,10 @@ impl<A: Sigma, B: Sigma<ChallengeLength = A::ChallengeLength>> Sigma for Or<A, B
         let rhs_challenge = lhs_challenge.zip(challenge, |byte1, byte2| byte1 ^ byte2);
 
         self.lhs
-            .implied_announcement(lhs_statement, lhs_challenge, &lhs_response)
+            .implied_announcement(lhs_statement, lhs_challenge, lhs_response)
             .and_then(|lhs_announcement| {
                 self.rhs
-                    .implied_announcement(rhs_statement, &rhs_challenge, &rhs_response)
+                    .implied_announcement(rhs_statement, &rhs_challenge, rhs_response)
                     .map(|rhs_announcement| (lhs_announcement, rhs_announcement))
             })
     }
@@ -231,7 +231,7 @@ mod test {
 
                 let statement = (statement.1, statement.0);
                 let proof_rhs = proof_system.prove(
-                    &Either::Right(x.clone()),
+                    &Either::Right(x),
                     &statement,
                     Some(&mut rand::thread_rng()),
                 );

--- a/sigma_fun/src/writable.rs
+++ b/sigma_fun/src/writable.rs
@@ -1,4 +1,4 @@
-/// Utility tarait for something that can be written as a string.
+/// Utility trait for something that can be written as a string.
 ///
 /// This is basically like [`core::fmt::Display`] except the thing being written to does not have to
 /// be a `Formatter`. This is useful because we write the names of [`Sigma`] protocols to a hash
@@ -12,6 +12,6 @@ pub trait Writable {
 
 impl Writable for str {
     fn write_to<W: core::fmt::Write>(&self, w: &mut W) -> core::fmt::Result {
-        write!(w, "{}", self)
+        write!(w, "{self}")
     }
 }


### PR DESCRIPTION
Small clippy fixes and also removed the pointless `sid_len` from the `derive_nonce_rng!` that doesn't add any collision resistance. Though this will **break consistency of deterministic nonce rngs between releases**.

Prior to this fixup, the `&&`s have just been getting fully dereferenced right?
Like
```
Scalar::from_hash(hash.add(R).add(X).add(&&Message))
```