### PR TITLE
Remove XOnlyKeyPair in favour of KeyPair<EvenY> and impl serde for KeyPair

### DIFF
--- a/ecdsa_fun/Cargo.toml
+++ b/ecdsa_fun/Cargo.toml
@@ -34,6 +34,7 @@ harness = false
 default = ["std"]
 libsecp_compat = ["secp256kfun/libsecp_compat"]
 std = ["alloc"]
+bincode = ["secp256kfun/bincode" ]
 alloc = ["secp256kfun/alloc", "sigma_fun?/alloc" ]
 serde = ["secp256kfun/serde","sigma_fun?/serde"]
 adaptor = ["dep:sigma_fun", "dep:bincode", "dep:rand_chacha"]

--- a/ecdsa_fun/README.md
+++ b/ecdsa_fun/README.md
@@ -26,6 +26,7 @@ This library and [secp256kfun] is experimental.
 - `proptest` to enable [secp256kfun]'s proptest feature.
 - `adaptor` to spec compliant ECDSA adaptor signatures.
 - `serde` to enable hex and binary [`serde`] serialization of data types.
+- `bincode`: for `bincode` v2 `Encode`/`Decode` implementations
 
 [secp256kfun]: https://docs.rs/secp256kfun
 [rust-secp256k1]: https://github.com/rust-bitcoin/rust-secp256k1/ 

--- a/ecdsa_fun/src/adaptor/encrypted_signature.rs
+++ b/ecdsa_fun/src/adaptor/encrypted_signature.rs
@@ -31,8 +31,8 @@ secp256kfun::impl_display_debug_serialize! {
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(
     feature = "serde",
-    derive(crate::serde::Deserialize, crate::serde::Serialize),
-    serde(crate = "crate::serde")
+    derive(crate::fun::serde::Deserialize, crate::fun::serde::Serialize),
+    serde(crate = "crate::fun::serde")
 )]
 #[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 pub(crate) struct EncryptedSignatureInternal {

--- a/ecdsa_fun/src/lib.rs
+++ b/ecdsa_fun/src/lib.rs
@@ -13,9 +13,6 @@ extern crate std;
 #[cfg(feature = "libsecp_compat")]
 mod libsecp_compat;
 
-#[cfg(feature = "serde")]
-/// Rexport `serde`
-pub use fun::serde;
 use fun::Tag;
 
 use fun::{derive_nonce, g, marker::*, nonce::NonceGen, s, Point, Scalar, G};

--- a/ecdsa_fun/tests/adaptor_test_vectors.rs
+++ b/ecdsa_fun/tests/adaptor_test_vectors.rs
@@ -3,9 +3,9 @@
 static DLC_SPEC_JSON: &str = include_str!("./test_vectors.json");
 use ecdsa_fun::{
     adaptor::{Adaptor, EncryptedSignature, HashTranscript},
-    fun::{Point, Scalar},
+    fun::{serde, Point, Scalar},
     nonce::NoNonces,
-    serde, Signature,
+    Signature,
 };
 use sha2::Sha256;
 

--- a/schnorr_fun/Cargo.toml
+++ b/schnorr_fun/Cargo.toml
@@ -38,6 +38,7 @@ harness = false
 default = ["std"]
 alloc = ["secp256kfun/alloc" ]
 std = ["alloc", "secp256kfun/std"]
+bincode = ["secp256kfun/bincode"]
 serde = ["secp256kfun/serde"]
 libsecp_compat = ["secp256kfun/libsecp_compat"]
 proptest = ["secp256kfun/proptest"]

--- a/schnorr_fun/README.md
+++ b/schnorr_fun/README.md
@@ -57,6 +57,7 @@ assert!(schnorr.verify(&verification_key, message, &signature));
 - WIP [FROST] implementation
 - Feature flags
   - `serde`: for serde implementations for signatures
+  - `bincode`: for `bincode` v2 `Encode`/`Decode` implementations
   - `libsecp_compat`: for `From` implementations between `rust-secp256k1`'s Schnorr signatures.
   - `proptest` to enable `secp256kfun/proptest`.
 

