### PR TITLE
[frost] Make "tweaks" mutate

### DIFF
--- a/schnorr_fun/src/frost/frost_poly.rs
+++ b/schnorr_fun/src/frost/frost_poly.rs
@@ -1,0 +1,210 @@
+use core::marker::PhantomData;
+
+use alloc::vec::Vec;
+use secp256kfun::{poly, prelude::*};
+
+use super::PartyIndex;
+/// A polynomial
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "serde",
+    derive(crate::fun::serde::Serialize),
+    serde(crate = "crate::fun::serde")
+)]
+#[cfg_attr(
+    feature = "bincode",
+    derive(crate::fun::bincode::Encode),
+    bincode(crate = "crate::fun::bincode",)
+)]
+pub struct FrostPoly<T> {
+    /// The public point polynomial that defines the access structure to the FROST key.
+    point_polynomial: Vec<Point<Normal, Public, Zero>>,
+    #[cfg_attr(feature = "serde", serde(skip))]
+    ty: PhantomData<T>,
+}
+
+impl<T: Copy> FrostPoly<T> {
+    /// The verification shares of each party in the key.
+    ///
+    /// The verification share is the image of their secret share.
+    pub fn verification_share(&self, index: PartyIndex) -> Point<NonNormal, Public, Zero> {
+        poly::point::eval(&self.point_polynomial, index)
+    }
+
+    /// The threshold number of participants required in a signing coalition to produce a valid signature.
+    pub fn threshold(&self) -> usize {
+        self.point_polynomial.len()
+    }
+
+    /// The public image of the key's polynomial on the elliptic curve.
+    ///
+    /// Note: the first coefficient (index `0`) is guaranteed to be non-zero but the coefficients
+    /// may be.
+    pub fn point_polynomial(&self) -> Vec<Point<Normal, Public, Zero>> {
+        self.point_polynomial.clone()
+    }
+}
+
+impl FrostPoly<Normal> {
+    /// The key that was shared with this polynomial defining the sharing.
+    ///
+    /// This is the first coefficient of the polynomial.
+    pub fn shared_key(&self) -> Point<Normal> {
+        self.point_polynomial[0].non_zero().expect("invariant")
+    }
+    /// Constructor to create a `FrostPoly<Normal>` from a vector of points.
+    ///
+    /// Returns `None` if the first coefficient is [`Point::zero`].
+    pub fn from_poly(poly: Vec<Point<Normal, Public, Zero>>) -> Option<Self> {
+        if poly.is_empty() {
+            return None;
+        }
+
+        if poly[0].is_zero() {
+            return None;
+        }
+
+        Some(Self {
+            point_polynomial: poly,
+            ty: PhantomData,
+        })
+    }
+
+    /// Create a `FrostPoly` from a set of verification shares.
+    pub fn from_verification_shares(
+        shares: &[(PartyIndex, Point<impl PointType, Public, impl ZeroChoice>)],
+    ) -> Self {
+        let poly = poly::point::interpolate(shares);
+        Self {
+            point_polynomial: poly::point::normalize(poly).collect(),
+            ty: PhantomData,
+        }
+    }
+    /// Convert the key into a BIP340 FrostKey.
+    ///
+    /// This is the [BIP340] compatible version of the key which you can put in a segwitv1 output.
+    ///
+    /// [BIP340]: https://bips.xyz/340
+    pub fn into_xonly(mut self) -> FrostPoly<EvenY> {
+        let needs_negation = !self.shared_key().is_y_even();
+        if needs_negation {
+            self.homomorphic_negate();
+            debug_assert!(self.shared_key().is_y_even());
+        }
+        FrostPoly {
+            point_polynomial: self.point_polynomial,
+            ty: PhantomData,
+        }
+    }
+
+    /// Adds a scalar `tweak` to the shared key.
+    ///
+    /// This is useful for deriving unhardened child frost keys from a master frost public key using
+    /// [BIP32].
+    ///
+    /// In order for `PairedSecretShare` s to be valid against the new key they will have to apply the same operation.
+    ///
+    /// ## Return value
+    ///
+    /// Returns a new [`FrostKey`] with the same parties but a different frost public key.
+    /// In the erroneous case that the tweak is exactly equal to the negation of the aggregate
+    /// secret key it returns `None`.
+    ///
+    /// [BIP32]: https://bips.xyz/32
+    #[must_use]
+    pub fn homomorphic_add(mut self, tweak: Scalar<impl Secrecy, impl ZeroChoice>) -> Option<Self> {
+        self.point_polynomial[0] = g!(self.point_polynomial[0] + tweak * G).normalize();
+        if self.point_polynomial[0].is_zero() {
+            None
+        } else {
+            Some(self)
+        }
+    }
+
+    /// Negates the polynomial
+    pub fn homomorphic_negate(&mut self) {
+        poly::point::negate(&mut self.point_polynomial)
+    }
+}
+
+impl FrostPoly<EvenY> {
+    /// Applies an "XOnly" tweak to the FROST public key.
+    /// This is how you embed a taproot commitment into a frost public key
+    ///
+    /// Tweak the frost public key with a scalar so that the resulting key is equal to the
+    /// existing key plus `tweak * G` as an [`EvenY`] point. The tweak mutates the public key while still allowing
+    /// the original set of signers to sign under the new key.
+    ///
+    /// ## Return value
+    ///
+    /// Returns a new [`FrostKey`] with the same parties but a different frost public key.
+    /// In the erroneous case that the tweak is exactly equal to the negation of the aggregate
+    /// secret key it returns `None`.
+    pub fn xonly_homomorphic_add(
+        mut self,
+        tweak: Scalar<impl Secrecy, impl ZeroChoice>,
+    ) -> Option<Self> {
+        self.point_polynomial[0] = g!(self.point_polynomial[0] + tweak * G).normalize();
+
+        let needs_negation = !self.point_polynomial[0].non_zero()?.is_y_even();
+        if needs_negation {
+            poly::point::negate(&mut self.point_polynomial);
+        }
+
+        Some(self)
+    }
+
+    /// The public key that would have signatures verified against for this shared key.
+    pub fn shared_key(&self) -> Point<EvenY> {
+        let (even_y_point, _needs_negation) = self.point_polynomial[0]
+            .non_zero()
+            .expect("invariant")
+            .into_point_with_even_y();
+        assert!(!_needs_negation);
+        even_y_point
+    }
+}
+
+#[cfg(feature = "bincode")]
+impl crate::fun::bincode::Decode for FrostPoly<Normal> {
+    fn decode<D: secp256kfun::bincode::de::Decoder>(
+        decoder: &mut D,
+    ) -> Result<Self, secp256kfun::bincode::error::DecodeError> {
+        let poly = Vec::<Point<Normal, Public, Zero>>::decode(decoder)?;
+
+        if poly[0].is_zero() {
+            return Err(secp256kfun::bincode::error::DecodeError::Other(
+                "first coefficient of a frost polynomial can't be zero",
+            ));
+        }
+
+        Ok(FrostPoly {
+            point_polynomial: poly,
+            ty: PhantomData,
+        })
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> crate::fun::serde::Deserialize<'de> for FrostPoly<Normal> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: secp256kfun::serde::Deserializer<'de>,
+    {
+        let poly = Vec::<Point<Normal, Public, Zero>>::deserialize(deserializer)?;
+
+        if poly[0].is_zero() {
+            return Err(crate::fun::serde::de::Error::custom(
+                "first coefficient of a frost polynomial can't be zero",
+            ));
+        }
+
+        Ok(Self {
+            point_polynomial: poly,
+            ty: PhantomData,
+        })
+    }
+}
+
+#[cfg(feature = "bincode")]
+crate::fun::bincode::impl_borrow_decode!(FrostPoly<Normal>);

--- a/schnorr_fun/src/musig.rs
+++ b/schnorr_fun/src/musig.rs
@@ -71,8 +71,7 @@
 //!
 //! [the excellent paper]: https://eprint.iacr.org/2020/1261.pdf
 //! [secp256k1-zkp]: https://github.com/ElementsProject/secp256k1-zkp/pull/131
-pub use crate::binonce::{Nonce, NonceKeyPair};
-use crate::{adaptor::EncryptedSignature, Message, Schnorr, Signature};
+use crate::{adaptor::EncryptedSignature, binonce, Message, Schnorr, Signature};
 use alloc::vec::Vec;
 use secp256kfun::{
     digest::{generic_array::typenum::U32, Digest},
@@ -116,8 +115,8 @@ impl<H, NG> MuSig<H, NG> {
     /// Generate nonces for creating signatures shares.
     ///
     /// ⚠ You must use a CAREFULLY CHOSEN nonce rng, see [`MuSig::seed_nonce_rng`]
-    pub fn gen_nonce<R: RngCore>(&self, nonce_rng: &mut R) -> NonceKeyPair {
-        NonceKeyPair::random(nonce_rng)
+    pub fn gen_nonce<R: RngCore>(&self, nonce_rng: &mut R) -> binonce::NonceKeyPair {
+        binonce::NonceKeyPair::random(nonce_rng)
     }
 }
 
@@ -430,9 +429,9 @@ pub struct Adaptor {
     bincode(crate = "crate::fun::bincode")
 )]
 pub struct SignSession<T = Ordinary> {
-    b: Scalar<Public, Zero>,
+    b: Scalar<Public>,
     c: Scalar<Public, Zero>,
-    public_nonces: Vec<Nonce>,
+    public_nonces: Vec<binonce::Nonce>,
     R: Point<EvenY>,
     nonce_needs_negation: bool,
     signing_type: T,
@@ -455,15 +454,11 @@ impl<H: Digest<OutputSize = U32> + Clone, NG> MuSig<H, NG> {
     pub fn start_sign_session(
         &self,
         agg_key: &AggKey<EvenY>,
-        nonces: Vec<Nonce>,
+        nonces: Vec<binonce::Nonce>,
         message: Message<'_, Public>,
     ) -> SignSession {
-        let (b, c, public_nonces, R, nonce_needs_negation) = self._start_sign_session(
-            agg_key,
-            nonces,
-            message,
-            &Point::<Normal, Public, _>::zero(),
-        );
+        let (b, c, public_nonces, R, nonce_needs_negation) =
+            self._start_sign_session(agg_key, nonces, message, Point::<Normal, Public, _>::zero());
         SignSession {
             b,
             c,
@@ -497,9 +492,9 @@ impl<H: Digest<OutputSize = U32> + Clone, NG> MuSig<H, NG> {
     pub fn start_encrypted_sign_session(
         &self,
         agg_key: &AggKey<EvenY>,
-        nonces: Vec<Nonce>,
+        nonces: Vec<binonce::Nonce>,
         message: Message<'_, Public>,
-        encryption_key: &Point<impl PointType, impl Secrecy, impl ZeroChoice>,
+        encryption_key: Point<impl PointType, impl Secrecy, impl ZeroChoice>,
     ) -> Option<SignSession<Adaptor>> {
         let (b, c, public_nonces, R, nonce_needs_negation) =
             self._start_sign_session(agg_key, nonces, message, encryption_key);
@@ -519,51 +514,41 @@ impl<H: Digest<OutputSize = U32> + Clone, NG> MuSig<H, NG> {
     fn _start_sign_session(
         &self,
         agg_key: &AggKey<EvenY>,
-        nonces: Vec<Nonce>,
+        mut nonces: Vec<binonce::Nonce>,
         message: Message<'_, Public>,
-        encryption_key: &Point<impl PointType, impl Secrecy, impl ZeroChoice>,
+        encryption_key: Point<impl PointType, impl Secrecy, impl ZeroChoice>,
     ) -> (
+        Scalar<Public>,
         Scalar<Public, Zero>,
-        Scalar<Public, Zero>,
-        Vec<Nonce>,
+        Vec<binonce::Nonce>,
         Point<EvenY>,
         bool,
     ) {
-        let mut Rs = nonces;
-        let agg_Rs = Rs.iter().fold([Point::zero(); 2], |acc, nonce| {
-            [g!(acc[0] + nonce.0[0]), g!(acc[1] + nonce.0[1])]
-        });
-        let agg_Rs = Nonce::<Zero>([
-            g!(agg_Rs[0] + encryption_key).normalize(),
-            agg_Rs[1].normalize(),
-        ]);
+        let mut agg_binonce = binonce::Nonce::aggregate(nonces.iter().cloned());
+        agg_binonce.0[0] = g!(agg_binonce.0[0] + encryption_key).normalize();
 
-        let b = {
+        let binding_coeff = {
             let H = self.nonce_coeff_hash.clone();
             Scalar::from_hash(
-                H.add(agg_Rs.to_bytes())
+                H.add(agg_binonce)
                     .add(agg_key.agg_public_key())
                     .add(message),
             )
         }
-        .public()
-        .mark_zero();
+        .public();
 
-        let (R, r_needs_negation) = g!(agg_Rs.0[0] + b * agg_Rs.0[1])
-            .normalize()
-            .non_zero()
-            .unwrap_or(Point::generator())
-            .into_point_with_even_y();
-
-        for R_i in &mut Rs {
-            R_i.conditional_negate(r_needs_negation);
-        }
+        let (R, nonces_need_negation) = agg_binonce.bind(binding_coeff);
 
         let c = self
             .schnorr
             .challenge(&R, &agg_key.agg_public_key(), message);
 
-        (b, c, Rs, R, r_needs_negation)
+        // we may as well eagerly do
+        for nonce in &mut nonces {
+            nonce.conditional_negate(nonces_need_negation);
+        }
+
+        (binding_coeff, c, nonces, R, nonces_need_negation)
     }
 
     /// Generates a partial signature (or partial encrypted signature depending on `T`) for the local_secret_nonce.
@@ -573,7 +558,7 @@ impl<H: Digest<OutputSize = U32> + Clone, NG> MuSig<H, NG> {
         session: &SignSession<T>,
         my_index: usize,
         keypair: &KeyPair,
-        local_secret_nonce: NonceKeyPair,
+        local_secret_nonce: binonce::NonceKeyPair,
     ) -> Scalar<Public, Zero> {
         assert_eq!(
             keypair.public_key(),
@@ -898,7 +883,7 @@ mod test {
                     &agg_key1,
                     nonces.clone(),
                     message,
-                    &encryption_key
+                    encryption_key
                 )
                 .unwrap();
             let p2_session = musig
@@ -906,7 +891,7 @@ mod test {
                     &agg_key2,
                     nonces.clone(),
                     message,
-                    &encryption_key
+                    encryption_key
                 )
                 .unwrap();
             let p3_session = musig
@@ -914,7 +899,7 @@ mod test {
                     &agg_key3,
                     nonces,
                     message,
-                    &encryption_key
+                    encryption_key
                 )
                 .unwrap();
                 let p1_sig = musig.sign(&agg_key1, &p1_session, 0, &keypair1, p1_nonce);

--- a/schnorr_fun/tests/musig_sign_verify.rs
+++ b/schnorr_fun/tests/musig_sign_verify.rs
@@ -1,9 +1,9 @@
 #![cfg(feature = "serde")]
 use schnorr_fun::{
     binonce,
+    binonce::NonceKeyPair,
     fun::{marker::*, serde, Point, Scalar},
-    musig::{self, NonceKeyPair},
-    Message,
+    musig, Message,
 };
 static TEST_JSON: &str = include_str!("musig/sign_verify_vectors.json");
 use secp256kfun::hex;

--- a/schnorr_fun/tests/musig_tweak.rs
+++ b/schnorr_fun/tests/musig_tweak.rs
@@ -4,9 +4,9 @@ use std::{rc::Rc, sync::Arc};
 
 use schnorr_fun::{
     binonce,
+    binonce::NonceKeyPair,
     fun::{marker::*, serde, Point, Scalar},
-    musig::{self, NonceKeyPair},
-    Message,
+    musig, Message,
 };
 static TEST_JSON: &'static str = include_str!("musig/tweak_vectors.json");
 use secp256kfun::hex;

--- a/secp256kfun/src/point.rs
+++ b/secp256kfun/src/point.rs
@@ -251,6 +251,19 @@ impl<T, S, Z> Point<T, S, Z> {
         backend::BackendPoint::is_zero(&self.0)
     }
 
+    /// Convert a point that is marked as `Zero` to `NonZero`.
+    ///
+    /// If the point *was* actually zero ([`is_zero`] returns true) it returns `None`.
+    ///
+    /// [`is_zero`]: Point::is_zero
+    pub fn non_zero(self) -> Option<Point<T, S, NonZero>> {
+        if self.is_zero() {
+            None
+        } else {
+            Some(Point::from_inner(self.0, self.1))
+        }
+    }
+
     pub(crate) const fn from_inner(backend_point: backend::Point, point_type: T) -> Self {
         Point(backend_point, point_type, PhantomData)
     }
@@ -421,19 +434,6 @@ impl<S> Point<EvenY, S, NonZero> {
 }
 
 impl<T, S> Point<T, S, Zero> {
-    /// Convert a point that is marked as `Zero` to `NonZero`.
-    ///
-    /// If the point *was* actually zero ([`is_zero`] returns true) it returns `None`.
-    ///
-    /// [`is_zero`]: Point::is_zero
-    pub fn non_zero(self) -> Option<Point<T, S, NonZero>> {
-        if self.is_zero() {
-            None
-        } else {
-            Some(Point::from_inner(self.0, self.1))
-        }
-    }
-
     /// Returns the [`identity element`] of the group A.K.A. the point at infinity.
     ///
     /// # Example

--- a/secp256kfun/src/poly.rs
+++ b/secp256kfun/src/poly.rs
@@ -133,6 +133,13 @@ pub mod scalar {
             _ => None,
         })
     }
+
+    /// Negates a scalar polynomial
+    pub fn negate(poly: &mut [Scalar<impl Secrecy, impl ZeroChoice>]) {
+        for coeff in poly {
+            *coeff = -*coeff;
+        }
+    }
 }
 
 /// Functions for dealing with point polynomials
@@ -185,8 +192,12 @@ pub mod point {
     /// Panics if the indicies are not unique.
     ///
     /// A vector with a tail of zero coefficients means the interpolation was overdetermined.
+    #[allow(clippy::type_complexity)]
     pub fn interpolate(
-        index_and_point: &[(Scalar<Public, impl ZeroChoice>, Point)],
+        index_and_point: &[(
+            Scalar<Public, impl ZeroChoice>,
+            Point<impl PointType, impl Secrecy, impl ZeroChoice>,
+        )],
     ) -> Vec<Point<NonNormal, Public, Zero>> {
         let x_ms = index_and_point.iter().map(|(index, _)| *index);
         let mut interpolating_polynomial: Vec<Point<NonNormal, Public, Zero>> = vec![];
@@ -200,6 +211,23 @@ pub mod point {
         }
 
         interpolating_polynomial
+    }
+
+    /// Negates a scalar polynomial
+    pub fn negate<T>(poly: &mut [Point<T, impl Secrecy, impl ZeroChoice>])
+    where
+        T: PointType<NegationType = T>,
+    {
+        for coeff in poly {
+            *coeff = -*coeff;
+        }
+    }
+
+    /// Normalizes the points in a polynomial
+    pub fn normalize<S, Z>(
+        poly: impl IntoIterator<Item = Point<impl PointType, S, Z>>,
+    ) -> impl Iterator<Item = Point<Normal, S, Z>> {
+        poly.into_iter().map(|point| point.normalize())
     }
 }
 /// Returns an iterator of 1, x, x², x³ ...


### PR DESCRIPTION
Prior to this PR tweaks were being stored in a separate field inside `FrostKey` and were applied at signature combination time. In frostsnap we actually want to be able to do "one-way" tweaks where you forget the original polynomial (at least the first coefficient). This is not an API safety concern but we strictly don't want the original to exist anymore.

The next problem we address is that we don't want you to need the full polynomial for signing. Instead we make the user provide a "paired" secret share which is the secret scalar and index paired with the shared key (first coefficient of polynomial). This is a convenient combination since it allows you to hash the shared key to figure out a tweak and then apply it to both the shared key and the shared secret.

See commits individually. eb6dc14994d0dc99e1b1118d58d7128aff386ca5 is the frost only one.

I haven't updated docs yet because I intend to integrate some bip-frost stuff which will change the API again.