### PR TITLE
Allow creating an n-of-n FROST key from a set of core shares

### DIFF
--- a/schnorr_fun/tests/against_c_lib.rs
+++ b/schnorr_fun/tests/against_c_lib.rs
@@ -24,7 +24,7 @@ struct Bip340NoAux {
 
 impl NonceGen for Bip340NoAux {
     type Hash = Sha256;
-    fn begin_derivation(&self, secret: &Scalar) -> Self::Hash {
+    fn begin_derivation(&self, secret: &Scalar<Secret, impl ZeroChoice>) -> Self::Hash {
         let sec_bytes = secret.to_bytes();
         let mut bytes = [0u8; 32];
         let zero_mask = self.aux_hash.clone().add([0u8; 32]);

--- a/schnorr_fun/tests/frost_prop.rs
+++ b/schnorr_fun/tests/frost_prop.rs
@@ -85,7 +85,7 @@ proptest! {
                 &frost_key,
                 &signing_session,
                 signer_index,
-                sig)
+                sig).is_ok()
             );
             signatures.push(sig);
         }
@@ -99,5 +99,14 @@ proptest! {
             message,
             &combined_sig
         ));
+    }
+
+    #[test]
+    fn test_core_shares_interpolation((n_parties, threshold) in (1usize..=7).prop_flat_map(|n| (Just(n), 1usize..=n))) {
+        let proto = new_with_deterministic_nonces::<Sha256>();
+        let mut rng = TestRng::deterministic_rng(RngAlgorithm::ChaCha);
+        let (frost_key, _secret_shares) = proto.simulate_keygen(threshold, n_parties, &mut rng);
+        let interp_frost_key = FrostKey::from_core_share_images(frost_key.core_shares().clone()).expect("computationally unreachable");
+        assert_eq!(frost_key, interp_frost_key);
     }
 }

--- a/secp256kfun/src/nonce.rs
+++ b/secp256kfun/src/nonce.rs
@@ -17,7 +17,7 @@
 //!
 //! [`NonceGen`]: crate::nonce::NonceGen
 //! [`derive_nonce!`]: crate::derive_nonce!
-use crate::{hash::*, Scalar};
+use crate::{hash::*, marker::*, Scalar};
 use core::marker::PhantomData;
 use digest::{generic_array::typenum::U32, Digest};
 use rand_core::RngCore;
@@ -172,12 +172,12 @@ pub trait NonceGen {
     /// Takes a secret [`Scalar`] and outputs a hash. Before turining this hash into the nonce, you
     /// must add a secret input and all the public inputs from the scheme into the hash. So for a
     /// signature scheme for example you would add your secret key, the message and the public key.
-    fn begin_derivation(&self, secret: &Scalar) -> Self::Hash;
+    fn begin_derivation(&self, secret: &Scalar<Secret, impl ZeroChoice>) -> Self::Hash;
 }
 
 impl<H: Digest<OutputSize = U32> + Clone> NonceGen for Deterministic<H> {
     type Hash = H;
-    fn begin_derivation(&self, secret: &Scalar) -> Self::Hash {
+    fn begin_derivation(&self, secret: &Scalar<Secret, impl ZeroChoice>) -> Self::Hash {
         self.nonce_hash.clone().add(secret)
     }
 }
@@ -208,7 +208,7 @@ where
     R: NonceRng,
 {
     type Hash = H;
-    fn begin_derivation(&self, secret: &Scalar) -> Self::Hash {
+    fn begin_derivation(&self, secret: &Scalar<Secret, impl ZeroChoice>) -> Self::Hash {
         let sec_bytes = secret.to_bytes();
         let mut aux_bytes = [0u8; 32];
         self.rng.fill_bytes(&mut aux_bytes[..]);


### PR DESCRIPTION
This intended to demonstrate how we could re-imagine FROST key generation.
This allows generating an n-of-n FROST key from a list of n public keys. This is insecure without proofs of possession for each of the n keys . The intention is that from this n-of-n FROST key you could add new parties to make it a t-of-n by using an enrollment protocol see [1]. We don't have a proof of security with FROST signing with respect to generating an n-of-n key like this let alone later converting it to a t-of-n key.

[1]: https://eprint.iacr.org/2017/1155.pdf section 4.1.3