### PR TITLE
Remove format_code_in_doc_comments from rustfmt.toml

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,2 @@
 edition = "2024"
 use_field_init_shorthand = true
-format_code_in_doc_comments = true


### PR DESCRIPTION
## Summary
- Removes `format_code_in_doc_comments` from rustfmt.toml to eliminate warnings on stable toolchain

## Test plan
- [x] Run `cargo fmt` - no warnings should appear
- [x] Verify formatting still works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)