### PR TITLE
[backend] re-introduce mixed point addition

### DIFF
--- a/secp256kfun/benches/bench_point.rs
+++ b/secp256kfun/benches/bench_point.rs
@@ -22,7 +22,7 @@ fn point_add(c: &mut Criterion) {
         b.iter_batched(
             || {
                 (
-                    g!({ Scalar::random(&mut rand::thread_rng()) } * G),
+                    Point::random(&mut rand::thread_rng()).non_normal(),
                     Point::random(&mut rand::thread_rng()),
                 )
             },
@@ -35,8 +35,8 @@ fn point_add(c: &mut Criterion) {
         b.iter_batched(
             || {
                 (
-                    g!({ Scalar::random(&mut rand::thread_rng()) } * G),
-                    g!({ Scalar::random(&mut rand::thread_rng()) } * G),
+                    Point::random(&mut rand::thread_rng()).non_normal(),
+                    Point::random(&mut rand::thread_rng()).non_normal(),
                 )
             },
             |(lhs, rhs)| g!(lhs + rhs),

--- a/secp256kfun/src/backend/k256_impl.rs
+++ b/secp256kfun/src/backend/k256_impl.rs
@@ -3,7 +3,6 @@ use crate::{
     backend::{BackendPoint, BackendScalar, TimeSensitive},
     vendor::k256::{mul, AffinePoint, FieldBytes, FieldElement, ProjectivePoint},
 };
-use core::ops::Neg;
 use subtle::{Choice, ConditionallyNegatable, ConditionallySelectable, ConstantTimeEq};
 
 pub static G_POINT: ProjectivePoint = ProjectivePoint::GENERATOR;
@@ -109,35 +108,17 @@ impl TimeSensitive for ConstantTime {
         lhs + &rhs
     }
 
-    fn any_point_neg(point: &mut Point) {
-        point.y = point.y.negate(1).normalize()
-    }
-
-    fn any_point_conditional_negate(point: &mut Point, cond: bool) {
-        point.conditional_negate(Choice::from(cond as u8));
-        point.y = point.y.normalize()
-    }
-
     fn point_neg(point: &mut Point) {
         point.y = point.y.negate(1).normalize_weak()
     }
 
-    fn point_sub_norm_point(lhs: &Point, rhs: &Point) -> Point {
-        let rhs = norm_point_to_affine(rhs);
-        lhs + &rhs.neg()
-    }
-
     fn point_conditional_negate(point: &mut Point, cond: bool) {
-        Self::any_point_conditional_negate(point, cond)
-    }
-
-    fn norm_point_sub_point(lhs: &Point, rhs: &Point) -> Point {
-        let lhs = norm_point_to_affine(lhs);
-        rhs.neg() + lhs
+        point.conditional_negate(Choice::from(cond as u8));
+        point.y = point.y.normalize()
     }
 
     fn norm_point_neg(point: &mut Point) {
-        Self::any_point_neg(point)
+        point.y = point.y.negate(1).normalize();
     }
 
     fn norm_point_eq_norm_point(lhs: &Point, rhs: &Point) -> bool {
@@ -150,7 +131,8 @@ impl TimeSensitive for ConstantTime {
     }
 
     fn norm_point_conditional_negate(point: &mut Point, cond: bool) {
-        Self::any_point_conditional_negate(point, cond)
+        point.conditional_negate(Choice::from(cond as u8));
+        point.y = point.y.normalize()
     }
 
     fn basepoint_double_mul(x: &Scalar, A: &BasePoint, y: &Scalar, B: &Point) -> Point {
@@ -252,28 +234,12 @@ impl TimeSensitive for VariableTime {
         ConstantTime::point_add_norm_point(lhs, rhs)
     }
 
-    fn any_point_neg(point: &mut Point) {
-        ConstantTime::any_point_neg(point)
-    }
-
-    fn any_point_conditional_negate(point: &mut Point, cond: bool) {
-        ConstantTime::any_point_conditional_negate(point, cond)
-    }
-
     fn point_neg(point: &mut Point) {
         ConstantTime::point_neg(point)
     }
 
-    fn point_sub_norm_point(lhs: &Point, rhs: &Point) -> Point {
-        ConstantTime::point_sub_norm_point(lhs, rhs)
-    }
-
     fn point_conditional_negate(point: &mut Point, cond: bool) {
         ConstantTime::point_conditional_negate(point, cond)
-    }
-
-    fn norm_point_sub_point(lhs: &Point, rhs: &Point) -> Point {
-        ConstantTime::norm_point_sub_point(lhs, rhs)
     }
 
     fn norm_point_neg(point: &mut Point) {

--- a/secp256kfun/src/backend/mod.rs
+++ b/secp256kfun/src/backend/mod.rs
@@ -29,19 +29,8 @@ pub trait TimeSensitive {
     fn point_eq_norm_point(lhs: &Point, rhs: &Point) -> bool;
     fn point_add_point(lhs: &Point, rhs: &Point) -> Point;
     fn point_add_norm_point(lhs: &Point, rhs: &Point) -> Point;
-    fn point_sub_point(lhs: &Point, rhs: &Point) -> Point {
-        let mut rhs = *rhs;
-        Self::point_neg(&mut rhs);
-        Self::point_add_point(lhs, &rhs)
-    }
-    // "any" variants are because doing a jacobian point neg is not good enough for a normalized
-    // point neg so for the general case we have to have a slower one that works for both.
-    fn any_point_neg(point: &mut Point);
-    fn any_point_conditional_negate(point: &mut Point, cond: bool);
     fn point_neg(point: &mut Point);
-    fn point_sub_norm_point(lhs: &Point, rhs: &Point) -> Point;
     fn point_conditional_negate(point: &mut Point, cond: bool);
-    fn norm_point_sub_point(lhs: &Point, rhs: &Point) -> Point;
     fn norm_point_neg(point: &mut Point);
     fn norm_point_eq_norm_point(lhs: &Point, rhs: &Point) -> bool;
     fn norm_point_is_y_even(point: &Point) -> bool;

--- a/secp256kfun/src/marker/point_type.rs
+++ b/secp256kfun/src/marker/point_type.rs
@@ -12,7 +12,7 @@ pub trait PointType:
     Sized + Clone + Copy + PartialEq + Eq + core::hash::Hash + Ord + PartialOrd
 {
     /// The point type returned from the negation of a point of this type.
-    type NegationType: Default;
+    type NegationType: Default + PointType;
 
     /// Whether the point type is normalized or not (i.e. not [`NonNormal`])
     fn is_normalized() -> bool;

--- a/secp256kfun/src/point.rs
+++ b/secp256kfun/src/point.rs
@@ -564,27 +564,27 @@ crate::impl_fromstr_deserialize! {
     }
 }
 
-impl<TR, SL, SR, ZR> AddAssign<Point<TR, SR, ZR>> for Point<NonNormal, SL, Zero> {
+impl<TR: PointType, SL, SR, ZR> AddAssign<Point<TR, SR, ZR>> for Point<NonNormal, SL, Zero> {
     fn add_assign(&mut self, rhs: Point<TR, SR, ZR>) {
-        *self = crate::op::point_add(*self, &rhs).set_secrecy::<SL>()
+        *self = crate::op::point_add(*self, rhs).set_secrecy::<SL>()
     }
 }
 
-impl<TR, SL, SR, ZR> AddAssign<&Point<TR, SR, ZR>> for Point<NonNormal, SL, Zero> {
+impl<TR: PointType, SL, SR, ZR> AddAssign<&Point<TR, SR, ZR>> for Point<NonNormal, SL, Zero> {
     fn add_assign(&mut self, rhs: &Point<TR, SR, ZR>) {
         *self = crate::op::point_add(*self, rhs).set_secrecy::<SL>()
     }
 }
 
-impl<TR, SL, SR, ZR> SubAssign<&Point<TR, SR, ZR>> for Point<NonNormal, SL, Zero> {
+impl<TR: PointType, SL, SR, ZR> SubAssign<&Point<TR, SR, ZR>> for Point<NonNormal, SL, Zero> {
     fn sub_assign(&mut self, rhs: &Point<TR, SR, ZR>) {
         *self = crate::op::point_sub(*self, rhs).set_secrecy::<SL>()
     }
 }
 
-impl<TR, SL, SR, ZR> SubAssign<Point<TR, SR, ZR>> for Point<NonNormal, SL, Zero> {
+impl<TR: PointType, SL, SR, ZR> SubAssign<Point<TR, SR, ZR>> for Point<NonNormal, SL, Zero> {
     fn sub_assign(&mut self, rhs: Point<TR, SR, ZR>) {
-        *self = crate::op::point_sub(*self, &rhs).set_secrecy::<SL>()
+        *self = crate::op::point_sub(*self, rhs).set_secrecy::<SL>()
     }
 }
 
@@ -839,10 +839,11 @@ mod test {
             .mark_zero()
             .non_normal();
         let mut a = a_orig;
-        let b = Point::random(&mut rand::thread_rng());
-        a += b;
-        assert_eq!(a, op::point_add(a_orig, b));
-        a -= b;
+        a += G;
+        assert_eq!(a, op::point_add(a_orig, G));
+        assert_ne!(a, a_orig);
+        assert_ne!(a, *G);
+        a -= G;
         assert_eq!(a, a_orig);
     }
 }


### PR DESCRIPTION
The underlying k256 backend has Projective + Affine addition (a little faster than Projective + Projective). We had at some point stopped using it (or maybe we never were!). This reintroduces it while also cleaning up the backend API a bit.

The actual perf improvement is ~310ns instead of ~335ns per addition.