### PR TITLE
v0.11.0 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 # CHANGELOG
 
-## UNRELEASED
+## v0.11.0
 
 - Added `prelude` module for convenient importing
+- Remove `ShareBackup` in favour of `SecretShare`
+- Add compatibility to `rust-secp256k1` v0.29.0
+- Add compatibility to `rust-secp256k1` v0.30.0
+- Large changes to FROST api as usual
+- Add `Hash32` trait to collect all the useful hash traits we use all over the place
+- Add our own take on [chill-dkg](ttps://github.com/BlockstreamResearch/bip-frost-dkg/tree/master) WIP BIP
 
 
 ## v0.10.0

--- a/ecdsa_fun/Cargo.toml
+++ b/ecdsa_fun/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ecdsa_fun"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["LLFourn <lloyd.fourn@gmail.com>"]
 edition = "2021"
 rust-version = "1.63"
@@ -14,8 +14,8 @@ categories = ["cryptography", "cryptography::cryptocurrencies"]
 keywords = ["bitcoin", "ecdsa", "secp256k1"]
 
 [dependencies]
-secp256kfun = { path = "../secp256kfun", version = "0.10", default-features = false }
-sigma_fun = { path = "../sigma_fun", version = "0.7", features = ["secp256k1"], default-features = false, optional = true }
+secp256kfun = { path = "../secp256kfun", version = "0.11", default-features = false }
+sigma_fun = { path = "../sigma_fun", version = "0.8", features = ["secp256k1"], default-features = false, optional = true }
 rand_chacha = {  version = "0.3", optional = true }  # needed for adaptor signatures atm but would be nice to get rid of
 bincode = { version = "1.0", optional = true }
 

--- a/ecdsa_fun/README.md
+++ b/ecdsa_fun/README.md
@@ -12,7 +12,7 @@ Built on [secp256kfun].
 
 ``` toml
 [dependencies]
-ecdsa_fun = "0.10"
+ecdsa_fun = "0.11"
 sha2 = "0.10" # You need a hash function for nonce derivation
 ```
 

--- a/schnorr_fun/Cargo.toml
+++ b/schnorr_fun/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "schnorr_fun"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["LLFourn <lloyd.fourn@gmail.com>"]
 edition = "2021"
 rust-version = "1.63"
@@ -14,11 +14,11 @@ categories = ["cryptography", "cryptography::cryptocurrencies"]
 keywords = ["bitcoin", "schnorr"]
 
 [dependencies]
-secp256kfun = { path = "../secp256kfun", version = "0.10",  default-features = false }
+secp256kfun = { path = "../secp256kfun", version = "0.11",  default-features = false }
 bech32 = { version = "0.11", optional = true, default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
-secp256kfun = { path = "../secp256kfun", version = "0.10",  features = ["proptest", "bincode", "alloc"] }
+secp256kfun = { path = "../secp256kfun", version = "0.11",  features = ["proptest", "bincode", "alloc"] }
 rand = { version = "0.8" }
 lazy_static = "1.4"
 bincode = "1.0"

--- a/schnorr_fun/README.md
+++ b/schnorr_fun/README.md
@@ -15,7 +15,7 @@ This implementation is based on the [BIP-340] specification, but is flexible eno
 
 ``` toml
 [dependencies]
-schnorr_fun = "0.10"
+schnorr_fun = "0.11"
 sha2 = "0.10"
 ```
 

--- a/secp256kfun/Cargo.toml
+++ b/secp256kfun/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "secp256kfun"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["LLFourn <lloyd.fourn@gmail.com>"]
 license = "0BSD"
 homepage = "https://github.com/LLFourn/secp256kfun"

--- a/secp256kfun/README.md
+++ b/secp256kfun/README.md
@@ -28,7 +28,7 @@ _Low-level_ libraries like [parity/libsecp256k1][4] make it possible but the res
 
 ```toml
 [dependencies]
-secp256kfun = "0.10"
+secp256kfun = "0.11"
 ```
 
 ### Should use?
@@ -110,7 +110,6 @@ Otherwise, information about those inputs may leak to anyone that can measure it
 In secp256kfun we try and solve this problem by allowing you to mark different inputs as `Public` or `Secret`.
 Depending on the marking the rust compiler may choose different low level operations.
 Choosing faster but variable time operations for `Public` inputs and slower safer constant time ones for things marked as `Secret`.
-In other words, the caller can decide which input are
 
 For example, below we have a `pedersen_commitment` function which is called by the committing party with a secret value and by the verifying party when the secret value is finally revealed.
 Note that we only have to write the function once and the caller decides by marking whether the function should run in constant time or variable time.

--- a/sigma_fun/Cargo.toml
+++ b/sigma_fun/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sigma_fun"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["LLFourn <lloyd.fourn@gmail.com>"]
 edition = "2021"
 rust-version = "1.63"
@@ -16,13 +16,13 @@ readme = "README.md"
 [dependencies]
 generic-array = "0.14"
 digest = "0.10"
-secp256kfun = { path = "../secp256kfun", version = "0.10", default-features = false, optional = true }
+secp256kfun = { path = "../secp256kfun", version = "0.11", default-features = false, optional = true }
 curve25519-dalek = { package = "curve25519-dalek-ng", version = "4", default-features = false, optional = true, features = ["u64_backend"] }
 serde = { package = "serde", version = "1.0", optional = true, default-features = false, features = ["derive"] }
 rand_core = "0.6"
 
 [dev-dependencies]
-secp256kfun = { path = "../secp256kfun", version = "0.10", default-features = false, features = ["proptest"] }
+secp256kfun = { path = "../secp256kfun", version = "0.11", default-features = false, features = ["proptest"] }
 rand = "0.8"
 sha2 = "0.10"
 bincode = "1"


### PR DESCRIPTION
Finally a release. I was considering updating `rand_core` in this one but that will have to come later.

## v0.11.0

- Added `prelude` module for convenient importing
- Remove `ShareBackup` in favour of `SecretShare`
- Add compatibility to `rust-secp256k1` v0.29.0
- Add compatibility to `rust-secp256k1` v0.30.0
- Large changes to FROST api as usual
- Add `Hash32` trait to collect all the useful hash traits we use all over the place
- Add our own take on [chill-dkg](ttps://github.com/BlockstreamResearch/bip-frost-dkg/tree/master) WIP BIP
