### PR TITLE
frost: Isolate creating shares and creating PoP

### DIFF
--- a/schnorr_fun/Cargo.toml
+++ b/schnorr_fun/Cargo.toml
@@ -25,7 +25,7 @@ sha2 = "0.10"
 serde_json = "1"
 rand_chacha = { version = "0.3" }
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-criterion = "0.3"
+criterion = "0.4"
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test = "0.3"
 

--- a/schnorr_fun/src/binonce.rs
+++ b/schnorr_fun/src/binonce.rs
@@ -11,7 +11,7 @@ use secp256kfun::{g, marker::*, rand_core::RngCore, Point, Scalar, G};
 /// The type argument determines whether the nonces can be `Zero` or not. The [musig
 /// spec](https://github.com/jonasnick/bips/pull/21) specifies that the aggregate nonce is allowed
 /// to be zero to avoid having to abort the protocol in this case.
-#[derive(Clone, Copy, PartialEq, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub struct Nonce<Z = NonZero>(pub [Point<Normal, Public, Z>; 2]);
 
 impl<Z: ZeroChoice> Nonce<Z> {

--- a/schnorr_fun/src/message.rs
+++ b/schnorr_fun/src/message.rs
@@ -22,6 +22,11 @@ impl<'a, S: Secrecy> Message<'a, S> {
         }
     }
 
+    /// Create an empty zero byte message.
+    pub fn empty() -> Self {
+        Self::raw(&[])
+    }
+
     /// Signs a plain variable length message.
     ///
     /// You must provide an application tag to make sure signatures valid in one context are not

--- a/schnorr_fun/src/signature.rs
+++ b/schnorr_fun/src/signature.rs
@@ -1,7 +1,7 @@
 use crate::fun::{marker::*, rand_core::RngCore, Point, Scalar};
 
 /// A Schnorr signature.
-#[derive(Clone)]
+#[derive(Clone, Eq)]
 pub struct Signature<S = Public> {
     /// The signature's public nonce
     ///

--- a/schnorr_fun/tests/frost_prop.rs
+++ b/schnorr_fun/tests/frost_prop.rs
@@ -68,7 +68,7 @@ proptest! {
 
         let signing_session = proto.start_sign_session(
             &frost_key,
-            public_nonces.clone(),
+            public_nonces,
             message
         );
 


### PR DESCRIPTION
After discussion today, we do not need to know the other partys' polynomials in order to create their secret shares, PROVIDED we have some pre-existing way to assign the other parties an index
```
    pub fn create_shares(
        &self,
        party_indexes: impl Iterator<Item = usize>,
        scalar_poly: &Vec<Scalar>,
    ) -> Vec<Scalar<Secret, Zero>> {
```
```
    pub fn create_proof_of_posessions(
        &self,
        keygen_id: &[u8],
        scalar_poly: &Vec<Scalar>,
```

This PR is a step towards passing non-standard participant indexes into frost key generation as opposed to `1, 2, 3, ...`.
 
I also added   `create_shares_and_pop()` which behaves similar to the existing usage before this PR. 
I did this primarily because the iterator of indexes is not so friendly to pass in `1..=n_parties`, and we will soon be adding a sorting algorithm.