### PR TITLE
[frost] expose public polynomial

### DIFF
--- a/schnorr_fun/src/frost.rs
+++ b/schnorr_fun/src/frost.rs
@@ -1083,6 +1083,11 @@ impl EncodedFrostKey {
     pub fn threshold(&self) -> usize {
         self.point_polynomial.len()
     }
+
+    /// The public polynomial that defines the access structure to the FROST key.
+    pub fn point_polynomial(&self) -> Vec<Point<Normal, Public, Zero>> {
+        self.point_polynomial.clone()
+    }
 }
 
 #[cfg(feature = "bincode")]


### PR DESCRIPTION
Applications that restore backups need to have the ability to check a share image lies on the public polynomial

```
let polynomial = key.frost_key().point_polynomial();
let expected = poly::point::eval(&polynomial, share_index);
```