### PR TITLE
Make Scalar::from_bytes work for Scalar<_, NonZero>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ## Unreleased
 
+- Change `Scalar::from_bytes` to work for `Scalar<_, NonZero>` as well.
 - Bumped MSRV to 1.63.0 to reduce friction
 - Added `share_backup` module in `schnorr_fun`
 - Added `arithmetic_macros` to make `g!` and `s!` macros into procedural macros

--- a/secp256kfun/src/scalar.rs
+++ b/secp256kfun/src/scalar.rs
@@ -354,22 +354,15 @@ impl<S> From<u32> for Scalar<S, Zero> {
 }
 
 crate::impl_fromstr_deserialize! {
-    name => "non-zero secp256k1 scalar",
-    fn from_bytes<S>(bytes: [u8;32]) -> Option<Scalar<S,NonZero>> {
-        Scalar::from_bytes(bytes)?.non_zero()
+    name => "secp256k1 scalar",
+    fn from_bytes<S, Z: ZeroChoice>(bytes: [u8;32]) -> Option<Scalar<S,Z>> {
+        Scalar::from_bytes(bytes)
     }
 }
 
 crate::impl_display_debug_serialize! {
     fn to_bytes<Z,S>(scalar: &Scalar<S,Z>) -> [u8;32] {
         scalar.to_bytes()
-    }
-}
-
-crate::impl_fromstr_deserialize! {
-    name => "secp256k1 scalar",
-    fn from_bytes<S>(bytes: [u8;32]) -> Option<Scalar<S,Zero>> {
-        Scalar::from_bytes(bytes)
     }
 }
 


### PR DESCRIPTION
Feedback from twitter. It also worked for Point but not for scalar so this makes them consistent.