### PR TITLE
Frost signature coordinator randomization (anti-exfil)

### DIFF
--- a/schnorr_fun/src/musig.rs
+++ b/schnorr_fun/src/musig.rs
@@ -526,8 +526,7 @@ impl<H: Hash32, NG> MuSig<H, NG> {
         Point<EvenY>,
         bool,
     ) {
-        let mut agg_binonce = binonce::Nonce::aggregate(nonces.iter().cloned());
-        agg_binonce.0[0] = g!(agg_binonce.0[0] + encryption_key).normalize();
+        let agg_binonce = binonce::Nonce::aggregate_and_add(nonces.iter().cloned(), encryption_key);
 
         let binding_coeff = {
             let H = self.nonce_coeff_hash.clone();
@@ -545,7 +544,7 @@ impl<H: Hash32, NG> MuSig<H, NG> {
             .schnorr
             .challenge(&R, &agg_key.agg_public_key(), message);
 
-        // we may as well eagerly do
+        // we may as well eagerly do the negation
         for nonce in &mut nonces {
             nonce.conditional_negate(nonces_need_negation);
         }

--- a/secp256kfun/src/marker/zero_choice.rs
+++ b/secp256kfun/src/marker/zero_choice.rs
@@ -13,16 +13,15 @@ pub struct NonZero;
 
 /// A marker trait implemented by [`Zero`] and [`NonZero`].
 ///
-/// Note it is rarely useful to define a function over any `Z: ZeroChoice`.
-/// This trait mostly just exists for consistency.
+/// It's sometimes useful to define a function over any `Z: ZeroChoice`.
 pub trait ZeroChoice:
     Default
     + Clone
     + PartialEq
     + Eq
     + Copy
-    + DecideZero<NonZero>
-    + DecideZero<Zero>
+    + DecideZero<NonZero, Out = Self>
+    + DecideZero<Zero, Out = Zero>
     + DecideZero<Self, Out = Self>
     + core::hash::Hash
     + Ord
@@ -59,7 +58,7 @@ impl ZeroChoice for NonZero {
 /// A trait to figure out whether the result of a multiplication should be [`Zero`] or [`NonZero`] at compile time.
 pub trait DecideZero<ZZ> {
     /// If both arguments are `NonZero` then `Out` will be `NonZero`, otherwise `Zero`.
-    type Out;
+    type Out: ZeroChoice;
 }
 
 impl<Z: ZeroChoice> DecideZero<Z> for Zero {


### PR DESCRIPTION
```
[❄] Allow for FROST signature randomization
Creates another session creation method that takes an rng. This ensures
that the final nonce R (and by implication the s) in the signature will
be indistinguishable from random even to all those who knew the
parameters ahead of time. This stops signers from contriving the final
nonce even if they are all corrupt.
```