### PR TITLE
schnorr_fun v0.9.2 release put bincode on SignSession

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # CHANGELOG
 
 
+## v0.9.2
+
+- Added bincode derive on FROST SignSession
+
 ## v0.9.1
 
 - Added more `bincode` derives for FROST things

--- a/schnorr_fun/Cargo.toml
+++ b/schnorr_fun/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "schnorr_fun"
-version = "0.9.1"
+version = "0.9.2"
 authors = ["LLFourn <lloyd.fourn@gmail.com>"]
 edition = "2021"
 rust-version = "1.60"

--- a/schnorr_fun/src/frost.rs
+++ b/schnorr_fun/src/frost.rs
@@ -966,6 +966,11 @@ impl<H: Digest<OutputSize = U32> + Clone, NG> Frost<H, NG> {
 ///
 /// [`Frost::start_sign_session`]
 #[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(
+    feature = "bincode",
+    derive(crate::fun::bincode::Encode, crate::fun::bincode::Decode),
+    bincode(crate = "crate::fun::bincode")
+)]
 pub struct SignSession {
     binding_coeff: Scalar,
     nonces_need_negation: bool,


### PR DESCRIPTION
release branch for v0.9.2 so I can have a release on crates.io on v0.9 without all the new changes.