### PR TITLE
[❄] Add binonce::SecretNonce

### DIFF
--- a/schnorr_fun/src/frost/session.rs
+++ b/schnorr_fun/src/frost/session.rs
@@ -1,8 +1,12 @@
-use crate::{binonce, frost::PartyIndex, Signature};
+use crate::{
+    binonce::{self, SecretNonce},
+    frost::PartyIndex,
+    Signature,
+};
 use alloc::collections::{BTreeMap, BTreeSet};
 use secp256kfun::{poly, prelude::*};
 
-use super::{NonceKeyPair, PairedSecretShare, SharedKey, SignatureShare, VerificationShare};
+use super::{PairedSecretShare, SharedKey, SignatureShare, VerificationShare};
 /// A FROST signing session used to *verify* signatures.
 ///
 /// Created using [`coordinator_sign_session`].
@@ -214,7 +218,7 @@ impl PartySignSession {
     pub fn sign(
         &self,
         secret_share: &PairedSecretShare<EvenY>,
-        secret_nonce: NonceKeyPair,
+        secret_nonce: impl AsRef<SecretNonce>,
     ) -> SignatureShare {
         if self.public_key != secret_share.public_key() {
             panic!("the share's shared key is not the same as the shared key of the session");
@@ -224,7 +228,7 @@ impl PartySignSession {
         }
         let secret_share = secret_share.secret_share();
         let lambda = poly::eval_basis_poly_at_0(secret_share.index, self.parties.iter().cloned());
-        let [mut r1, mut r2] = secret_nonce.secret;
+        let [mut r1, mut r2] = secret_nonce.as_ref().0;
         r1.conditional_negate(self.binonce_needs_negation);
         r2.conditional_negate(self.binonce_needs_negation);
 

--- a/schnorr_fun/tests/musig_sign_verify.rs
+++ b/schnorr_fun/tests/musig_sign_verify.rs
@@ -1,7 +1,6 @@
 #![cfg(feature = "serde")]
 use schnorr_fun::{
     binonce,
-    binonce::NonceKeyPair,
     fun::{marker::*, serde, Point, Scalar},
     musig, Message,
 };
@@ -26,7 +25,7 @@ impl<T> Maybe<T> {
 
 #[derive(Clone, Debug)]
 struct SecNonce {
-    nonce: NonceKeyPair,
+    nonce: binonce::SecretNonce,
     pk: Point,
 }
 
@@ -34,7 +33,7 @@ impl SecNonce {
     pub fn from_bytes(bytes: [u8; 97]) -> Option<Self> {
         let mut nonce = [0u8; 64];
         nonce.copy_from_slice(&bytes[..64]);
-        let nonce = binonce::NonceKeyPair::from_bytes(nonce)?;
+        let nonce = binonce::SecretNonce::from_bytes(nonce)?;
         Some(SecNonce {
             nonce,
             pk: Point::from_slice(&bytes[64..])?,

--- a/schnorr_fun/tests/musig_tweak.rs
+++ b/schnorr_fun/tests/musig_tweak.rs
@@ -3,8 +3,7 @@
 use std::{rc::Rc, sync::Arc};
 
 use schnorr_fun::{
-    binonce,
-    binonce::NonceKeyPair,
+    binonce::{self, NonceKeyPair},
     fun::{marker::*, serde, Point, Scalar},
     musig, Message,
 };
@@ -28,7 +27,7 @@ impl<T> Maybe<T> {
 }
 
 struct SecNonce {
-    nonce: NonceKeyPair,
+    nonce: binonce::SecretNonce,
     _pk: Point,
 }
 
@@ -36,7 +35,7 @@ impl SecNonce {
     pub fn from_bytes(bytes: [u8; 97]) -> Option<Self> {
         let mut nonce = [0u8; 64];
         nonce.copy_from_slice(&bytes[..64]);
-        let nonce = binonce::NonceKeyPair::from_bytes(nonce)?;
+        let nonce = binonce::SecretNonce::from_bytes(nonce)?;
         Some(SecNonce {
             nonce,
             _pk: Point::from_slice(&bytes[64..])?,


### PR DESCRIPTION
Sometimes you don't want the keypair. When you just want to sign you shouldn't be forced to recompute it.