--- a/schnorr_fun/src/adaptor/encrypted_signature.rs
+++ b/schnorr_fun/src/adaptor/encrypted_signature.rs
@@ -7,8 +7,8 @@ use secp256kfun::{marker::*, Point, Scalar};
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(
     feature = "serde",
-    derive(crate::serde::Deserialize, crate::serde::Serialize),
-    serde(crate = "crate::serde")
+    derive(crate::fun::serde::Deserialize, crate::fun::serde::Serialize),
+    serde(crate = "crate::fun::serde")
 )]
 #[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 pub struct EncryptedSignature<S = Public> {

--- a/schnorr_fun/src/adaptor/mod.rs
+++ b/schnorr_fun/src/adaptor/mod.rs
@@ -53,7 +53,7 @@ use crate::{
         digest::{generic_array::typenum::U32, Digest},
         g,
         marker::*,
-        nonce, s, Point, Scalar, XOnlyKeyPair, G,
+        nonce, s, KeyPair, Point, Scalar, G,
     },
     Message, Schnorr, Signature,
 };
@@ -71,7 +71,7 @@ pub trait EncryptedSign {
     /// [synopsis]: crate::adaptor#synopsis
     fn encrypted_sign(
         &self,
-        signing_keypair: &XOnlyKeyPair,
+        signing_keypair: &KeyPair<EvenY>,
         encryption_key: &Point<Normal, impl Secrecy>,
         message: Message<'_, impl Secrecy>,
     ) -> EncryptedSignature;
@@ -84,7 +84,7 @@ where
 {
     fn encrypted_sign(
         &self,
-        signing_key: &XOnlyKeyPair,
+        signing_key: &KeyPair<EvenY>,
         encryption_key: &Point<Normal, impl Secrecy>,
         message: Message<'_, impl Secrecy>,
     ) -> EncryptedSignature {

--- a/schnorr_fun/src/frost.rs
+++ b/schnorr_fun/src/frost.rs
@@ -351,16 +351,16 @@ impl std::error::Error for FinishKeyGenError {}
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(
     feature = "serde",
-    derive(crate::serde::Deserialize, crate::serde::Serialize),
-    serde(crate = "crate::serde")
+    derive(crate::fun::serde::Deserialize, crate::fun::serde::Serialize),
+    serde(crate = "crate::fun::serde")
 )]
 pub struct FrostKey<T: PointType> {
     /// The joint public key of the frost multisignature.
     #[cfg_attr(
         feature = "serde",
         serde(bound(
-            deserialize = "Point<T>: crate::serde::de::Deserialize<'de>",
-            serialize = "Point<T>: crate::serde::Serialize"
+            deserialize = "Point<T>: crate::fun::serde::de::Deserialize<'de>",
+            serialize = "Point<T>: crate::fun::serde::Serialize"
         ))
     )]
     public_key: Point<T>,

--- a/schnorr_fun/src/lib.rs
+++ b/schnorr_fun/src/lib.rs
@@ -17,9 +17,6 @@ extern crate std;
 pub use secp256kfun as fun;
 pub use secp256kfun::nonce;
 
-#[cfg(feature = "serde")]
-pub use secp256kfun::serde;
-
 /// binonces for Musig and FROST
 pub mod binonce;
 // musig needs vecs

--- a/schnorr_fun/src/musig.rs
+++ b/schnorr_fun/src/musig.rs
@@ -383,8 +383,8 @@ where
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(
     feature = "serde",
-    derive(crate::serde::Deserialize, crate::serde::Serialize),
-    serde(crate = "crate::serde")
+    derive(crate::fun::serde::Deserialize, crate::fun::serde::Serialize),
+    serde(crate = "crate::fun::serde")
 )]
 pub struct Ordinary;
 
