### PR TITLE
Use procedural macro for `g!` and `s!` macros

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,7 @@ on:
 # Make sure CI fails on all warnings, including Clippy lints
 env:
     RUSTFLAGS: "-Dwarnings"
+    RUSTDOCFLAGS: "-Dwarnings"
 
 jobs:
 
@@ -17,25 +18,33 @@ jobs:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
         with:
-          profile: minimal
-          toolchain: nightly
-          override: true
           components: rustfmt
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+      - run: cargo fmt --all -- --check
 
   clippy_check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - name: Clippy
-        run: cargo clippy --all-targets --all-features
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo clippy --all-targets --all-features --tests
 
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@1.60.0
+      - uses: Swatinem/rust-cache@v2
+      - run: |
+          cargo update -p proptest --precise "1.2.0"
+          cargo update -p tempfile --precise "3.3.0"
+      - run: cargo tree --all-features # to debug deps issues
+      - run: cargo build --release --all-features
 
   # We want to test stable on multiple platforms with --all-features
   test:
@@ -45,11 +54,11 @@ jobs:
       matrix:
         target: ["x86_64-unknown-linux-gnu", "armv7-unknown-linux-gnueabihf"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.60.0
+          toolchain: stable
           target: ${{ matrix.target }}
           override: true
       - uses: Swatinem/rust-cache@v2.0.0
@@ -65,18 +74,10 @@ jobs:
   test-nightly:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-          target: "x86_64-unknown-linux-gnu"
-          override: true
-      - uses: Swatinem/rust-cache@v2.0.0
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --release --all-features
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo test --release --all-features
 
   # test without default features
   test-minimal:
@@ -85,18 +86,10 @@ jobs:
       matrix:
         package: [ "secp256kfun", "sigma_fun", "ecdsa_fun", "schnorr_fun" ]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          target: "x86_64-unknown-linux-gnu"
-          override: true
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2.0.0
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --release --no-default-features -p ${{ matrix.package }}
+      - run: cargo test --release --no-default-features -p ${{ matrix.package }}
 
 
   # test with alloc feature only
@@ -106,30 +99,16 @@ jobs:
       matrix:
         package: [ "secp256kfun", "sigma_fun", "ecdsa_fun", "schnorr_fun" ]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          target: "x86_64-unknown-linux-gnu"
-          override: true
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2.0.0
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --release --no-default-features --features alloc -p ${{ matrix.package }}
+      - run: cargo test --release --no-default-features --features alloc -p ${{ matrix.package }}
 
 
   doc-build:
      name: doc-build
      runs-on: ubuntu-latest
      steps:
-       - uses: actions/checkout@v2
-       - uses: actions-rs/toolchain@v1
-         with:
-           profile: minimal
-           toolchain: nightly
-           override: true
-       - name: build-doc
-         # convoluted way to make it fail on warnings
-         run: "cargo doc --no-deps --workspace 2>&1 | tee /dev/fd/2 | grep -iEq '^(warning|error)' && exit 1 || exit 0"
+       - uses: actions/checkout@v4
+       - uses: dtolnay/rust-toolchain@stable
+       - run:  cargo doc --no-deps --workspace

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # CHANGELOG
 
 
+## Unreleased
+
+- Added `arithmetic_macros` to make `g!` and `s!` macros into procedural macros
+- Made even `Secret` things `Copy`. See discussion [here](https://github.com/LLFourn/secp256kfun/issues/6#issuecomment-1363752651).
+
 ## v0.9.1
 
 - Added more `bincode` derives for FROST things

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "secp256kfun",
     "schnorr_fun",
     "ecdsa_fun",
-    "sigma_fun"
+    "sigma_fun",
+    "arithmetic_macros"
 ]
 resolver = "2"

--- a/arithmetic_macros/Cargo.toml
+++ b/arithmetic_macros/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "secp256kfun_arithmetic_macros"
+version = "0.9.0"
+edition = "2021"
+
+[lib]
+proc-macro = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+proc-macro2 = "1"
+quote = "1"

--- a/arithmetic_macros/src/lib.rs
+++ b/arithmetic_macros/src/lib.rs
@@ -1,0 +1,168 @@
+mod optree;
+use optree::{Infix, InfixKind, Node, OpTree};
+use proc_macro::TokenStream;
+use proc_macro2::{Ident, TokenTree};
+use quote::{quote, quote_spanned};
+use std::iter::Peekable;
+type Input = Peekable<proc_macro2::token_stream::IntoIter>;
+
+#[proc_macro]
+pub fn gen_s(input: TokenStream) -> TokenStream {
+    let input: proc_macro2::TokenStream = input.into();
+    let mut iter = input.into_iter().peekable();
+
+    let path = match iter.next() {
+        Some(TokenTree::Ident(path)) => path,
+        _ => panic!("put the path to secpfun crate first"),
+    };
+    let optree = match optree::parse_tokens(&mut iter) {
+        Ok(optree) => optree,
+        Err(e) => {
+            let problem = e.problem;
+            return quote_spanned!(e.span => compile_error!(#problem)).into();
+        }
+    };
+
+    compile_s(&path, optree).into()
+}
+
+fn compile_s(path: &Ident, node: Node) -> proc_macro2::TokenStream {
+    match *node.tree {
+        OpTree::Infix(Infix { lhs, rhs, kind }) => {
+            let lhs_ = compile_s(path, lhs);
+            let mut rhs_ = compile_s(path, rhs);
+            let fn_name = Ident::new(
+                match kind {
+                    InfixKind::Add => "scalar_add",
+                    InfixKind::Mul => "scalar_mul",
+                    InfixKind::Sub => "scalar_sub",
+                    InfixKind::LinComb => "scalar_dot_product",
+                    InfixKind::Div => {
+                        rhs_ = quote_spanned! { node.span => #path::op::scalar_invert(#rhs_) };
+                        "scalar_mul"
+                    }
+                },
+                node.span,
+            );
+
+            quote_spanned! { node.span =>  #path::op::#fn_name(#lhs_, #rhs_) }
+        }
+        OpTree::Unary(unary) => match unary.kind {
+            optree::UnaryKind::Neg => {
+                let fn_name = Ident::new("scalar_negate", node.span);
+                let subj = compile_s(path, unary.subj);
+                quote_spanned! { node.span => #path::op::#fn_name(#subj) }
+            }
+            optree::UnaryKind::Ref => {
+                let a = unary.punct;
+                let subj = compile_g(path, unary.subj);
+                quote!( #a #subj )
+            }
+        },
+        OpTree::Term(ts) => ts,
+        OpTree::Paren(node) => compile_s(path, node),
+        OpTree::LitInt(lit_int) => {
+            if lit_int == 0 {
+                quote_spanned! { node.span =>  #path::Scalar::<#path::marker::Secret, _>::zero() }
+            } else {
+                quote_spanned! { node.span =>
+                    #path::Scalar::<#path::marker::Secret, #path::marker::NonZero>::from_non_zero_u32(unsafe {
+                        core::num::NonZeroU32::new_unchecked(#lit_int)
+                    })
+                }
+            }
+        }
+    }
+}
+
+#[proc_macro]
+pub fn gen_g(input: TokenStream) -> TokenStream {
+    let input: proc_macro2::TokenStream = input.into();
+    let mut iter = input.into_iter().peekable();
+
+    let path = match iter.next() {
+        Some(TokenTree::Ident(path)) => path,
+        _ => panic!("put the path to secpfun crate first"),
+    };
+    let node = match optree::parse_tokens(&mut iter) {
+        Ok(optree) => optree,
+        Err(e) => {
+            let problem = e.problem;
+            return quote_spanned!(e.span => compile_error!(#problem)).into();
+        }
+    };
+
+    compile_g(&path, node).into()
+}
+
+fn compile_g(path: &Ident, node: Node) -> proc_macro2::TokenStream {
+    match *node.tree {
+        OpTree::Infix(Infix { lhs, rhs, kind }) => match kind {
+            InfixKind::Add | InfixKind::Sub => {
+                let is_sub = kind == InfixKind::Sub;
+                match (&*lhs.tree, &*rhs.tree) {
+                    (
+                        OpTree::Infix(Infix {
+                            kind: InfixKind::Mul,
+                            lhs: llhs,
+                            rhs: lrhs,
+                        }),
+                        OpTree::Infix(Infix {
+                            kind: InfixKind::Mul,
+                            lhs: rlhs,
+                            rhs: rrhs,
+                        }),
+                    ) => {
+                        let llhs = compile_s(path, llhs.clone());
+                        let lrhs = compile_g(path, lrhs.clone());
+                        let mut rlhs = compile_s(path, rlhs.clone());
+                        let rrhs = compile_g(path, rrhs.clone());
+                        if is_sub {
+                            rlhs = quote_spanned! { node.span => #path::op::scalar_negate(#rlhs) };
+                        }
+                        quote_spanned! { node.span => #path::op::double_mul(#llhs, #lrhs, #rlhs, #rrhs) }
+                    }
+                    (..) => {
+                        let lhs_ = compile_g(path, lhs);
+                        let rhs_ = compile_g(path, rhs);
+                        if is_sub {
+                            quote_spanned! { node.span => #path::op::point_sub(#lhs_, #rhs_) }
+                        } else {
+                            quote_spanned! { node.span => #path::op::point_add(#lhs_, #rhs_) }
+                        }
+                    }
+                }
+            }
+            InfixKind::Mul => {
+                let lhs_ = compile_s(path, lhs);
+                let rhs_ = compile_g(path, rhs);
+                quote_spanned! { node.span => #path::op::scalar_mul_point(#lhs_, #rhs_) }
+            }
+            InfixKind::LinComb => {
+                let lhs_ = compile_s(path, lhs);
+                let rhs_ = compile_g(path, rhs);
+                quote_spanned! { node.span => #path::op::point_scalar_dot_product(#lhs_, #rhs_) }
+            }
+            InfixKind::Div => {
+                quote_spanned! { node.span => compile_error!("can't use division in group expression") }
+            }
+        },
+        OpTree::Term(term) => term,
+        OpTree::Paren(node) => compile_g(path, node),
+        OpTree::Unary(unary) => match unary.kind {
+            optree::UnaryKind::Neg => {
+                let fn_name = Ident::new("point_negate", node.span);
+                let subj = compile_g(path, unary.subj);
+                quote_spanned! { node.span => #path::op::#fn_name(#subj) }
+            }
+            optree::UnaryKind::Ref => {
+                let a = unary.punct;
+                let subj = compile_g(path, unary.subj);
+                quote!( #a #subj )
+            }
+        },
+        OpTree::LitInt(lit_int) => {
+            quote_spanned! { node.span => compile_error!("can't use literal int {} in group expression", #lit_int)}
+        }
+    }
+}

--- a/arithmetic_macros/src/optree.rs
+++ b/arithmetic_macros/src/optree.rs
@@ -1,0 +1,567 @@
+#![allow(unused)]
+use super::Input;
+use proc_macro2::{token_stream, Delimiter, Punct, Span, TokenStream, TokenTree};
+use quote::{quote_spanned, ToTokens};
+use std::{fmt::Display, iter::Peekable};
+
+#[derive(Clone)]
+pub(crate) enum OpTree {
+    Infix(Infix),
+    Term(TokenStream),
+    Paren(Node),
+    Unary(Unary),
+    LitInt(u32),
+}
+
+#[derive(Clone)]
+pub(crate) struct Node {
+    pub tree: Box<OpTree>,
+    pub span: Span,
+}
+
+impl core::fmt::Debug for Node {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.tree.fmt(f)
+    }
+}
+
+impl core::fmt::Debug for OpTree {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Infix(infix) => f
+                .debug_tuple(&infix.kind.to_string())
+                .field(&infix.lhs)
+                .field(&infix.rhs)
+                .finish(),
+            Self::Term(arg0) => write!(f, "{}", arg0.to_string().replace(' ', "")),
+            Self::Paren(arg0) => arg0.fmt(f),
+            Self::Unary(unary) => f
+                .debug_tuple(&unary.kind.to_string())
+                .field(&unary.subj)
+                .finish(),
+            Self::LitInt(arg0) => write!(f, "{}", arg0),
+        }
+    }
+}
+
+impl Node {
+    fn new(tree: OpTree, span: Span) -> Self {
+        Node {
+            tree: Box::new(tree),
+            span,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct Infix {
+    pub lhs: Node,
+    pub rhs: Node,
+    pub kind: InfixKind,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(crate) enum InfixKind {
+    Add,
+    Mul,
+    Sub,
+    LinComb,
+    Div,
+}
+
+impl InfixKind {
+    fn precedence(self) -> u8 {
+        match self {
+            InfixKind::Add | InfixKind::Sub => 0,
+            InfixKind::Mul | InfixKind::LinComb | InfixKind::Div => 1,
+        }
+    }
+}
+
+impl core::fmt::Display for InfixKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", match self {
+            InfixKind::Add => "+",
+            InfixKind::Mul => "*",
+            InfixKind::Sub => "-",
+            InfixKind::LinComb => ".*",
+            InfixKind::Div => "/",
+        })
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct Unary {
+    pub subj: Node,
+    pub kind: UnaryKind,
+    pub punct: Punct,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum UnaryKind {
+    Neg,
+    Ref,
+}
+
+impl core::fmt::Display for UnaryKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", match self {
+            UnaryKind::Neg => "-",
+            UnaryKind::Ref => "&",
+        })
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Error {
+    pub span: Span,
+    pub problem: String,
+}
+
+pub(crate) fn token_stream_to_node(ts: token_stream::TokenStream) -> Result<Node, Error> {
+    parse_tokens(&mut ts.into_iter().peekable())
+}
+
+pub(crate) fn parse_tokens(input: &mut Input) -> Result<Node, Error> {
+    rule_opchain(input)
+}
+
+fn rule_term(input: &mut Input) -> Result<Node, Error> {
+    let unaries = rule_prefix(input)?;
+    let next = input
+        .peek()
+        .expect("must not be called with an empty input");
+    let mut span = next.span();
+    let mut optree = match next {
+        TokenTree::Ident(_) => {
+            let mut tt = TokenStream::new();
+            tt.extend(input.next());
+            tt.extend(rule_postfix(input)?);
+            OpTree::Term(tt)
+        }
+        TokenTree::Group(group) => {
+            let group = group.clone();
+            match group.delimiter() {
+                Delimiter::Parenthesis => {
+                    let _ = input.next();
+                    OpTree::Paren(token_stream_to_node(group.stream())?)
+                }
+                Delimiter::Brace => {
+                    let input: TokenStream = input.next().unwrap().into();
+                    let term = quote_spanned! { span => #[allow(unused_braces)] #input };
+                    OpTree::Term(term)
+                }
+                _ => {
+                    return Err(Error {
+                        span: group.span(),
+                        problem: "can only use '(..)' or '{..}'".into(),
+                    })
+                }
+            }
+        }
+        TokenTree::Literal(lit) => {
+            let int_lit: u32 = lit.to_string().parse().map_err(|e| Error {
+                span: lit.span(),
+                problem: "only u32 literals are supported".into(),
+            })?;
+            let _ = input.next();
+            OpTree::LitInt(int_lit)
+        }
+        tt => {
+            return Err(Error {
+                span: tt.span(),
+                problem: "this is an invalid term".into(),
+            })
+        }
+    };
+
+    for (unary_kind, punct) in unaries {
+        optree = OpTree::Unary(Unary {
+            kind: unary_kind,
+            subj: Node::new(optree, span),
+            punct: punct.clone(),
+        });
+        span = punct.span();
+    }
+    Ok(Node::new(optree, span))
+}
+
+fn rule_prefix(input: &mut Input) -> Result<Vec<(UnaryKind, Punct)>, Error> {
+    let mut unaries = vec![];
+    while let Some(TokenTree::Punct(punct)) = input.peek() {
+        match punct.as_char() {
+            '-' => {
+                unaries.push((UnaryKind::Neg, punct.to_owned()));
+                let _ = input.next();
+            }
+            '&' => {
+                unaries.push((UnaryKind::Ref, punct.to_owned()));
+                let _ = input.next();
+            }
+            _ => break,
+        }
+    }
+    Ok(unaries)
+}
+fn rule_postfix(input: &mut Input) -> Result<Vec<TokenTree>, Error> {
+    let mut tokens = vec![];
+
+    loop {
+        let mut lookahead = input.clone();
+        let next = lookahead.next();
+        match next {
+            Some(TokenTree::Punct(punct)) => {
+                if punct.as_char() == '.' {
+                    let is_dot_product = matches!(lookahead.peek(), Some(TokenTree::Punct(punct)) if punct.as_char() == '*');
+                    if is_dot_product {
+                        break;
+                    }
+
+                    tokens.push(input.next().unwrap());
+
+                    let error = Err(Error {
+                        span: punct.span(),
+                        problem:
+                            "expecting a method call, property access or tuple access after period"
+                                .into(),
+                    });
+                    // look for .0, .foo or .foo(a,b)
+                    match input.next() {
+                        Some(following_period) => match &following_period {
+                            TokenTree::Ident(_) => {
+                                tokens.push(following_period);
+                                if let Some(TokenTree::Group(group)) = input.peek() {
+                                    if group.delimiter() == Delimiter::Parenthesis {
+                                        tokens.push(input.next().unwrap())
+                                    }
+                                }
+                            }
+                            TokenTree::Literal(lit) if lit.to_string().parse::<f32>().is_ok() => {
+                                tokens.push(following_period);
+                            }
+                            _following_period => return error,
+                        },
+                        None => return error,
+                    }
+                } else {
+                    break;
+                }
+            }
+            Some(TokenTree::Group(group)) if group.delimiter() == Delimiter::Bracket => {
+                tokens.push(input.next().unwrap());
+            }
+            _ => break,
+        }
+    }
+
+    Ok(tokens)
+}
+
+fn rule_opchain(input: &mut Input) -> Result<Node, Error> {
+    let mut lhs = rule_term(input)?;
+
+    if input.peek().is_none() {
+        return Ok(lhs);
+    }
+
+    let (kind, span) = rule_infix_op(input)?;
+
+    let mut rhs = rule_opchain(input)?;
+    let mut top_node = Node::new(OpTree::Infix(Infix { lhs, rhs, kind }), span);
+    let mut cursor = &mut top_node;
+
+    while let OpTree::Infix(infix) = *cursor.tree.clone() {
+        match &*infix.rhs.tree {
+            OpTree::Infix(rhs_infix) if infix.kind.precedence() >= rhs_infix.kind.precedence() => {
+                let fixed = Node::new(
+                    OpTree::Infix(Infix {
+                        lhs: Node::new(
+                            OpTree::Infix(Infix {
+                                lhs: infix.lhs.clone(),
+                                rhs: rhs_infix.lhs.clone(),
+                                kind,
+                            }),
+                            span,
+                        ),
+                        rhs: rhs_infix.rhs.clone(),
+                        kind: rhs_infix.kind,
+                    }),
+                    infix.rhs.span,
+                );
+                *cursor = fixed.clone();
+                cursor = match &mut *cursor.tree {
+                    OpTree::Infix(infix) => &mut infix.lhs,
+                    _ => unreachable!(),
+                }
+            }
+            _ => break,
+        }
+    }
+
+    Ok(top_node)
+}
+
+fn rule_infix_op(input: &mut Input) -> Result<(InfixKind, Span), Error> {
+    let next = input.next().expect("must not be called on empty input");
+    match next {
+        TokenTree::Punct(punct) => {
+            let error = Err(Error {
+                span: punct.span(),
+                problem: "unknown infix operator".into(),
+            });
+
+            let op = match punct.as_char() {
+                '+' => InfixKind::Add,
+                '*' => InfixKind::Mul,
+                '-' => InfixKind::Sub,
+                '.' => match input.next() {
+                    Some(TokenTree::Punct(star)) if star.as_char() == '*' => InfixKind::LinComb,
+                    _ => return error,
+                },
+                '/' => InfixKind::Div,
+                _ => return error,
+            };
+            Ok((op, punct.span()))
+        }
+        _ => Err(Error {
+            span: next.span(),
+            problem: "expecting an infix operator".into(),
+        }),
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::str::FromStr;
+
+    macro_rules! parse {
+        ($lit:expr) => {
+            *match token_stream_to_node(TokenStream::from_str($lit).unwrap()) {
+                Err(e) => panic!("{}", e.problem),
+                Ok(expr) => expr,
+            }
+            .tree
+        };
+    }
+
+    #[test]
+    fn test_term() {
+        assert!(matches!(parse!("a_term"), OpTree::Term(tt) if tt.to_string() == "a_term"));
+    }
+
+    #[test]
+    fn add2() {
+        let ot = parse!("a + b");
+        assert!(
+            matches!(ot, OpTree::Infix (Infix {  lhs, rhs, kind: InfixKind::Add  }) if
+                    matches!(&*lhs.tree, OpTree::Term(tt) if tt.to_string() == "a") &&
+                    matches!(&*rhs.tree, OpTree::Term(tt) if tt.to_string() == "b")
+            )
+        );
+    }
+
+    #[test]
+    fn add3() {
+        let ot = parse!("a + b + c");
+        assert!(
+            matches!(ot, OpTree::Infix(Infix { lhs, rhs, kind: InfixKind::Add }) if
+                             matches!(&*lhs.tree, OpTree::Infix(Infix{ lhs, rhs, kind: InfixKind::Add }) if
+                                      matches!(&*lhs.tree, OpTree::Term(a) if a.to_string() == "a") &&
+                                      matches!(&*rhs.tree, OpTree::Term(b) if b.to_string() == "b")
+                             )  &&
+                    matches!(&*rhs.tree, OpTree::Term(c) if c.to_string() == "c")
+            )
+        );
+    }
+
+    #[test]
+    fn add_mul3() {
+        let ot = parse!("a * A + b * B + c * C");
+        dbg!(&ot);
+        assert!(
+            matches!(ot, OpTree::Infix(Infix { lhs, rhs, kind: InfixKind::Add }) if
+                matches!(&*lhs.tree, OpTree::Infix(Infix { lhs, rhs, kind: InfixKind::Add })
+                    if matches!(&*lhs.tree, OpTree::Infix(Infix { lhs, rhs, kind: InfixKind::Mul })) &&
+                        matches!(&*rhs.tree, OpTree::Infix(Infix { lhs, rhs, kind: InfixKind::Mul }))
+                ) &&
+                matches!(&*rhs.tree, OpTree::Infix(Infix { lhs, rhs, kind: InfixKind::Mul })))
+        );
+    }
+
+    #[test]
+    fn addparen() {
+        let ot = parse!("(a + b) + c");
+        assert!(
+            matches!(ot, OpTree::Infix(Infix { lhs, kind: InfixKind::Add, .. }) if
+            matches!(&*lhs.tree, OpTree::Paren(paren) if
+                     matches!(&*paren.tree, OpTree::Infix(Infix { kind: InfixKind::Add, .. }))
+            ))
+        );
+    }
+
+    #[test]
+    fn addparen2() {
+        let ot = parse!("a + (b + c)");
+        assert!(
+            matches!(ot, OpTree::Infix(Infix { rhs, kind: InfixKind::Add, .. }) if
+            matches!(&*rhs.tree, OpTree::Paren(paren) if
+                     matches!(&*paren.tree, OpTree::Infix(Infix { kind: InfixKind::Add, .. }))
+            ))
+        );
+    }
+
+    #[test]
+    fn addmul() {
+        let ot = parse!("a + b * c");
+        assert!(
+            matches!(ot, OpTree::Infix(Infix { lhs, rhs, kind: InfixKind::Add }) if
+                             matches!(&*lhs.tree, OpTree::Term(a) if a.to_string() == "a")
+                               &&
+                             matches!(&*rhs.tree, OpTree::Infix(Infix{ lhs, rhs, kind: InfixKind::Mul }) if
+                                      matches!(&*lhs.tree, OpTree::Term(b) if b.to_string() == "b") &&
+                                      matches!(&*rhs.tree, OpTree::Term(c) if c.to_string() == "c")
+                             )
+            )
+        );
+    }
+
+    #[test]
+    fn muladd() {
+        let ot = parse!("a * b + c");
+        assert!(
+            matches!(ot, OpTree::Infix(Infix { lhs, rhs, kind: InfixKind::Add }) if
+                             matches!(&*lhs.tree, OpTree::Infix(Infix{ lhs, rhs, kind: InfixKind::Mul }) if
+                                      matches!(&*lhs.tree, OpTree::Term(a) if a.to_string() == "a") &&
+                                      matches!(&*rhs.tree, OpTree::Term(b) if b.to_string() == "b")
+                             )  &&
+                    matches!(&*rhs.tree, OpTree::Term(c) if c.to_string() == "c")
+            )
+        );
+    }
+
+    #[test]
+    fn addsub() {
+        let ot = parse!("a + b - c");
+        assert!(
+            matches!(ot, OpTree::Infix(Infix { lhs, rhs, kind: InfixKind::Sub }) if
+                             matches!(&*lhs.tree, OpTree::Infix(Infix{ lhs, rhs, kind: InfixKind::Add }) if
+                                      matches!(&*lhs.tree, OpTree::Term(a) if a.to_string() == "a") &&
+                                      matches!(&*rhs.tree, OpTree::Term(b) if b.to_string() == "b")
+                             )  &&
+                    matches!(&*rhs.tree, OpTree::Term(c) if c.to_string() == "c")
+            )
+        );
+    }
+
+    #[test]
+    fn subadd() {
+        let ot = parse!("a - b + c");
+        assert!(
+            matches!(ot, OpTree::Infix(Infix { lhs, rhs, kind: InfixKind::Add }) if
+                             matches!(&*lhs.tree, OpTree::Infix(Infix{ lhs, rhs, kind: InfixKind::Sub }) if
+                                      matches!(&*lhs.tree, OpTree::Term(a) if a.to_string() == "a") &&
+                                      matches!(&*rhs.tree, OpTree::Term(b) if b.to_string() == "b")
+                             )  &&
+                    matches!(&*rhs.tree, OpTree::Term(c) if c.to_string() == "c")
+            )
+        );
+    }
+
+    #[test]
+    fn unary_negate() {
+        let ot = parse!("-a");
+        assert!(
+            matches!(ot, OpTree::Unary(Unary { kind: UnaryKind::Neg, subj, .. }) if matches!(&*subj.tree, OpTree::Term(a) if a.to_string() == "a"))
+        )
+    }
+
+    #[test]
+    fn unary_ref() {
+        let ot = parse!("&a");
+        assert!(
+            matches!(ot, OpTree::Unary(Unary { kind: UnaryKind::Ref, subj, .. }) if matches!(&*subj.tree, OpTree::Term(a) if a.to_string() == "a"))
+        )
+    }
+
+    #[test]
+    fn double_negate() {
+        let ot = parse!("--a");
+        assert!(
+            matches!(ot, OpTree::Unary(Unary { kind: UnaryKind::Neg, subj, ..})
+                     if matches!(&*subj.tree, OpTree::Unary(Unary { kind: UnaryKind::Neg, subj, .. })
+                                 if matches!(&*subj.tree, OpTree::Term(a) if a.to_string() == "a")))
+        )
+    }
+
+    #[test]
+    fn unary_negate_with_infix() {
+        let ot = parse!("-a * b");
+        assert!(matches!(ot, OpTree::Infix( Infix { lhs, .. },)
+                     if   matches!(&*lhs.tree, OpTree::Unary(Unary { kind: UnaryKind::Neg, subj, .. })
+                                   if matches!(&*subj.tree, OpTree::Term(a) if a.to_string() == "a"))))
+    }
+
+    #[test]
+    fn dot_product() {
+        let ot = parse!("a .* b");
+        assert!(
+            matches!(ot, OpTree::Infix( Infix { lhs, rhs, kind: InfixKind::LinComb } ) if
+                             matches!(&*lhs.tree, OpTree::Term(a) if a.to_string() == "a") &&
+                             matches!(&*rhs.tree, OpTree::Term(b) if b.to_string() == "b")
+            )
+        )
+    }
+
+    #[test]
+    fn callmethod() {
+        let ot = parse!("term.method(other, stuff)");
+        assert!(
+            matches!(ot, OpTree::Term(call) if call.to_string() == "term . method (other , stuff)")
+        );
+        let ot = parse!("term.method(other, stuff).another()");
+        assert!(
+            matches!(ot, OpTree::Term(call) if call.to_string() == "term . method (other , stuff) . another ()")
+        );
+    }
+
+    #[test]
+    fn property() {
+        let ot = parse!("term.property");
+        assert!(matches!(ot, OpTree::Term(call) if call.to_string() == "term . property"));
+        let ot = parse!("term.property.another");
+        assert!(
+            matches!(ot, OpTree::Term(call) if call.to_string() == "term . property . another")
+        );
+    }
+
+    #[test]
+    fn tuple_index() {
+        let ot = parse!("term.0");
+        assert!(matches!(ot, OpTree::Term(call) if call.to_string().replace(' ', "") == "term.0"));
+        let ot = parse!("term.1.2.3");
+        assert!(
+            matches!(ot, OpTree::Term(call) if call.to_string().replace(' ', "") == "term.1.2.3")
+        );
+    }
+
+    #[test]
+    fn array_index() {
+        let ot = parse!("term[1]");
+        assert!(matches!(ot, OpTree::Term(call) if call.to_string().replace(' ', "") == "term[1]"));
+        let ot = parse!("term[1..10]");
+        assert!(
+            matches!(ot, OpTree::Term(call) if call.to_string().replace(' ', "") == "term[1..10]")
+        );
+        let ot = parse!("term[1].7.a_method()[2]");
+        assert!(
+            matches!(ot, OpTree::Term(call) if call.to_string().replace(' ', "") == "term[1].7.a_method()[2]")
+        );
+    }
+
+    #[test]
+    fn int_lit() {
+        let ot = parse!("1");
+        assert!(matches!(ot, OpTree::LitInt(1u32)));
+    }
+}

--- a/ecdsa_fun/src/adaptor/mod.rs
+++ b/ecdsa_fun/src/adaptor/mod.rs
@@ -166,7 +166,7 @@ impl<T: Transcript<DLEQ>, NG> Adaptor<T, NG> {
             // will also be uniform.
             .expect("computationally unreachable");
 
-        let s_hat = s!({ r.invert() } * (m + R_x * x))
+        let s_hat = s!(r.invert() * (m + R_x * x))
             .public()
             .non_zero()
             .expect("computationally unreachable");
@@ -286,7 +286,7 @@ impl<T: Transcript<DLEQ>, NG> Adaptor<T, NG> {
             return None;
         }
         let s = &signature.s;
-        let y = s!({ s.invert() } * s_hat);
+        let y = s!(s.invert() * s_hat);
         let Y = g!(y * G);
 
         if Y == *encryption_key {

--- a/ecdsa_fun/src/lib.rs
+++ b/ecdsa_fun/src/lib.rs
@@ -177,17 +177,18 @@ impl<NG: NonceGen> ECDSA<NG> {
             .non_zero()
             .expect("computationally unreachable");
 
-        let mut s = s!({ r.invert() } * (m + R_x * x))
+        let mut s = s!((m + R_x * x) / r)
             // Given R_x is determined by x and m through a hash, reaching
             // (m + R_x * x) = 0 is intractable.
             .non_zero()
-            .expect("computationally unreachable");
+            .expect("computationally unreachable")
+            .public();
 
         // s values must be low (less than half group order), otherwise signatures
         // would be malleable i.e. (R,s) and (R,-s) would both be valid signatures.
         s.conditional_negate(s.is_high());
 
-        Signature { R_x, s: s.public() }
+        Signature { R_x, s }
     }
 }
 

--- a/ecdsa_fun/tests/adaptor_test_vectors.rs
+++ b/ecdsa_fun/tests/adaptor_test_vectors.rs
@@ -102,5 +102,5 @@ fn run_test_vector(
     let decryption_key =
         ecdsa_adaptor.recover_decryption_key(&t.encryption_key, &t.signature, &t.adaptor_sig);
 
-    decryption_key == Some(t.decryption_key.clone())
+    decryption_key == Some(t.decryption_key)
 }

--- a/schnorr_fun/benches/bench_schnorr.rs
+++ b/schnorr_fun/benches/bench_schnorr.rs
@@ -18,7 +18,7 @@ lazy_static::lazy_static! {
 fn sign_schnorr(c: &mut Criterion) {
     let mut group = c.benchmark_group("schnorr_sign");
     {
-        let keypair = schnorr.new_keypair(SK.clone());
+        let keypair = schnorr.new_keypair(*SK);
         group.bench_function("fun::schnorr_sign", |b| {
             b.iter(|| schnorr.sign(&keypair, Message::<Public>::raw(MESSAGE)))
         });
@@ -27,7 +27,7 @@ fn sign_schnorr(c: &mut Criterion) {
     {
         use secp256k1::{KeyPair, Message, Secp256k1};
         let secp = Secp256k1::new();
-        let kp = KeyPair::from_secret_key(&secp, &SK.clone().into());
+        let kp = KeyPair::from_secret_key(&secp, &(*SK).into());
         let msg = Message::from_slice(&MESSAGE[..]).unwrap();
         group.bench_function("secp::schnorrsig_sign_no_aux_rand", |b| {
             b.iter(|| {
@@ -39,7 +39,7 @@ fn sign_schnorr(c: &mut Criterion) {
 
 fn verify_schnorr(c: &mut Criterion) {
     let mut group = c.benchmark_group("schnorr_verify");
-    let keypair = schnorr.new_keypair(SK.clone());
+    let keypair = schnorr.new_keypair(*SK);
     {
         let message = Message::<Public>::raw(MESSAGE);
         let sig = schnorr.sign(&keypair, message);
@@ -59,7 +59,7 @@ fn verify_schnorr(c: &mut Criterion) {
     {
         use secp256k1::{KeyPair, Message, Secp256k1, XOnlyPublicKey};
         let secp = Secp256k1::new();
-        let kp = KeyPair::from_secret_key(&secp, &SK.clone().into());
+        let kp = KeyPair::from_secret_key(&secp, &(*SK).into());
         let pk = XOnlyPublicKey::from_keypair(&kp).0;
         let msg = Message::from_slice(&MESSAGE[..]).unwrap();
         let sig = secp.sign_schnorr_no_aux_rand(&msg, &kp);

--- a/schnorr_fun/src/frost.rs
+++ b/schnorr_fun/src/frost.rs
@@ -524,7 +524,7 @@ impl<H: Digest<OutputSize = U32> + Clone, NG: NonceGen> Frost<H, NG> {
         scalar_poly: &[Scalar],
         message: Message,
     ) -> Signature {
-        let key_pair = self.schnorr.new_keypair(scalar_poly[0].clone());
+        let key_pair = self.schnorr.new_keypair(scalar_poly[0]);
         self.schnorr.sign(&key_pair, message)
     }
 
@@ -848,10 +848,7 @@ impl<H: Digest<OutputSize = U32> + Clone, NG> Frost<H, NG> {
         let agg_nonce = nonce_map
             .iter()
             .fold([Point::zero(); 2], |acc, (_, nonce)| {
-                [
-                    g!({ acc[0] } + { nonce.0[0] }),
-                    g!({ acc[1] } + { nonce.0[1] }),
-                ]
+                [g!(acc[0] + nonce.0[0]), g!(acc[1] + nonce.0[1])]
             });
 
         let agg_nonce = [agg_nonce[0].normalize(), agg_nonce[1].normalize()];
@@ -864,12 +861,11 @@ impl<H: Digest<OutputSize = U32> + Clone, NG> Frost<H, NG> {
                 .add(frost_key.public_key())
                 .add(message),
         );
-        let (agg_nonce, nonces_need_negation) =
-            g!({ agg_nonce[0] } + binding_coeff * { agg_nonce[1] })
-                .normalize()
-                .non_zero()
-                .unwrap_or(Point::generator())
-                .into_point_with_even_y();
+        let (agg_nonce, nonces_need_negation) = g!(agg_nonce[0] + binding_coeff * agg_nonce[1])
+            .normalize()
+            .non_zero()
+            .unwrap_or(Point::generator())
+            .into_point_with_even_y();
 
         let challenge = self
             .schnorr
@@ -1099,11 +1095,12 @@ fn scalar_poly_eval(
     poly: &[Scalar],
     x: Scalar<impl Secrecy, impl ZeroChoice>,
 ) -> Scalar<Secret, Zero> {
-    poly.iter()
-        .fold((s!(0), s!(1).mark_zero()), |(eval, xpow), coeff| {
-            (s!(eval + xpow * coeff), s!(xpow * x))
-        })
-        .0
+    let xpows = core::iter::successors(Some(s!(1).public().mark_zero()), |xpow| {
+        Some(s!(xpow * x).public())
+    })
+    .take(poly.len());
+
+    s!(xpows .* poly)
 }
 
 fn point_poly_eval(
@@ -1113,9 +1110,8 @@ fn point_poly_eval(
     let xpows = core::iter::successors(Some(s!(1).public().mark_zero()), |xpow| {
         Some(s!(xpow * x).public())
     })
-    .take(poly.len())
-    .collect::<Vec<_>>();
-    secp256kfun::op::lincomb(&xpows, poly.iter())
+    .take(poly.len());
+    g!(xpows .* poly)
 }
 
 #[cfg(test)]

--- a/schnorr_fun/src/frost.rs
+++ b/schnorr_fun/src/frost.rs
@@ -1095,23 +1095,21 @@ fn scalar_poly_eval(
     poly: &[Scalar],
     x: Scalar<impl Secrecy, impl ZeroChoice>,
 ) -> Scalar<Secret, Zero> {
-    let xpows = core::iter::successors(Some(s!(1).public().mark_zero()), |xpow| {
-        Some(s!(xpow * x).public())
-    })
-    .take(poly.len());
-
-    s!(xpows .* poly)
+    s!(powers(x) .* poly)
 }
 
 fn point_poly_eval(
     poly: &[Point<impl PointType, Public, impl ZeroChoice>],
     x: Scalar<Public, impl ZeroChoice>,
 ) -> Point<NonNormal, Public, Zero> {
-    let xpows = core::iter::successors(Some(s!(1).public().mark_zero()), |xpow| {
-        Some(s!(xpow * x).public())
+    g!(powers(x) .* poly)
+}
+
+/// Returns an iterator of 1, x, x², x³ ...
+fn powers<S: Secrecy, Z: ZeroChoice>(x: Scalar<S, Z>) -> impl Iterator<Item = Scalar<S, Z>> {
+    core::iter::successors(Some(Scalar::one().mark_zero_choice::<Z>()), move |xpow| {
+        Some(s!(xpow * x).set_secrecy())
     })
-    .take(poly.len());
-    g!(xpows .* poly)
 }
 
 #[cfg(test)]

--- a/schnorr_fun/src/musig.rs
+++ b/schnorr_fun/src/musig.rs
@@ -312,7 +312,7 @@ impl<H: Digest<OutputSize = U32> + Clone, NG> MuSig<H, NG> {
             })
             .collect::<Vec<_>>();
 
-        let agg_key = crate::fun::op::lincomb(coefs.iter(), keys.iter())
+        let agg_key = g!(&coefs .* &keys)
             .non_zero().expect("computationally unreachable: linear combination of hash randomised points cannot add to zero");
 
         AggKey {
@@ -531,13 +531,10 @@ impl<H: Digest<OutputSize = U32> + Clone, NG> MuSig<H, NG> {
     ) {
         let mut Rs = nonces;
         let agg_Rs = Rs.iter().fold([Point::zero(); 2], |acc, nonce| {
-            [
-                g!({ acc[0] } + { nonce.0[0] }),
-                g!({ acc[1] } + { nonce.0[1] }),
-            ]
+            [g!(acc[0] + nonce.0[0]), g!(acc[1] + nonce.0[1])]
         });
         let agg_Rs = Nonce::<Zero>([
-            g!({ agg_Rs[0] } + encryption_key).normalize(),
+            g!(agg_Rs[0] + encryption_key).normalize(),
             agg_Rs[1].normalize(),
         ]);
 
@@ -552,7 +549,7 @@ impl<H: Digest<OutputSize = U32> + Clone, NG> MuSig<H, NG> {
         .public()
         .mark_zero();
 
-        let (R, r_needs_negation) = g!({ agg_Rs.0[0] } + b * { agg_Rs.0[1] })
+        let (R, r_needs_negation) = g!(agg_Rs.0[0] + b * agg_Rs.0[1])
             .normalize()
             .non_zero()
             .unwrap_or(Point::generator())

--- a/schnorr_fun/tests/against_c_lib.rs
+++ b/schnorr_fun/tests/against_c_lib.rs
@@ -63,7 +63,7 @@ proptest! {
         msg in any::<[u8;32]>(),
     ) {
         let secp = &*SECP;
-        let keypair = secp256k1::KeyPair::from_secret_key(secp, &key.clone().into());
+        let keypair = secp256k1::KeyPair::from_secret_key(secp, &key.into());
         let secp_msg = secp256k1::Message::from_slice(&msg).unwrap();
         let sig = secp.sign_schnorr_no_aux_rand(&secp_msg, &keypair);
         let schnorr = Schnorr::<Sha256,Bip340NoAux>::default();

--- a/schnorr_fun/tests/musig_sign_verify.rs
+++ b/schnorr_fun/tests/musig_sign_verify.rs
@@ -90,7 +90,7 @@ pub struct TestCase {
 fn musig_sign_verify() {
     let test_cases = serde_json::from_str::<TestCases>(TEST_JSON).unwrap();
     let musig = musig::new_without_nonce_generation::<sha2::Sha256>();
-    let keypair = musig.new_keypair(test_cases.sk.clone());
+    let keypair = musig.new_keypair(test_cases.sk);
 
     for test_case in &test_cases.valid_test_cases {
         let pubkeys = test_case
@@ -119,7 +119,7 @@ fn musig_sign_verify() {
                 .unwrap()
                 .nonce,
         );
-        assert_eq!(partial_sig, test_case.expected.clone().unwrap());
+        assert_eq!(partial_sig, test_case.expected.unwrap());
         assert!(musig.verify_partial_signature(
             &agg_key,
             &session,

--- a/secp256kfun/Cargo.toml
+++ b/secp256kfun/Cargo.toml
@@ -18,6 +18,7 @@ keywords = ["bitcoin", "secp256k1"]
 digest = { version = "0.10", default-features = false }
 subtle = { package = "subtle-ng", version = "2", default-features = false }
 rand_core = { version = "0.6", default-features = false }
+secp256kfun_arithmetic_macros = { version = "0.9.0", path = "../arithmetic_macros" }
 
 # optional
 serde = { version = "1.0",  optional = true, default-features = false, features = ["derive"] }

--- a/secp256kfun/benches/bench_ecmult.rs
+++ b/secp256kfun/benches/bench_ecmult.rs
@@ -153,7 +153,7 @@ fn multi_mul(c: &mut Criterion) {
                     ],
                 )
             },
-            |(scalars, points)| op::lincomb(scalars.iter(), points.iter()),
+            |(scalars, points)| op::point_scalar_dot_product(scalars.iter(), points.iter()),
             BatchSize::SmallInput,
         )
     });

--- a/secp256kfun/src/backend/k256_impl.rs
+++ b/secp256kfun/src/backend/k256_impl.rs
@@ -202,11 +202,17 @@ impl TimeSensitive for ConstantTime {
     }
 
     #[cfg(feature = "alloc")]
-    fn lincomb_iter<'a, 'b, A: Iterator<Item = &'a Point>, B: Iterator<Item = &'b Scalar>>(
+    #[inline(always)]
+    fn lincomb_iter<
+        A: Iterator<Item = AT>,
+        B: Iterator<Item = BT>,
+        AT: AsRef<Point>,
+        BT: AsRef<Scalar>,
+    >(
         points: A,
         scalars: B,
     ) -> Point {
-        mul::lincomb_iter(points, scalars)
+        mul::lincomb_iter(points.map(|p| *p.as_ref()), scalars)
     }
 }
 
@@ -327,7 +333,12 @@ impl TimeSensitive for VariableTime {
     }
 
     #[cfg(feature = "alloc")]
-    fn lincomb_iter<'a, 'b, A: Iterator<Item = &'a Point>, B: Iterator<Item = &'b Scalar>>(
+    fn lincomb_iter<
+        A: Iterator<Item = AT>,
+        B: Iterator<Item = BT>,
+        AT: AsRef<Point>,
+        BT: AsRef<Scalar>,
+    >(
         points: A,
         scalars: B,
     ) -> Point {

--- a/secp256kfun/src/keypair.rs
+++ b/secp256kfun/src/keypair.rs
@@ -77,8 +77,8 @@ impl KeyPair<EvenY> {
     ///     &original_secret_key == keypair.secret_key()
     ///         || &-original_secret_key == keypair.secret_key()
     /// );
-    /// assert!(g!({ keypair.secret_key() } * G).normalize().is_y_even());
-    /// assert_eq!(g!({ keypair.secret_key() } * G), keypair.public_key());
+    /// assert!(g!(keypair.secret_key() * G).normalize().is_y_even());
+    /// assert_eq!(g!(keypair.secret_key() * G), keypair.public_key());
     /// ```
     ///
     /// [`Point`]: crate::Point

--- a/secp256kfun/src/lib.rs
+++ b/secp256kfun/src/lib.rs
@@ -57,6 +57,10 @@ pub use serde;
 #[cfg(feature = "bincode")]
 pub use bincode;
 
+#[doc(hidden)]
+/// these are helpers so we hide them. Actual g! macro is defined in macros.rs
+pub use secp256kfun_arithmetic_macros as arithmetic_macros;
+
 mod libsecp_compat;
 #[cfg(any(feature = "proptest", test))]
 mod proptest_impls;

--- a/secp256kfun/src/marker/zero_choice.rs
+++ b/secp256kfun/src/marker/zero_choice.rs
@@ -22,6 +22,7 @@ pub trait ZeroChoice:
     + Copy
     + DecideZero<NonZero>
     + DecideZero<Zero>
+    + DecideZero<Self, Out = Self>
     + core::hash::Hash
     + Ord
     + PartialOrd

--- a/secp256kfun/src/point.rs
+++ b/secp256kfun/src/point.rs
@@ -72,7 +72,13 @@ impl<Z, S, T: Clone> Clone for Point<T, S, Z> {
     }
 }
 
-impl<T: Copy, Z> Copy for Point<T, Public, Z> {}
+impl<T, S, Z> AsRef<backend::Point> for Point<T, S, Z> {
+    fn as_ref(&self) -> &backend::Point {
+        &self.0
+    }
+}
+
+impl<T: Copy, S, Z> Copy for Point<T, S, Z> {}
 
 impl Point<Normal, Public, NonZero> {
     /// Samples a point uniformly from the group.
@@ -222,7 +228,7 @@ impl Point<EvenY, Public, NonZero> {
         base: &Point<impl PointType, impl Secrecy>,
         scalar: &mut Scalar<impl Secrecy>,
     ) -> Self {
-        let point = crate::op::scalar_mul_point(scalar, base);
+        let point = crate::op::scalar_mul_point(*scalar, base);
         let (point, needs_negation) = point.into_point_with_even_y();
         scalar.conditional_negate(needs_negation);
         point
@@ -256,7 +262,7 @@ impl<T, S, Z> Point<T, S, Z> {
     where
         T: PointType,
     {
-        op::point_conditional_negate(&self.clone(), cond)
+        op::point_conditional_negate(*self, cond)
     }
 
     /// Set the [`Secrecy`] of the point.
@@ -329,7 +335,7 @@ impl<Z, T> Point<T, Public, Z> {
 impl<T: PointType, S, Z> core::ops::Neg for Point<T, S, Z> {
     type Output = Point<T::NegationType, S, Z>;
     fn neg(self) -> Self::Output {
-        op::point_negate(&self)
+        op::point_negate(self)
     }
 }
 
@@ -560,25 +566,25 @@ crate::impl_fromstr_deserialize! {
 
 impl<TR, SL, SR, ZR> AddAssign<Point<TR, SR, ZR>> for Point<NonNormal, SL, Zero> {
     fn add_assign(&mut self, rhs: Point<TR, SR, ZR>) {
-        *self = crate::op::point_add(self, &rhs).set_secrecy::<SL>()
+        *self = crate::op::point_add(*self, &rhs).set_secrecy::<SL>()
     }
 }
 
 impl<TR, SL, SR, ZR> AddAssign<&Point<TR, SR, ZR>> for Point<NonNormal, SL, Zero> {
     fn add_assign(&mut self, rhs: &Point<TR, SR, ZR>) {
-        *self = crate::op::point_add(self, rhs).set_secrecy::<SL>()
+        *self = crate::op::point_add(*self, rhs).set_secrecy::<SL>()
     }
 }
 
 impl<TR, SL, SR, ZR> SubAssign<&Point<TR, SR, ZR>> for Point<NonNormal, SL, Zero> {
     fn sub_assign(&mut self, rhs: &Point<TR, SR, ZR>) {
-        *self = crate::op::point_sub(self, rhs).set_secrecy::<SL>()
+        *self = crate::op::point_sub(*self, rhs).set_secrecy::<SL>()
     }
 }
 
 impl<TR, SL, SR, ZR> SubAssign<Point<TR, SR, ZR>> for Point<NonNormal, SL, Zero> {
     fn sub_assign(&mut self, rhs: Point<TR, SR, ZR>) {
-        *self = crate::op::point_sub(self, &rhs).set_secrecy::<SL>()
+        *self = crate::op::point_sub(*self, &rhs).set_secrecy::<SL>()
     }
 }
 
@@ -835,7 +841,7 @@ mod test {
         let mut a = a_orig;
         let b = Point::random(&mut rand::thread_rng());
         a += b;
-        assert_eq!(a, op::point_add(&a_orig, &b));
+        assert_eq!(a, op::point_add(a_orig, b));
         a -= b;
         assert_eq!(a, a_orig);
     }

--- a/secp256kfun/src/scalar.rs
+++ b/secp256kfun/src/scalar.rs
@@ -149,6 +149,39 @@ impl<S> Scalar<S, NonZero> {
     pub fn minus_one() -> Self {
         Self::from_inner(backend::BackendScalar::minus_one())
     }
+
+    /// Marks a scalar non-zero scalar as having the zero choice `Z` (rather than `NonZero`).
+    ///
+    /// Useful when writing code that preserves the zero choice of the caller.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use secp256kfun::{marker::*, s, Scalar};
+    ///
+    /// /// Returns an iterator of 1, x, x², x³ ...
+    /// fn powers<S: Secrecy, Z: ZeroChoice>(x: Scalar<S, Z>) -> impl Iterator<Item = Scalar<S, Z>> {
+    ///     core::iter::successors(Some(Scalar::one().mark_zero_choice::<Z>()), move |xpow| {
+    ///         Some(s!(xpow * x).set_secrecy())
+    ///     })
+    /// }
+    ///
+    /// assert_eq!(powers(s!(2)).take(4).collect::<Vec<_>>(), vec![
+    ///     s!(1),
+    ///     s!(2),
+    ///     s!(4),
+    ///     s!(8)
+    /// ]);
+    /// assert_eq!(powers(s!(0)).take(4).collect::<Vec<_>>(), vec![
+    ///     s!(1).mark_zero(),
+    ///     s!(0),
+    ///     s!(0),
+    ///     s!(0)
+    /// ]);
+    /// ```
+    pub fn mark_zero_choice<Z: ZeroChoice>(self) -> Scalar<S, Z> {
+        Scalar::from_inner(self.0)
+    }
 }
 
 impl Scalar<Secret, NonZero> {

--- a/secp256kfun/src/scalar.rs
+++ b/secp256kfun/src/scalar.rs
@@ -51,11 +51,17 @@ use rand_core::RngCore;
 /// [`ZeroChoice]: crate::marker::ZeroChoice
 pub struct Scalar<S = Secret, Z = NonZero>(pub(crate) backend::Scalar, PhantomData<(Z, S)>);
 
-impl<Z> Copy for Scalar<Public, Z> {}
+impl<Z, S> Copy for Scalar<S, Z> {}
+
+impl<S, Z> AsRef<backend::Scalar> for Scalar<S, Z> {
+    fn as_ref(&self) -> &backend::Scalar {
+        &self.0
+    }
+}
 
 impl<S, Z> Clone for Scalar<S, Z> {
     fn clone(&self) -> Self {
-        Self(self.0, self.1)
+        *self
     }
 }
 
@@ -320,7 +326,7 @@ impl<S, Z> core::ops::Neg for Scalar<S, Z> {
     type Output = Scalar<S, Z>;
 
     fn neg(self) -> Self::Output {
-        crate::op::scalar_negate(&self)
+        crate::op::scalar_negate(self)
     }
 }
 
@@ -358,49 +364,49 @@ where
 
 impl<SL, SR, ZR> AddAssign<Scalar<SR, ZR>> for Scalar<SL, Zero> {
     fn add_assign(&mut self, rhs: Scalar<SR, ZR>) {
-        *self = crate::op::scalar_add(self, &rhs).set_secrecy::<SL>();
+        *self = crate::op::scalar_add(*self, rhs).set_secrecy::<SL>();
     }
 }
 
 impl<SL, SR, ZR> AddAssign<&Scalar<SR, ZR>> for Scalar<SL, Zero> {
     fn add_assign(&mut self, rhs: &Scalar<SR, ZR>) {
-        *self = crate::op::scalar_add(self, rhs).set_secrecy::<SL>();
+        *self = crate::op::scalar_add(*self, rhs).set_secrecy::<SL>();
     }
 }
 
 impl<SL, SR, ZR> SubAssign<&Scalar<SR, ZR>> for Scalar<SL, Zero> {
     fn sub_assign(&mut self, rhs: &Scalar<SR, ZR>) {
-        *self = crate::op::scalar_sub(self, rhs).set_secrecy::<SL>();
+        *self = crate::op::scalar_sub(*self, rhs).set_secrecy::<SL>();
     }
 }
 
 impl<SL, SR, ZR> SubAssign<Scalar<SR, ZR>> for Scalar<SL, Zero> {
     fn sub_assign(&mut self, rhs: Scalar<SR, ZR>) {
-        *self = crate::op::scalar_sub(self, &rhs).set_secrecy::<SL>();
+        *self = crate::op::scalar_sub(*self, rhs).set_secrecy::<SL>();
     }
 }
 
 impl<SL, SR> MulAssign<Scalar<SR, NonZero>> for Scalar<SL, NonZero> {
     fn mul_assign(&mut self, rhs: Scalar<SR, NonZero>) {
-        *self = crate::op::scalar_mul(self, &rhs).set_secrecy::<SL>();
+        *self = crate::op::scalar_mul(*self, rhs).set_secrecy::<SL>();
     }
 }
 
 impl<SL, SR> MulAssign<&Scalar<SR, NonZero>> for Scalar<SL, NonZero> {
     fn mul_assign(&mut self, rhs: &Scalar<SR, NonZero>) {
-        *self = crate::op::scalar_mul(self, rhs).set_secrecy::<SL>();
+        *self = crate::op::scalar_mul(*self, rhs).set_secrecy::<SL>();
     }
 }
 
 impl<SL, SR, ZR: ZeroChoice> MulAssign<Scalar<SR, ZR>> for Scalar<SL, Zero> {
     fn mul_assign(&mut self, rhs: Scalar<SR, ZR>) {
-        *self = crate::op::scalar_mul(self, &rhs).set_secrecy::<SL>();
+        *self = crate::op::scalar_mul(*self, rhs).set_secrecy::<SL>();
     }
 }
 
 impl<SL, SR, ZR: ZeroChoice> MulAssign<&Scalar<SR, ZR>> for Scalar<SL, Zero> {
     fn mul_assign(&mut self, rhs: &Scalar<SR, ZR>) {
-        *self = crate::op::scalar_mul(self, rhs).set_secrecy::<SL>();
+        *self = crate::op::scalar_mul(*self, rhs).set_secrecy::<SL>();
     }
 }
 
@@ -506,7 +512,7 @@ mod test {
             -Scalar::<Secret, NonZero>::one()
         );
         assert_eq!(
-            op::scalar_mul(&s!(3), &Scalar::<Secret, NonZero>::minus_one()),
+            op::scalar_mul(s!(3), Scalar::<Secret, NonZero>::minus_one()),
             -s!(3)
         );
     }

--- a/secp256kfun/src/slice.rs
+++ b/secp256kfun/src/slice.rs
@@ -26,10 +26,7 @@ pub struct Slice<'a, S = Public> {
 
 impl<'a, S> Clone for Slice<'a, S> {
     fn clone(&self) -> Self {
-        Self {
-            inner: self.inner,
-            secrecy: PhantomData,
-        }
+        *self
     }
 }
 

--- a/secp256kfun/src/vendor/k256/mul.rs
+++ b/secp256kfun/src/vendor/k256/mul.rs
@@ -411,9 +411,9 @@ impl MulAssign<&Scalar> for ProjectivePoint {
 
 /// Calculates a linear combination `sum(x[i] * k[i])`, `i = 0..N`
 #[cfg(feature = "alloc")]
-pub fn lincomb_iter<'a, 'b>(
-    xs: impl Iterator<Item = &'a ProjectivePoint>,
-    ks: impl Iterator<Item = &'b Scalar>,
+pub fn lincomb_iter<S: AsRef<Scalar>, P: AsRef<ProjectivePoint>>(
+    xs: impl Iterator<Item = P>,
+    ks: impl Iterator<Item = S>,
 ) -> ProjectivePoint {
     use alloc::vec::Vec;
     use subtle::ConditionallyNegatable;
@@ -424,8 +424,9 @@ pub fn lincomb_iter<'a, 'b>(
     let mut tables2 = Vec::with_capacity(size);
     let mut n = 0;
 
-    for (k, mut x) in ks.zip(xs.cloned()) {
-        let (mut r1, mut r2) = decompose_scalar(&k);
+    for (k, x) in ks.zip(xs) {
+        let mut x = x.as_ref().clone();
+        let (mut r1, mut r2) = decompose_scalar(k.as_ref());
         let mut x_beta = x.endomorphism();
         let r1_is_high = r1.is_high();
         let r2_is_high = r2.is_high();

--- a/secp256kfun/src/vendor/k256/projective.rs
+++ b/secp256kfun/src/vendor/k256/projective.rs
@@ -490,3 +490,9 @@ impl<'a> Neg for &'a ProjectivePoint {
         ProjectivePoint::neg(self)
     }
 }
+
+impl AsRef<ProjectivePoint> for ProjectivePoint {
+    fn as_ref(&self) -> &ProjectivePoint {
+        self
+    }
+}

--- a/secp256kfun/src/vendor/k256/scalar.rs
+++ b/secp256kfun/src/vendor/k256/scalar.rs
@@ -429,3 +429,9 @@ impl From<&Scalar> for FieldBytes {
         scalar.to_bytes()
     }
 }
+
+impl AsRef<Scalar> for Scalar {
+    fn as_ref(&self) -> &Scalar {
+        self
+    }
+}

--- a/secp256kfun/tests/against_c_lib.rs
+++ b/secp256kfun/tests/against_c_lib.rs
@@ -51,10 +51,10 @@ mod against_c_lib {
             let result = {
                 let H = g!({ Scalar::<Secret, Zero>::from_bytes_mod_order(scalar_H) } * G);
                 double_mul(
-                    &Scalar::<Secret, Zero>::from_bytes_mod_order(x).public(),
+                    Scalar::<Secret, Zero>::from_bytes_mod_order(x).public(),
                     G,
-                    &Scalar::<Secret, Zero>::from_bytes_mod_order(y).public(),
-                    &H,
+                    Scalar::<Secret, Zero>::from_bytes_mod_order(y).public(),
+                    H,
                 )
                     .normalize().non_zero()
                     .unwrap()

--- a/secp256kfun/tests/expression_macros.rs
+++ b/secp256kfun/tests/expression_macros.rs
@@ -17,53 +17,61 @@ fn s_expressions_give_correct_answers() {
     let b = s!(5);
     let c = s!(11);
 
-    assert_eq!(s!(a), &a);
-    assert_eq!(s!({ a.invert() }), a.invert());
+    assert_eq!(s!(a), a);
+    assert_eq!(s!(a.invert()), a.invert());
     assert_eq!(s!(-a), -&a);
-    assert_eq!(s!(a + b), op::scalar_add(&a, &b));
-    assert_eq!(s!(-a + b), op::scalar_sub(&b, &a));
-    assert_eq!(s!(a - b), op::scalar_sub(&a, &b));
-    assert_eq!(s!({ a.invert() } * a), s!(1));
+    assert_eq!(s!(a + b), op::scalar_add(a, b));
+    assert_eq!(s!(-a + b), op::scalar_sub(b, a));
+    assert_eq!(s!(a - b), op::scalar_sub(a, b));
+    assert_eq!(s!(a.invert() * a), s!(1));
+    assert_eq!(s!(a / a), s!(1));
+    assert_eq!(s!(a / a * b), b);
+    assert_eq!(s!(a * b / a), b);
     assert_eq!(
         s!(a + b - c - a),
-        op::scalar_sub(&op::scalar_sub(&op::scalar_add(&a, &b), &c), &a)
+        op::scalar_sub(op::scalar_sub(op::scalar_add(a, b), c), a)
     );
 
-    assert_eq!(s!(a - c * b), op::scalar_sub(&a, &op::scalar_mul(&c, &b)));
+    assert_eq!(s!(a - c * b), op::scalar_sub(a, op::scalar_mul(c, b)));
     assert_eq!(
         s!(a - c * b - a),
-        op::scalar_sub(&op::scalar_sub(&a, &op::scalar_mul(&c, &b)), &a)
+        op::scalar_sub(op::scalar_sub(a, op::scalar_mul(c, b)), a)
     );
     assert_eq!(
         s!(a - c * b + a),
-        op::scalar_add(&op::scalar_sub(&a, &op::scalar_mul(&c, &b)), &a)
+        op::scalar_add(op::scalar_sub(a, op::scalar_mul(c, b)), a)
     );
-    assert_eq!(s!(a * b), op::scalar_mul(&a, &b));
-    assert_eq!(s!(a * -b), op::scalar_mul(&a, &-&b));
-    assert_eq!(s!(a * b - c), op::scalar_sub(&op::scalar_mul(&a, &b), &c));
-    assert_eq!(s!(a * (b + c)), op::scalar_mul(&a, &op::scalar_add(&b, &c)));
-    assert_eq!(
-        s!(a * -(b + c)),
-        op::scalar_mul(&a, &-op::scalar_add(&b, &c))
-    );
+    assert_eq!(s!(a * b), op::scalar_mul(a, b));
+    assert_eq!(s!(a * -b), op::scalar_mul(a, -b));
+    assert_eq!(s!(a * b - c), op::scalar_sub(op::scalar_mul(a, b), c));
+    assert_eq!(s!(a * (b + c)), op::scalar_mul(a, op::scalar_add(b, c)));
+    assert_eq!(s!(a * -(b + c)), op::scalar_mul(a, -op::scalar_add(b, c)));
     assert_eq!(
         s!(a * -(b + c) + a),
-        op::scalar_add(&op::scalar_mul(&a, &-op::scalar_add(&b, &c)), &a)
+        op::scalar_add(op::scalar_mul(a, -op::scalar_add(b, c)), a)
     );
-    assert_eq!(s!(a * b * c), op::scalar_mul(&a, &op::scalar_mul(&b, &c)));
-    assert_eq!(s!(-a * b * -c), op::scalar_mul(&a, &op::scalar_mul(&b, &c)));
+    assert_eq!(s!(a * b * c), op::scalar_mul(a, op::scalar_mul(b, c)));
+    assert_eq!(s!(-a * b * -c), op::scalar_mul(a, op::scalar_mul(b, c)));
 
     let has_scalar = Has { has: s!(17) };
 
-    assert_eq!(s!(has_scalar.has * a), op::scalar_mul(&has_scalar.has, &a));
+    assert_eq!(s!(has_scalar.has * a), op::scalar_mul(has_scalar.has, a));
     let has_has_scalar = HasHas {
         has_has: has_scalar.clone(),
     };
     assert_eq!(
         s!(has_has_scalar.has_has.has * a),
-        op::scalar_mul(&has_scalar.has, &a)
+        op::scalar_mul(has_scalar.has, a)
     );
     assert_eq!(s!(3 * 11 + 5), s!(a * c + b));
+
+    let x = [a, b, c];
+    let y = [s!(13), s!(17), s!(19)];
+
+    assert_eq!(s!(x .* y), s!(a * y[0] + b * y[1] + c * y[2]));
+    let ref_x = &x;
+    let ref_y = &y;
+    assert_eq!(s!(ref_x .* ref_y), s!(a * y[0] + b * y[1] + c * y[2]));
 }
 
 #[test]
@@ -75,85 +83,61 @@ fn g_expressions_give_correct_answers() {
     let B = Point::random(&mut rand::thread_rng());
     let C = Point::random(&mut rand::thread_rng());
 
-    assert_eq!(g!(A), &A);
+    assert_eq!(g!(A), A);
     assert_eq!(g!(-A), -&A);
-    assert_eq!(g!(x * A), op::scalar_mul_point(&x, &A));
-    assert_eq!(g!(-x * A), op::scalar_mul_point(&-&x, &A));
-    assert_eq!(g!(A - B), op::point_sub(&A, &B));
-    assert_eq!(g!(A + -B), op::point_sub(&A, &B));
-    assert_eq!(g!(A + B), op::point_add(&A, &B));
-    assert_eq!(
-        g!(x * A + B),
-        op::point_add(&op::scalar_mul_point(&x, &A), &B)
-    );
-    assert_eq!(
-        g!(x * A - B),
-        op::point_sub(&op::scalar_mul_point(&x, &A), &B)
-    );
+    assert_eq!(g!(x * A), op::scalar_mul_point(x, A));
+    assert_eq!(g!(-x * A), op::scalar_mul_point(-x, A));
+    assert_eq!(g!(A - B), op::point_sub(A, B));
+    assert_eq!(g!(A + -B), op::point_sub(A, B));
+    assert_eq!(g!(A + B), op::point_add(A, B));
+    assert_eq!(g!(x * A + B), op::point_add(op::scalar_mul_point(x, A), B));
+    assert_eq!(g!(x * A - B), op::point_sub(op::scalar_mul_point(x, A), B));
     assert_eq!(
         g!(-x * A + B),
-        op::point_add(&op::scalar_mul_point(&-&x, &A), &B)
+        op::point_add(op::scalar_mul_point(-x, A), B)
     );
     assert_eq!(
         g!(-x * A - B),
-        op::point_sub(&op::scalar_mul_point(&-&x, &A), &B)
+        op::point_sub(op::scalar_mul_point(-x, A), B)
     );
-    assert_eq!(
-        g!(A + x * B),
-        op::point_add(&A, &op::scalar_mul_point(&x, &B))
-    );
-    assert_eq!(
-        g!(A - x * B),
-        op::point_sub(&A, &op::scalar_mul_point(&x, &B))
-    );
-    assert_eq!(g!(x * A + y * B), op::double_mul(&x, &A, &y, &B));
-    assert_eq!(g!(x * A - y * B), op::double_mul(&x, &A, &-&y, &B));
+    assert_eq!(g!(A + x * B), op::point_add(A, op::scalar_mul_point(x, B)));
+    assert_eq!(g!(A - x * B), op::point_sub(A, op::scalar_mul_point(x, B)));
+    assert_eq!(g!(x * A + y * B), op::double_mul(x, A, y, B));
+    assert_eq!(g!(x * A - y * B), op::double_mul(x, A, -y, B));
 
     assert_eq!(
         g!((x - x * y) * A + y * B),
-        op::double_mul(&op::scalar_sub(&x, &op::scalar_mul(&x, &y)), &A, &y, &B)
+        op::double_mul(op::scalar_sub(x, op::scalar_mul(x, y)), A, y, B)
     );
 
     assert_eq!(
         g!(x * A + y * B + z * C),
-        op::point_add(
-            &op::double_mul(&x, &A, &y, &B),
-            &op::scalar_mul_point(&z, &C)
-        )
+        op::point_add(op::double_mul(x, A, y, B), op::scalar_mul_point(z, C))
     );
 
     assert_eq!(
         g!(x * A - y * B + z * C),
-        op::point_add(
-            &op::double_mul(&x, &A, &-&y, &B),
-            &op::scalar_mul_point(&z, &C)
-        )
+        op::point_add(op::double_mul(x, A, -y, B), op::scalar_mul_point(z, C))
     );
 
     assert_eq!(
         g!(x * A - y * B - z * C),
-        op::point_add(
-            &op::double_mul(&x, &A, &-&y, &B),
-            &op::scalar_mul_point(&-&z, &C)
-        )
+        op::point_add(op::double_mul(x, A, -y, B), op::scalar_mul_point(-z, C))
     );
 
     assert_eq!(
         g!(x * A + y * B + C),
-        op::point_add(&op::double_mul(&x, &A, &y, &B), &C)
+        op::point_add(op::double_mul(x, A, y, B), C)
     );
 
     assert_eq!(
         g!(x * A + y * B - C),
-        op::point_add(&op::double_mul(&x, &A, &y, &B), &-&C)
+        op::point_add(op::double_mul(x, A, y, B), -C)
     );
 
     assert_eq!(
         g!(x * A - y * B + z * C),
-        op::point_add(
-            &op::double_mul(&x, &A, &-&y, &B),
-            &op::scalar_mul_point(&z, &C)
-        )
+        op::point_add(op::double_mul(x, A, -y, B), op::scalar_mul_point(z, C))
     );
 
     let has_scalar = Has { has: s!(17) };
@@ -167,16 +151,16 @@ fn g_expressions_give_correct_answers() {
 
     assert_eq!(
         g!(has_scalar.has * A),
-        op::scalar_mul_point(&has_scalar.has, &A)
+        op::scalar_mul_point(has_scalar.has, A)
     );
 
     assert_eq!(
         g!(has_has_scalar.has_has.has * A),
-        op::scalar_mul_point(&has_scalar.has, &A)
+        op::scalar_mul_point(has_scalar.has, A)
     );
 
     assert_eq!(
         g!(x * has_point.has + y * has_has_point.has_has.has),
-        op::double_mul(&x, &has_point.has, &y, &has_has_point.has_has.has)
+        op::double_mul(x, has_point.has, y, has_has_point.has_has.has)
     );
 }

--- a/sigma_fun/src/or.rs
+++ b/sigma_fun/src/or.rs
@@ -214,14 +214,14 @@ mod test {
                 let proof_system = crate::FiatShamir::<OrDL, HashTranscript<Sha256,ChaCha20Rng>>::default();
 
                 let proof_lhs = proof_system.prove(
-                    &Either::Left(x.clone()),
+                    &Either::Left(x),
                     &statement,
                     Some(&mut rand::thread_rng()),
                 );
                 assert!(proof_system.verify(&statement, &proof_lhs));
 
                 let wrong_proof_lhs = proof_system.prove(
-                    &Either::Right(x.clone()),
+                    &Either::Right(x),
                     &statement,
                     Some(&mut rand::thread_rng()),
                 );


### PR DESCRIPTION
This gives us much more expressivity in the macros:

1. No more `{..}` when you need to call methods or access tuple or array elements.
2. New `.*` dot product operator which replaces manually called `op::lincomb`.
3. New scalar division operator `/` (mostly for fun -- it's used in one place in ecdsa_fun).

RIP macro_rules stack machine.

In order to design the thing correctly I also tried to make everything copy (#146) to maintain backwards compat with omitting &.
In the end I didn't really use that but instead just allowed you to pass a reference to most of the functions in op which also fixes #125.

This is probably a breaking change due to some slight changes in the way some parts of the expressions are interpreted.

I've done benchmarks to confirm that there's no performance regression in terms of what is produced.

Fixes #146 #125 #6