@@ -393,8 +393,8 @@ pub struct Ordinary;
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(
     feature = "serde",
-    derive(crate::serde::Deserialize, crate::serde::Serialize),
-    serde(crate = "crate::serde")
+    derive(crate::fun::serde::Deserialize, crate::fun::serde::Serialize),
+    serde(crate = "crate::fun::serde")
 )]
 pub struct Adaptor {
     y_needs_negation: bool,
@@ -411,8 +411,8 @@ pub struct Adaptor {
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(
     feature = "serde",
-    derive(crate::serde::Deserialize, crate::serde::Serialize),
-    serde(crate = "crate::serde")
+    derive(crate::fun::serde::Deserialize, crate::fun::serde::Serialize),
+    serde(crate = "crate::fun::serde")
 )]
 pub struct SignSession<T = Ordinary> {
     b: Scalar<Public, Zero>,

--- a/schnorr_fun/src/musig.rs
+++ b/schnorr_fun/src/musig.rs
@@ -102,8 +102,10 @@ impl<H, NG> MuSig<H, NG> {
     /// Create a new keypair.
     ///
     /// A shorthand for [`KeyPair::new`].
+    ///
+    /// [`KeyPair::new`]: KeyPair::<Normal>::new
     pub fn new_keypair(&self, secret_key: Scalar) -> KeyPair {
-        KeyPair::new(secret_key)
+        KeyPair::<Normal>::new(secret_key)
     }
 
     /// Gets the nonce generator from the underlying Schnorr instance.

--- a/schnorr_fun/src/schnorr.rs
+++ b/schnorr_fun/src/schnorr.rs
@@ -8,7 +8,7 @@ use crate::{
         hash::{HashAdd, Tag},
         marker::*,
         nonce::NonceGen,
-        s, Point, Scalar, XOnlyKeyPair, G,
+        s, KeyPair, Point, Scalar, G,
     },
     Message, Signature,
 };
@@ -131,7 +131,7 @@ where
     /// let signature = schnorr.sign(&keypair, message);
     /// assert!(schnorr.verify(&keypair.public_key(), message, &signature));
     /// ```
-    pub fn sign(&self, keypair: &XOnlyKeyPair, message: Message<'_, impl Secrecy>) -> Signature {
+    pub fn sign(&self, keypair: &KeyPair<EvenY>, message: Message<'_, impl Secrecy>) -> Signature {
         let (x, X) = keypair.as_tuple();
 
         let mut r = derive_nonce!(
@@ -154,11 +154,11 @@ impl<NG, CH: Digest<OutputSize = U32> + Clone> Schnorr<CH, NG> {
         self.challenge_hash.clone()
     }
 
-    /// Create a new signing keypair.
+    /// Convieninece method for creating a new signing [`KeyPair<EvenY>`]
     ///
-    /// Short form of [`XOnlyKeyPair::new`].
-    pub fn new_keypair(&self, sk: Scalar) -> XOnlyKeyPair {
-        XOnlyKeyPair::new(sk)
+    /// [`KeyPair<EvenY>`]: crate::fun::KeyPair
+    pub fn new_keypair(&self, sk: Scalar) -> KeyPair<EvenY> {
+        KeyPair::<EvenY>::new(sk)
     }
 
     /// Produces the Fiat-Shamir challenge for a Schnorr signature in the form specified by [BIP-340].

--- a/schnorr_fun/tests/musig_keyagg.rs
+++ b/schnorr_fun/tests/musig_keyagg.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "serde")]
 use schnorr_fun::{
-    fun::{marker::*, Point, Scalar},
-    musig, serde,
+    fun::{marker::*, serde, Point, Scalar},
+    musig,
 };
 static TEST_JSON: &str = include_str!("musig/key_agg_vectors.json");
 
@@ -20,7 +20,7 @@ impl<T> Maybe<T> {
         }
     }
 }
-#[derive(crate::serde::Deserialize)]
+#[derive(serde::Deserialize)]
 #[serde(crate = "self::serde")]
 pub struct TestCases {
     #[serde(bound(deserialize = "Maybe<Point>: serde::de::Deserialize<'de>"))]
@@ -32,7 +32,7 @@ pub struct TestCases {
     error_test_cases: Vec<TestCase>,
 }
 
-#[derive(crate::serde::Deserialize)]
+#[derive(serde::Deserialize)]
 #[serde(crate = "self::serde")]
 pub struct TestCase {
     key_indices: Vec<usize>,

--- a/schnorr_fun/tests/musig_sign_verify.rs
+++ b/schnorr_fun/tests/musig_sign_verify.rs
@@ -1,14 +1,14 @@
 #![cfg(feature = "serde")]
 use schnorr_fun::{
     binonce,
-    fun::{marker::*, Point, Scalar},
+    fun::{marker::*, serde, Point, Scalar},
     musig::{self, NonceKeyPair},
-    serde, Message,
+    Message,
 };
 static TEST_JSON: &str = include_str!("musig/sign_verify_vectors.json");
 use secp256kfun::hex;
 
-#[derive(schnorr_fun::serde::Deserialize, Clone, Copy, Debug)]
+#[derive(serde::Deserialize, Clone, Copy, Debug)]
 #[serde(crate = "self::serde", untagged)]
 pub enum Maybe<T> {
     Valid(T),

--- a/schnorr_fun/tests/musig_tweak.rs
+++ b/schnorr_fun/tests/musig_tweak.rs
@@ -4,9 +4,9 @@ use std::{rc::Rc, sync::Arc};
 
 use schnorr_fun::{
     binonce,
-    fun::{marker::*, Point, Scalar},
+    fun::{marker::*, serde, Point, Scalar},
     musig::{self, NonceKeyPair},
-    serde, Message,
+    Message,
 };
 static TEST_JSON: &'static str = include_str!("musig/tweak_vectors.json");
 use secp256kfun::hex;

--- a/secp256kfun/src/keypair.rs
+++ b/secp256kfun/src/keypair.rs
@@ -1,24 +1,53 @@
 use crate::{g, marker::*, Point, Scalar, G};
 /// A secret and public key pair.
 ///
-/// The secret key is a [`Scalar`] and the public key is the [`Point`] resulting from multiplying the scalar by [`G`].
+/// ## Synopsis
 ///
 /// ```
-/// use secp256kfun::{KeyPair, Scalar};
+/// use secp256kfun::{marker::*, KeyPair, Scalar};
 /// let my_secret_key = Scalar::random(&mut rand::thread_rng());
-/// let my_keypair = KeyPair::new(my_secret_key);
+/// let my_keypair = KeyPair::<Normal>::new(my_secret_key.clone());
+/// let my_xonly_keypair = KeyPair::<EvenY>::new(my_secret_key);
+///
+/// if my_keypair.public_key().is_y_even() {
+///     assert_eq!(my_keypair, my_xonly_keypair);
+/// } else {
+///     assert_eq!(-my_keypair.public_key(), my_xonly_keypair.public_key());
+/// }
 /// ```
+///
+/// ## Description
+///
+/// The secret key is a [`Scalar`] and the public key is the [`Point`] resulting from multiplying
+/// the scalar by [`G`].
+///
+/// The type parameter `T` of `KeyPair<T>` indicates the type of the public key (a `Point<T>`). It
+/// can either be [`Normal`] or [`EvenY`]. The only difference between the two is that
+/// `KeyPair::<EvenY>::new` is defined so that the public key always has an even y-coordinate and
+/// the secret key is negated to match it (if need be).
+///
 ///
 /// [`Scalar`]: crate::Scalar
 /// [`G`]: crate::G
 /// [`Point`]: crate::Point
-#[derive(Clone, Debug, PartialEq)]
-pub struct KeyPair {
+/// [`Normal`]: crate::marker::Normal
+/// [`EvenY`]: crate::marker::EvenY
+#[derive(Clone, Debug)]
+pub struct KeyPair<T = Normal> {
     sk: Scalar,
-    pk: Point,
+    pk: Point<T>,
 }
 
-impl KeyPair {
+/// two keypairs are the same if they have the
+impl<T1: PointType, T2: PointType> PartialEq<KeyPair<T2>> for KeyPair<T1> {
+    fn eq(&self, other: &KeyPair<T2>) -> bool {
+        self.pk == other.pk
+    }
+}
+
+impl<T: PointType> Eq for KeyPair<T> {}
+
+impl KeyPair<Normal> {
     /// Create a new `KeyPair` from a `secret_key`.
     pub fn new(secret_key: Scalar) -> Self {
         Self {
@@ -26,39 +55,9 @@ impl KeyPair {
             sk: secret_key,
         }
     }
-
-    /// Returns a reference to the secret key.
-    pub fn secret_key(&self) -> &Scalar {
-        &self.sk
-    }
-
-    /// The public key
-    pub fn public_key(&self) -> Point {
-        self.pk
-    }
-
-    /// Gets a reference to the keypair as a tuple
-    ///
-    /// # Example
-    /// ```
-    /// use secp256kfun::{KeyPair, Scalar};
-    /// let keypair = KeyPair::new(Scalar::random(&mut rand::thread_rng()));
-    /// let (secret_key, public_key) = keypair.as_tuple();
-    pub fn as_tuple(&self) -> (&Scalar, Point) {
-        (&self.sk, self.pk)
-    }
 }
 
-/// A secret and public key pair where the public key has an even y-coordinate.
-///
-/// [`Scalar`]: crate::Scalar
-#[derive(Clone, Debug, PartialEq)]
-pub struct XOnlyKeyPair {
-    sk: Scalar,
-    pk: Point<EvenY>,
-}
-
-impl XOnlyKeyPair {
+impl KeyPair<EvenY> {
     /// Converts a non-zero scalar to a keypair by interpreting it as a secret key, generating
     /// the corresponding public key by multiplying it by [`G`] and dropping the y-coordinate.
     ///
@@ -69,10 +68,10 @@ impl XOnlyKeyPair {
     ///
     /// # Example
     /// ```
-    /// use secp256kfun::{g, s, Scalar, XOnlyKeyPair, G};
+    /// use secp256kfun::{g, marker::*, s, KeyPair, Scalar, G};
     ///
     /// let original_secret_key = Scalar::random(&mut rand::thread_rng());
-    /// let keypair = XOnlyKeyPair::new(original_secret_key.clone());
+    /// let keypair = KeyPair::<EvenY>::new(original_secret_key.clone());
     ///
     /// assert!(
     ///     &original_secret_key == keypair.secret_key()
@@ -88,17 +87,19 @@ impl XOnlyKeyPair {
         let pk = Point::even_y_from_scalar_mul(G, &mut secret_key);
         Self { sk: secret_key, pk }
     }
+}
 
+impl<T> KeyPair<T> {
     /// Returns a reference to the secret key.
-    ///
-    /// The secret key will always correspond to a point with an even y-coordinate when multiplied
-    /// by [`G`] (regardless of what was passed into [`XOnlyKeyPair::new`]).
     pub fn secret_key(&self) -> &Scalar {
         &self.sk
     }
 
-    /// The public key as a point.
-    pub fn public_key(&self) -> Point<EvenY> {
+    /// The public key
+    pub fn public_key(&self) -> Point<T>
+    where
+        T: Copy,
+    {
         self.pk
     }
 
@@ -106,22 +107,19 @@ impl XOnlyKeyPair {
     ///
     /// # Example
     /// ```
-    /// use secp256kfun::{XOnlyKeyPair, Scalar};
-    /// let keypair = XOnlyKeyPair::new(Scalar::random(&mut rand::thread_rng()));
+    /// use secp256kfun::{KeyPair, Scalar, marker::*};
+    /// let keypair = KeyPair::<Normal>::new(Scalar::random(&mut rand::thread_rng()));
     /// let (secret_key, public_key) = keypair.as_tuple();
-    pub fn as_tuple(&self) -> (&Scalar, Point<EvenY>) {
+    pub fn as_tuple(&self) -> (&Scalar, Point<T>)
+    where
+        T: Copy,
+    {
         (&self.sk, self.pk)
     }
 }
 
-impl From<XOnlyKeyPair> for (Scalar, Point<EvenY>) {
-    fn from(kp: XOnlyKeyPair) -> Self {
-        (kp.sk, kp.pk)
-    }
-}
-
-impl From<XOnlyKeyPair> for KeyPair {
-    fn from(xonly: XOnlyKeyPair) -> Self {
+impl From<KeyPair<EvenY>> for KeyPair<Normal> {
+    fn from(xonly: KeyPair<EvenY>) -> Self {
         Self {
             sk: xonly.sk,
             pk: xonly.pk.normalize(),
@@ -129,8 +127,8 @@ impl From<XOnlyKeyPair> for KeyPair {
     }
 }
 
-impl From<KeyPair> for XOnlyKeyPair {
-    fn from(kp: KeyPair) -> Self {
+impl From<KeyPair<Normal>> for KeyPair<EvenY> {
+    fn from(kp: KeyPair<Normal>) -> Self {
         let mut sk = kp.sk;
         let (pk, needs_negation) = kp.pk.into_point_with_even_y();
         sk.conditional_negate(needs_negation);

--- a/secp256kfun/src/keypair.rs
+++ b/secp256kfun/src/keypair.rs
@@ -135,3 +135,25 @@ impl From<KeyPair<Normal>> for KeyPair<EvenY> {
         Self { sk, pk }
     }
 }
+
+crate::impl_serialize! {
+    fn to_bytes<T>(kp: &KeyPair<T>) -> [u8;32] {
+        kp.secret_key().to_bytes()
+    }
+}
+
+crate::impl_fromstr_deserialize! {
+    name => "secp256k1 scalar",
+    fn from_bytes(bytes: [u8;32]) -> Option<KeyPair<Normal>> {
+        let sk = Scalar::from_bytes(bytes)?.non_zero()?;
+        Some(KeyPair::<Normal>::new(sk))
+    }
+}
+
+crate::impl_fromstr_deserialize! {
+    name => "secp256k1 scalar",
+    fn from_bytes(bytes: [u8;32]) -> Option<KeyPair<EvenY>> {
+        let sk = Scalar::from_bytes(bytes)?.non_zero()?;
+        Some(KeyPair::<EvenY>::new(sk))
+    }
+}

--- a/secp256kfun/src/macros.rs
+++ b/secp256kfun/src/macros.rs
@@ -467,7 +467,7 @@ macro_rules! impl_serialize {
         #[cfg_attr(docsrs, doc(cfg(feature = "bincode")))]
         impl$(<$($tpl $(:$tcl)?),*>)? $crate::bincode::Encode for $type {
             fn encode<E: $crate::bincode::enc::Encoder>(&self, encoder: &mut E) -> Result<(), $crate::bincode::error::EncodeError> {
-                use bincode::enc::write::Writer;
+                use $crate::bincode::enc::write::Writer;
                 let $self = &self;
                 let bytes = $block;
                 encoder.writer().write(bytes.as_ref())
@@ -606,8 +606,8 @@ macro_rules! impl_fromstr_deserialize {
         #[cfg(feature = "bincode")]
         #[cfg_attr(docsrs, doc(cfg(feature = "bincode")))]
         impl$(<$($tpl $(:$tcl)?),*>)? $crate::bincode::de::Decode for $type {
-            fn decode<D: bincode::de::Decoder>(decoder: &mut D) -> Result<Self, $crate::bincode::error::DecodeError> {
-                use bincode::de::read::Reader;
+            fn decode<D: $crate::bincode::de::Decoder>(decoder: &mut D) -> Result<Self, $crate::bincode::error::DecodeError> {
+                use $crate::bincode::de::read::Reader;
                 let mut $input = [0u8; $len];
                 decoder.reader().read(&mut $input)?;
                 #[allow(clippy::redundant_closure_call)]


### PR DESCRIPTION
- Remove `XOnlyKeyPair` in favour of `KeyPair<EvenY>`
- impl serde/bincode for `KeyPair`
- also stop exporting `serde` from `ecdsa_fun` and `schnorr_fun` as we don't need to do that (it's already re-exported under secp256kfun
- add `bincode` features to `schnorr_fun` and `ecdsa_fun`. Skipping `sigma_fun` for now because it's more work.