### PR TITLE
Implement hash_to_curve for secp256k1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 - Upgrade to bincode v2
 - MSRV 1.63 -> 1.85
 - **BREAKING**: Refactor `CompactProof` in `sigma_fun` to use two type parameters `CompactProof<R, L>` instead of `CompactProof<S: Sigma>` to enable serde support
+- Add hash-to-curve methods to `Point`:
+  - `hash_to_curve` - Simple try-and-increment with uniform distribution (recommended)
+  - `hash_to_curve_sswu` - RFC 9380 compliant constant-time hashing
+  - `hash_to_curve_rfc9381_tai` - RFC 9381 VRF try-and-increment format
 
 ## v0.11.0
 

--- a/secp256kfun/src/backend/k256_impl.rs
+++ b/secp256kfun/src/backend/k256_impl.rs
@@ -67,6 +67,15 @@ impl BackendPoint for Point {
             }
         })
     }
+
+    fn hash_to_curve<
+        H: crate::hash::Hash32 + crate::digest::Update + crate::digest::crypto_common::BlockSizeUser,
+    >(
+        msg: &[u8],
+        dst: &[u8],
+    ) -> Point {
+        crate::vendor::hash_to_curve::hash_to_curve::<H>(msg, dst)
+    }
 }
 
 pub struct ConstantTime;

--- a/secp256kfun/src/backend/mod.rs
+++ b/secp256kfun/src/backend/mod.rs
@@ -17,6 +17,15 @@ pub trait BackendPoint {
     fn norm_to_coordinates(&self) -> ([u8; 32], [u8; 32]);
     fn norm_from_bytes_y_oddness(x_bytes: [u8; 32], y_odd: bool) -> Option<Point>;
     fn norm_from_coordinates(x: [u8; 32], y: [u8; 32]) -> Option<Point>;
+
+    /// Hash to curve implementation following draft-irtf-cfrg-hash-to-curve
+    /// See: <https://datatracker.ietf.org/doc/draft-irtf-cfrg-hash-to-curve/>
+    fn hash_to_curve<
+        H: crate::hash::Hash32 + crate::digest::Update + crate::digest::crypto_common::BlockSizeUser,
+    >(
+        msg: &[u8],
+        dst: &[u8],
+    ) -> Point;
 }
 
 #[allow(dead_code)]

--- a/secp256kfun/src/vendor/hash_to_curve.rs
+++ b/secp256kfun/src/vendor/hash_to_curve.rs
@@ -1,0 +1,560 @@
+//! Hash to curve implementation for secp256k1
+//!
+//! This module implements the hash-to-curve algorithm as specified in:
+//! [RFC 9380](https://datatracker.ietf.org/doc/html/rfc9380)
+//!
+//! Specifically, it implements:
+//! - Suite ID: secp256k1_XMD:SHA-256_SSWU_RO_
+//! - The simplified SWU method (Section 6.6.3)
+//! - 3-isogeny mapping to secp256k1 (Appendix E.3)
+//!
+//! This implementation is heavily inspired by the k256 crate's hash-to-curve implementation,
+//! with the main difference being a hand-rolled `pow_c1` operation rather than relying on
+//! an external exponentiation library.
+//!
+//! It is @llfourn's opinion that this construction is overwrought for secp256k1
+
+use crate::digest::crypto_common::BlockSizeUser;
+use crate::hash::Hash32;
+use crate::vendor::k256::{AffinePoint, FieldElement, ProjectivePoint};
+use subtle::{Choice, ConditionallySelectable, ConstantTimeEq};
+
+// L parameter for hash_to_field - fixed at 48 bytes for secp256k1
+const L: usize = 48;
+
+// Constants for expand_message_xmd
+const F_2_192: FieldElement = FieldElement::from_bytes_unchecked(&[
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+]);
+
+// SSWU constants from k256
+#[allow(dead_code)]
+const C1: [u64; 4] = [
+    0xffff_ffff_bfff_ff0b,
+    0xffff_ffff_ffff_ffff,
+    0xffff_ffff_ffff_ffff,
+    0x3fff_ffff_ffff_ffff,
+];
+
+const C2: FieldElement = FieldElement::from_bytes_unchecked(&[
+    0x25, 0xe9, 0x71, 0x1a, 0xe8, 0xc0, 0xda, 0xdc, 0x46, 0xfd, 0xbc, 0xb7, 0x2a, 0xad, 0xd8, 0xf4,
+    0x25, 0x0b, 0x65, 0x07, 0x30, 0x12, 0xec, 0x80, 0xbc, 0x6e, 0xcb, 0x9c, 0x12, 0x97, 0x39, 0x75,
+]);
+
+const MAP_A: FieldElement = FieldElement::from_bytes_unchecked(&[
+    0x3f, 0x87, 0x31, 0xab, 0xdd, 0x66, 0x1a, 0xdc, 0xa0, 0x8a, 0x55, 0x58, 0xf0, 0xf5, 0xd2, 0x72,
+    0xe9, 0x53, 0xd3, 0x63, 0xcb, 0x6f, 0x0e, 0x5d, 0x40, 0x54, 0x47, 0xc0, 0x1a, 0x44, 0x45, 0x33,
+]);
+
+const MAP_B: FieldElement = FieldElement::from_bytes_unchecked(&[
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x06, 0xeb,
+]);
+
+const Z: FieldElement = FieldElement::from_bytes_unchecked(&[
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xfe, 0xff, 0xff, 0xfc, 0x24,
+]);
+
+// Isogeny constants
+const XNUM: [FieldElement; 4] = [
+    FieldElement::from_bytes_unchecked(&[
+        0x8e, 0x38, 0xe3, 0x8e, 0x38, 0xe3, 0x8e, 0x38, 0xe3, 0x8e, 0x38, 0xe3, 0x8e, 0x38, 0xe3,
+        0x8e, 0x38, 0xe3, 0x8e, 0x38, 0xe3, 0x8e, 0x38, 0xe3, 0x8e, 0x38, 0xe3, 0x8d, 0xaa, 0xaa,
+        0xa8, 0xc7,
+    ]),
+    FieldElement::from_bytes_unchecked(&[
+        0x07, 0xd3, 0xd4, 0xc8, 0x0b, 0xc3, 0x21, 0xd5, 0xb9, 0xf3, 0x15, 0xce, 0xa7, 0xfd, 0x44,
+        0xc5, 0xd5, 0x95, 0xd2, 0xfc, 0x0b, 0xf6, 0x3b, 0x92, 0xdf, 0xff, 0x10, 0x44, 0xf1, 0x7c,
+        0x65, 0x81,
+    ]),
+    FieldElement::from_bytes_unchecked(&[
+        0x53, 0x4c, 0x32, 0x8d, 0x23, 0xf2, 0x34, 0xe6, 0xe2, 0xa4, 0x13, 0xde, 0xca, 0x25, 0xca,
+        0xec, 0xe4, 0x50, 0x61, 0x44, 0x03, 0x7c, 0x40, 0x31, 0x4e, 0xcb, 0xd0, 0xb5, 0x3d, 0x9d,
+        0xd2, 0x62,
+    ]),
+    FieldElement::from_bytes_unchecked(&[
+        0x8e, 0x38, 0xe3, 0x8e, 0x38, 0xe3, 0x8e, 0x38, 0xe3, 0x8e, 0x38, 0xe3, 0x8e, 0x38, 0xe3,
+        0x8e, 0x38, 0xe3, 0x8e, 0x38, 0xe3, 0x8e, 0x38, 0xe3, 0x8e, 0x38, 0xe3, 0x8d, 0xaa, 0xaa,
+        0xa8, 0x8c,
+    ]),
+];
+
+const XDEN: [FieldElement; 3] = [
+    FieldElement::from_bytes_unchecked(&[
+        0xd3, 0x57, 0x71, 0x19, 0x3d, 0x94, 0x91, 0x8a, 0x9c, 0xa3, 0x4c, 0xcb, 0xb7, 0xb6, 0x40,
+        0xdd, 0x86, 0xcd, 0x40, 0x95, 0x42, 0xf8, 0x48, 0x7d, 0x9f, 0xe6, 0xb7, 0x45, 0x78, 0x1e,
+        0xb4, 0x9b,
+    ]),
+    FieldElement::from_bytes_unchecked(&[
+        0xed, 0xad, 0xc6, 0xf6, 0x43, 0x83, 0xdc, 0x1d, 0xf7, 0xc4, 0xb2, 0xd5, 0x1b, 0x54, 0x22,
+        0x54, 0x06, 0xd3, 0x6b, 0x64, 0x1f, 0x5e, 0x41, 0xbb, 0xc5, 0x2a, 0x56, 0x61, 0x2a, 0x8c,
+        0x6d, 0x14,
+    ]),
+    FieldElement::from_bytes_unchecked(&[
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x01,
+    ]),
+];
+
+const YNUM: [FieldElement; 4] = [
+    FieldElement::from_bytes_unchecked(&[
+        0x4b, 0xda, 0x12, 0xf6, 0x84, 0xbd, 0xa1, 0x2f, 0x68, 0x4b, 0xda, 0x12, 0xf6, 0x84, 0xbd,
+        0xa1, 0x2f, 0x68, 0x4b, 0xda, 0x12, 0xf6, 0x84, 0xbd, 0xa1, 0x2f, 0x68, 0x4b, 0x8e, 0x38,
+        0xe2, 0x3c,
+    ]),
+    FieldElement::from_bytes_unchecked(&[
+        0xc7, 0x5e, 0x0c, 0x32, 0xd5, 0xcb, 0x7c, 0x0f, 0xa9, 0xd0, 0xa5, 0x4b, 0x12, 0xa0, 0xa6,
+        0xd5, 0x64, 0x7a, 0xb0, 0x46, 0xd6, 0x86, 0xda, 0x6f, 0xdf, 0xfc, 0x90, 0xfc, 0x20, 0x1d,
+        0x71, 0xa3,
+    ]),
+    FieldElement::from_bytes_unchecked(&[
+        0x29, 0xa6, 0x19, 0x46, 0x91, 0xf9, 0x1a, 0x73, 0x71, 0x52, 0x09, 0xef, 0x65, 0x12, 0xe5,
+        0x76, 0x72, 0x28, 0x30, 0xa2, 0x01, 0xbe, 0x20, 0x18, 0xa7, 0x65, 0xe8, 0x5a, 0x9e, 0xce,
+        0xe9, 0x31,
+    ]),
+    FieldElement::from_bytes_unchecked(&[
+        0x2f, 0x68, 0x4b, 0xda, 0x12, 0xf6, 0x84, 0xbd, 0xa1, 0x2f, 0x68, 0x4b, 0xda, 0x12, 0xf6,
+        0x84, 0xbd, 0xa1, 0x2f, 0x68, 0x4b, 0xda, 0x12, 0xf6, 0x84, 0xbd, 0xa1, 0x2f, 0x38, 0xe3,
+        0x8d, 0x84,
+    ]),
+];
+
+const YDEN: [FieldElement; 4] = [
+    FieldElement::from_bytes_unchecked(&[
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xfe, 0xff, 0xff,
+        0xf9, 0x3b,
+    ]),
+    FieldElement::from_bytes_unchecked(&[
+        0x7a, 0x06, 0x53, 0x4b, 0xb8, 0xbd, 0xb4, 0x9f, 0xd5, 0xe9, 0xe6, 0x63, 0x27, 0x22, 0xc2,
+        0x98, 0x94, 0x67, 0xc1, 0xbf, 0xc8, 0xe8, 0xd9, 0x78, 0xdf, 0xb4, 0x25, 0xd2, 0x68, 0x5c,
+        0x25, 0x73,
+    ]),
+    FieldElement::from_bytes_unchecked(&[
+        0x64, 0x84, 0xaa, 0x71, 0x65, 0x45, 0xca, 0x2c, 0xf3, 0xa7, 0x0c, 0x3f, 0xa8, 0xfe, 0x33,
+        0x7e, 0x0a, 0x3d, 0x21, 0x16, 0x2f, 0x0d, 0x62, 0x99, 0xa7, 0xbf, 0x81, 0x92, 0xbf, 0xd2,
+        0xa7, 0x6f,
+    ]),
+    FieldElement::from_bytes_unchecked(&[
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x01,
+    ]),
+];
+
+/// Hash to curve implementation for secp256k1 following the IETF draft
+/// https://datatracker.ietf.org/doc/draft-irtf-cfrg-hash-to-curve/
+pub fn hash_to_curve<H: Hash32 + digest::Update + BlockSizeUser>(
+    msg: &[u8],
+    dst: &[u8],
+) -> ProjectivePoint {
+    let u = hash_to_field::<H>(msg, dst);
+    let q0 = map_to_curve(u[0]);
+    let q1 = map_to_curve(u[1]);
+    ProjectivePoint::from(q0) + q1
+}
+
+/// Expand message using XMD (expand_message_xmd)
+/// Implements the algorithm from Section 5.4.1 of draft-irtf-cfrg-hash-to-curve
+fn expand_message_xmd<H: Hash32 + digest::Update + BlockSizeUser>(
+    msg: &[u8],
+    dst: &[u8],
+    len_in_bytes: usize,
+) -> [u8; 2 * L] {
+    debug_assert_eq!(len_in_bytes, 2 * L); // We only use this for 2*L bytes
+
+    const B_IN_BYTES: usize = 32; // Hash32 always outputs 32 bytes
+    let r_in_bytes = <H as BlockSizeUser>::block_size();
+
+    // ell = ceil(len_in_bytes / b_in_bytes)
+    let ell = ((len_in_bytes + B_IN_BYTES - 1) / B_IN_BYTES) as u8;
+
+    // Build DST prime
+    if dst.len() > 255 {
+        panic!("DST length must be less than 256 bytes");
+    }
+
+    let mut dst_prime = [0u8; 256];
+    dst_prime[..dst.len()].copy_from_slice(dst);
+    dst_prime[dst.len()] = dst.len() as u8;
+    let actual_dst_prime_len = dst.len() + 1;
+
+    // Z_pad = I2OSP(0, r_in_bytes)
+    let z_pad = [0u8; 128]; // Max block size we support
+
+    // msg_prime = Z_pad || msg || I2OSP(len_in_bytes, 2) || I2OSP(0, 1) || DST_prime
+    let mut hasher = H::default();
+    hasher.update(&z_pad[..r_in_bytes]);
+    hasher.update(msg);
+    hasher.update(&(len_in_bytes as u16).to_be_bytes());
+    hasher.update(&[0u8]);
+    hasher.update(&dst_prime[..actual_dst_prime_len]);
+
+    // b_0 = H(msg_prime)
+    let b_0 = hasher.finalize_fixed();
+
+    // Initialize output
+    let mut uniform_bytes = [0u8; 2 * L];
+    let mut offset = 0;
+
+    // b_1 = H(b_0 || I2OSP(1, 1) || DST_prime)
+    let mut hasher = H::default();
+    hasher.update(&b_0);
+    hasher.update(&[1u8]);
+    hasher.update(&dst_prime[..actual_dst_prime_len]);
+    let mut b_i = hasher.finalize_fixed();
+    let copy_len = core::cmp::min(B_IN_BYTES, len_in_bytes - offset);
+    uniform_bytes[offset..offset + copy_len].copy_from_slice(&b_i[..copy_len]);
+    offset += copy_len;
+
+    // For i in (2, ..., ell):
+    for i in 2..=ell {
+        if offset >= len_in_bytes {
+            break;
+        }
+
+        // b_i = H(strxor(b_0, b_(i-1)) || I2OSP(i, 1) || DST_prime)
+        let mut hasher = H::default();
+        let mut xor_result = [0u8; 32]; // Hash32 output size
+        for j in 0..B_IN_BYTES {
+            xor_result[j] = b_0[j] ^ b_i[j];
+        }
+        hasher.update(&xor_result[..B_IN_BYTES]);
+        hasher.update(&[i]);
+        hasher.update(&dst_prime[..actual_dst_prime_len]);
+        b_i = hasher.finalize_fixed();
+
+        let copy_len = core::cmp::min(B_IN_BYTES, len_in_bytes - offset);
+        uniform_bytes[offset..offset + copy_len].copy_from_slice(&b_i[..copy_len]);
+        offset += copy_len;
+    }
+
+    uniform_bytes
+}
+
+/// Hash to field element - always returns 2 elements for hash_to_curve
+fn hash_to_field<H: Hash32 + digest::Update + BlockSizeUser>(
+    msg: &[u8],
+    dst: &[u8],
+) -> [FieldElement; 2] {
+    let len_in_bytes = 2 * L;
+    let uniform_bytes = expand_message_xmd::<H>(msg, dst, len_in_bytes);
+
+    let mut output = [FieldElement::ZERO; 2];
+
+    // Split the uniform_bytes into two L-byte chunks
+    let (first_half, second_half) = uniform_bytes.split_at(L);
+    output[0] = from_okm(first_half.try_into().unwrap());
+    output[1] = from_okm(second_half.try_into().unwrap());
+
+    output
+}
+
+/// Convert output keying material to field element
+fn from_okm(data: &[u8; L]) -> FieldElement {
+    // Construct d0 from first 24 bytes
+    let d0 = FieldElement::from_bytes_unchecked(&[
+        0, 0, 0, 0, 0, 0, 0, 0, data[0], data[1], data[2], data[3], data[4], data[5], data[6],
+        data[7], data[8], data[9], data[10], data[11], data[12], data[13], data[14], data[15],
+        data[16], data[17], data[18], data[19], data[20], data[21], data[22], data[23],
+    ]);
+
+    // Construct d1 from next 24 bytes
+    let d1 = FieldElement::from_bytes_unchecked(&[
+        0, 0, 0, 0, 0, 0, 0, 0, data[24], data[25], data[26], data[27], data[28], data[29],
+        data[30], data[31], data[32], data[33], data[34], data[35], data[36], data[37], data[38],
+        data[39], data[40], data[41], data[42], data[43], data[44], data[45], data[46], data[47],
+    ]);
+
+    d0 * F_2_192 + d1
+}
+
+/// Map field element to curve using Simplified SWU
+fn map_to_curve(u: FieldElement) -> AffinePoint {
+    let (x, y) = sswu_map(u);
+    let (x_iso, y_iso) = isogeny_map(x, y);
+
+    AffinePoint::new(x_iso, y_iso)
+}
+
+/// Simplified SWU map
+fn sswu_map(u: FieldElement) -> (FieldElement, FieldElement) {
+    let tv1 = u.square();
+    let tv3 = Z * tv1;
+    let mut tv2 = tv3.square();
+    let mut xd = tv2 + tv3;
+    let x1n = MAP_B * (xd + FieldElement::ONE);
+    xd = (xd * MAP_A.negate(1)).normalize();
+
+    let tv = Z * MAP_A;
+    xd.conditional_assign(&tv, xd.is_zero());
+
+    tv2 = xd.square();
+    let gxd = tv2 * xd;
+    tv2 *= MAP_A;
+
+    let mut gx1 = x1n * (tv2 + x1n.square());
+    tv2 = gxd * MAP_B;
+    gx1 += tv2;
+
+    let mut tv4 = gxd.square();
+    tv2 = gx1 * gxd;
+    tv4 *= tv2;
+
+    let y1 = pow_c1(&tv4) * tv2;
+    let x2n = tv3 * x1n;
+
+    let y2 = y1 * C2 * tv1 * u;
+
+    tv2 = y1.square() * gxd;
+
+    let e2 = tv2.normalize().ct_eq(&gx1.normalize());
+
+    let mut x = FieldElement::conditional_select(&x2n, &x1n, e2);
+    x *= xd.invert().unwrap();
+
+    let mut y = FieldElement::conditional_select(&y2, &y1, e2);
+    y.conditional_assign(&y.negate(1), sgn0(&u) ^ sgn0(&y));
+
+    (x, y)
+}
+
+/// Sign of field element (LSB)
+fn sgn0(x: &FieldElement) -> Choice {
+    x.normalize().is_odd()
+}
+
+/// Compute base^c1 where c1 = (p-3)/4 for secp256k1
+fn pow_c1(base: &FieldElement) -> FieldElement {
+    // For secp256k1, (p-3)/4 = (p+1)/4 - 1
+    // We can use the same addition chain as sqrt but divide by base at the end
+
+    let x2 = base.pow2k(1).mul(base); // base^3
+    let x3 = x2.pow2k(1).mul(base); // base^7  
+    let x6 = x3.pow2k(3).mul(&x3); // base^63
+    let x9 = x6.pow2k(3).mul(&x3); // base^511
+    let x11 = x9.pow2k(2).mul(&x2); // base^2047
+    let x22 = x11.pow2k(11).mul(&x11); // base^(2^22 - 1)
+    let x44 = x22.pow2k(22).mul(&x22); // base^(2^44 - 1)
+    let x88 = x44.pow2k(44).mul(&x44); // base^(2^88 - 1)
+    let x176 = x88.pow2k(88).mul(&x88); // base^(2^176 - 1)
+    let x220 = x176.pow2k(44).mul(&x44); // base^(2^220 - 1)
+    let x223 = x220.pow2k(3).mul(&x3); // base^(2^223 - 1)
+
+    // The final assembly for (p-3)/4
+    // Following the pattern from sqrt but with different final window
+    // We need the exponent 0x3fffffffffffffffffffffffffffffffffffffffffffffffffffffffbfffff0b
+    // The last part 0b = 11 in decimal
+    // We already have x11 = base^2047, but we need base^11
+    // base^11 = base^8 * base^2 * base = base^8 * x2 (since x2 = base^3)
+    // Actually: base^11 = base^8 * base^3 = x9 * base^2 (since x9 = base^511)
+    // Let's just compute it: base^11 = x3 * base^4 (since x3 = base^7)
+
+    let t = x223.pow2k(23).mul(&x22);
+    let t = t.pow2k(8);
+    // Now multiply by base^11 = x3 * base^4
+    let base4 = base.pow2k(2); // base^4
+    t.mul(&x3).mul(&base4)
+}
+
+/// 3-isogeny map from E' to E
+fn isogeny_map(x: FieldElement, y: FieldElement) -> (FieldElement, FieldElement) {
+    let xx = x.square();
+    let xxx = xx * x;
+
+    let x_num = XNUM[0] + XNUM[1] * x + XNUM[2] * xx + XNUM[3] * xxx;
+    let x_den = XDEN[0] + XDEN[1] * x + xx; // XDEN[2] = 1 is implicit
+
+    let y_num = YNUM[0] + YNUM[1] * x + YNUM[2] * xx + YNUM[3] * xxx;
+    let y_den = YDEN[0] + YDEN[1] * x + YDEN[2] * xx + xxx; // YDEN[3] = 1 is implicit
+
+    let x_iso = x_num * x_den.invert().unwrap();
+    let y_iso = y * y_num * y_den.invert().unwrap();
+
+    (x_iso, y_iso)
+}
+
+#[cfg(all(test, feature = "alloc"))]
+mod tests {
+    use super::*;
+    use crate::hex::decode_array;
+    use sha2::Sha256;
+
+    // Local hex! macro that mimics hex_literal::hex!
+    macro_rules! hex {
+        ($hex:expr) => {
+            decode_array($hex).unwrap()
+        };
+    }
+
+    struct TestVector {
+        msg: &'static [u8],
+        p_x: [u8; 32],
+        p_y: [u8; 32],
+        u_0: [u8; 32],
+        u_1: [u8; 32],
+        q0_x: [u8; 32],
+        q0_y: [u8; 32],
+        q1_x: [u8; 32],
+        q1_y: [u8; 32],
+    }
+
+    const DST: &[u8] = b"QUUX-V01-CS02-with-secp256k1_XMD:SHA-256_SSWU_RO_";
+
+    #[test]
+    fn test_hash_to_curve_test_vectors() {
+        let test_vectors = vec![
+            TestVector {
+                msg: b"",
+                p_x: hex!("c1cae290e291aee617ebaef1be6d73861479c48b841eaba9b7b5852ddfeb1346"),
+                p_y: hex!("64fa678e07ae116126f08b022a94af6de15985c996c3a91b64c406a960e51067"),
+                u_0: hex!("6b0f9910dd2ba71c78f2ee9f04d73b5f4c5f7fc773a701abea1e573cab002fb3"),
+                u_1: hex!("1ae6c212e08fe1a5937f6202f929a2cc8ef4ee5b9782db68b0d5799fd8f09e16"),
+                q0_x: hex!("74519ef88b32b425a095e4ebcc84d81b64e9e2c2675340a720bb1a1857b99f1e"),
+                q0_y: hex!("c174fa322ab7c192e11748beed45b508e9fdb1ce046dee9c2cd3a2a86b410936"),
+                q1_x: hex!("44548adb1b399263ded3510554d28b4bead34b8cf9a37b4bd0bd2ba4db87ae63"),
+                q1_y: hex!("96eb8e2faf05e368efe5957c6167001760233e6dd2487516b46ae725c4cce0c6"),
+            },
+            TestVector {
+                msg: b"abc",
+                p_x: hex!("3377e01eab42db296b512293120c6cee72b6ecf9f9205760bd9ff11fb3cb2c4b"),
+                p_y: hex!("7f95890f33efebd1044d382a01b1bee0900fb6116f94688d487c6c7b9c8371f6"),
+                u_0: hex!("128aab5d3679a1f7601e3bdf94ced1f43e491f544767e18a4873f397b08a2b61"),
+                u_1: hex!("5897b65da3b595a813d0fdcc75c895dc531be76a03518b044daaa0f2e4689e00"),
+                q0_x: hex!("07dd9432d426845fb19857d1b3a91722436604ccbbbadad8523b8fc38a5322d7"),
+                q0_y: hex!("604588ef5138cffe3277bbd590b8550bcbe0e523bbaf1bed4014a467122eb33f"),
+                q1_x: hex!("e9ef9794d15d4e77dde751e06c182782046b8dac05f8491eb88764fc65321f78"),
+                q1_y: hex!("cb07ce53670d5314bf236ee2c871455c562dd76314aa41f012919fe8e7f717b3"),
+            },
+            TestVector {
+                msg: b"abcdef0123456789",
+                p_x: hex!("bac54083f293f1fe08e4a70137260aa90783a5cb84d3f35848b324d0674b0e3a"),
+                p_y: hex!("4436476085d4c3c4508b60fcf4389c40176adce756b398bdee27bca19758d828"),
+                u_0: hex!("ea67a7c02f2cd5d8b87715c169d055a22520f74daeb080e6180958380e2f98b9"),
+                u_1: hex!("7434d0d1a500d38380d1f9615c021857ac8d546925f5f2355319d823a478da18"),
+                q0_x: hex!("576d43ab0260275adf11af990d130a5752704f79478628761720808862544b5d"),
+                q0_y: hex!("643c4a7fb68ae6cff55edd66b809087434bbaff0c07f3f9ec4d49bb3c16623c3"),
+                q1_x: hex!("f89d6d261a5e00fe5cf45e827b507643e67c2a947a20fd9ad71039f8b0e29ff8"),
+                q1_y: hex!("b33855e0cc34a9176ead91c6c3acb1aacb1ce936d563bc1cee1dcffc806caf57"),
+            },
+            TestVector {
+                msg: b"q128_qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq",
+                p_x: hex!("e2167bc785333a37aa562f021f1e881defb853839babf52a7f72b102e41890e9"),
+                p_y: hex!("f2401dd95cc35867ffed4f367cd564763719fbc6a53e969fb8496a1e6685d873"),
+                u_0: hex!("eda89a5024fac0a8207a87e8cc4e85aa3bce10745d501a30deb87341b05bcdf5"),
+                u_1: hex!("dfe78cd116818fc2c16f3837fedbe2639fab012c407eac9dfe9245bf650ac51d"),
+                q0_x: hex!("9c91513ccfe9520c9c645588dff5f9b4e92eaf6ad4ab6f1cd720d192eb58247a"),
+                q0_y: hex!("c7371dcd0134412f221e386f8d68f49e7fa36f9037676e163d4a063fbf8a1fb8"),
+                q1_x: hex!("10fee3284d7be6bd5912503b972fc52bf4761f47141a0015f1c6ae36848d869b"),
+                q1_y: hex!("0b163d9b4bf21887364332be3eff3c870fa053cf508732900fc69a6eb0e1b672"),
+            },
+            TestVector {
+                msg: b"a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                p_x: hex!("e3c8d35aaaf0b9b647e88a0a0a7ee5d5bed5ad38238152e4e6fd8c1f8cb7c998"),
+                p_y: hex!("8446eeb6181bf12f56a9d24e262221cc2f0c4725c7e3803024b5888ee5823aa6"),
+                u_0: hex!("8d862e7e7e23d7843fe16d811d46d7e6480127a6b78838c277bca17df6900e9f"),
+                u_1: hex!("68071d2530f040f081ba818d3c7188a94c900586761e9115efa47ae9bd847938"),
+                q0_x: hex!("b32b0ab55977b936f1e93fdc68cec775e13245e161dbfe556bbb1f72799b4181"),
+                q0_y: hex!("2f5317098360b722f132d7156a94822641b615c91f8663be69169870a12af9e8"),
+                q1_x: hex!("148f98780f19388b9fa93e7dc567b5a673e5fca7079cd9cdafd71982ec4c5e12"),
+                q1_y: hex!("3989645d83a433bc0c001f3dac29af861f33a6fd1e04f4b36873f5bff497298a"),
+            },
+        ];
+
+        for (i, tv) in test_vectors.iter().enumerate() {
+            // First test hash_to_field to verify u values
+            let u = hash_to_field::<Sha256>(tv.msg, DST);
+
+            // Verify u values match
+            let u0_bytes = u[0].to_bytes();
+            let u1_bytes = u[1].to_bytes();
+            assert_eq!(&u0_bytes[..], &tv.u_0[..], "Vector {}: u_0 mismatch", i);
+            assert_eq!(&u1_bytes[..], &tv.u_1[..], "Vector {}: u_1 mismatch", i);
+
+            // Test map_to_curve for q0 and q1
+            let q0 = map_to_curve(u[0]);
+            let q1 = map_to_curve(u[1]);
+
+            // Verify q0 and q1
+            assert_eq!(
+                &q0.x.to_bytes()[..],
+                &tv.q0_x[..],
+                "Vector {}: q0_x mismatch",
+                i
+            );
+            assert_eq!(
+                &q0.y.to_bytes()[..],
+                &tv.q0_y[..],
+                "Vector {}: q0_y mismatch",
+                i
+            );
+            assert_eq!(
+                &q1.x.to_bytes()[..],
+                &tv.q1_x[..],
+                "Vector {}: q1_x mismatch",
+                i
+            );
+            assert_eq!(
+                &q1.y.to_bytes()[..],
+                &tv.q1_y[..],
+                "Vector {}: q1_y mismatch",
+                i
+            );
+
+            // Test the complete hash_to_curve function
+            let point = hash_to_curve::<Sha256>(tv.msg, DST);
+
+            // Convert ProjectivePoint to AffinePoint to get coordinates
+            let affine_point = AffinePoint::from(point);
+            let x_bytes = affine_point.x.to_bytes();
+            let y_bytes = affine_point.y.to_bytes();
+
+            // Verify the final hash_to_curve output matches expected coordinates
+            assert_eq!(
+                &x_bytes[..],
+                &tv.p_x[..],
+                "Vector {}: final x coordinate mismatch",
+                i
+            );
+            assert_eq!(
+                &y_bytes[..],
+                &tv.p_y[..],
+                "Vector {}: final y coordinate mismatch",
+                i
+            );
+        }
+    }
+
+    #[test]
+    fn test_hash_to_curve_properties() {
+        // Test that hash_to_curve produces valid points
+        let test_messages: [&[u8]; 4] = [b"", b"abc", b"abcdef0123456789", b"test message"];
+
+        for msg in &test_messages {
+            let point = hash_to_curve::<Sha256>(msg, DST);
+
+            // For hash_to_curve, points should never be the identity
+            assert!(
+                !bool::from(point.is_identity()),
+                "hash_to_curve should not produce identity point for message {:?}",
+                msg
+            );
+
+            // Verify the point is on the curve (implicit in ProjectivePoint)
+            // Convert to affine to ensure it's a valid point
+            let affine = AffinePoint::from(point);
+
+            // Verify deterministic - same input produces same output
+            let point2 = hash_to_curve::<Sha256>(msg, DST);
+            assert_eq!(
+                affine,
+                AffinePoint::from(point2),
+                "hash_to_curve should be deterministic for message {:?}",
+                msg
+            );
+        }
+    }
+}

--- a/secp256kfun/src/vendor/k256/field.rs
+++ b/secp256kfun/src/vendor/k256/field.rs
@@ -125,7 +125,7 @@ impl FieldElement {
     }
 
     /// Raises the scalar to the power `2^k`
-    fn pow2k(&self, k: usize) -> Self {
+    pub(crate) fn pow2k(&self, k: usize) -> Self {
         let mut x = *self;
         for _j in 0..k {
             x = x.square();

--- a/secp256kfun/src/vendor/mod.rs
+++ b/secp256kfun/src/vendor/mod.rs
@@ -1,2 +1,3 @@
 #![allow(clippy::all)]
+pub mod hash_to_curve;
 pub mod k256;

--- a/secp256kfun/tests/test_hash_to_curve.rs
+++ b/secp256kfun/tests/test_hash_to_curve.rs
@@ -1,0 +1,238 @@
+use proptest::prelude::*;
+use secp256kfun::{Point, hash::HashAdd, hex, marker::*};
+use sha2::Sha256;
+
+#[test]
+fn test_hash_to_curve_sswu_test_vectors() {
+    // Test vectors from RFC 9380 specification
+    // See: https://datatracker.ietf.org/doc/rfc9380/
+    // These are the final P.x and P.y values for each test case
+    let test_vectors: [(&[u8], [u8; 32], [u8; 32]); 5] = [
+        (
+            &b""[..],
+            hex::decode_array("c1cae290e291aee617ebaef1be6d73861479c48b841eaba9b7b5852ddfeb1346").unwrap(),
+            hex::decode_array("64fa678e07ae116126f08b022a94af6de15985c996c3a91b64c406a960e51067").unwrap(),
+        ),
+        (
+            &b"abc"[..],
+            hex::decode_array("3377e01eab42db296b512293120c6cee72b6ecf9f9205760bd9ff11fb3cb2c4b").unwrap(),
+            hex::decode_array("7f95890f33efebd1044d382a01b1bee0900fb6116f94688d487c6c7b9c8371f6").unwrap(),
+        ),
+        (
+            &b"abcdef0123456789"[..],
+            hex::decode_array("bac54083f293f1fe08e4a70137260aa90783a5cb84d3f35848b324d0674b0e3a").unwrap(),
+            hex::decode_array("4436476085d4c3c4508b60fcf4389c40176adce756b398bdee27bca19758d828").unwrap(),
+        ),
+        (
+            &b"q128_qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq"[..],
+            hex::decode_array("e2167bc785333a37aa562f021f1e881defb853839babf52a7f72b102e41890e9").unwrap(),
+            hex::decode_array("f2401dd95cc35867ffed4f367cd564763719fbc6a53e969fb8496a1e6685d873").unwrap(),
+        ),
+        (
+            &b"a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"[..],
+            hex::decode_array("e3c8d35aaaf0b9b647e88a0a0a7ee5d5bed5ad38238152e4e6fd8c1f8cb7c998").unwrap(),
+            hex::decode_array("8446eeb6181bf12f56a9d24e262221cc2f0c4725c7e3803024b5888ee5823aa6").unwrap(),
+        ),
+    ];
+
+    let dst = b"QUUX-V01-CS02-with-secp256k1_XMD:SHA-256_SSWU_RO_";
+
+    for (i, (msg, expected_x, expected_y)) in test_vectors.iter().enumerate() {
+        let point = Point::hash_to_curve_sswu::<Sha256>(msg, dst).normalize();
+        let (x_bytes, y_bytes) = point.coordinates();
+
+        assert_eq!(
+            &x_bytes[..],
+            &expected_x[..],
+            "Test vector {} failed: x coordinate mismatch",
+            i
+        );
+        assert_eq!(
+            &y_bytes[..],
+            &expected_y[..],
+            "Test vector {} failed: y coordinate mismatch",
+            i
+        );
+    }
+}
+
+proptest! {
+    #[test]
+    fn test_hash_to_curve_sswu_properties(
+        msg1 in prop::collection::vec(any::<u8>(), 0..1000),
+        msg2 in prop::collection::vec(any::<u8>(), 0..1000),
+        dst1 in prop::collection::vec(any::<u8>(), 0..255),
+        dst2 in prop::collection::vec(any::<u8>(), 0..255),
+    ) {
+        // Test determinism - same message and DST should produce same point
+        let point1 = Point::hash_to_curve_sswu::<Sha256>(&msg1, &dst1);
+        let point1_again = Point::hash_to_curve_sswu::<Sha256>(&msg1, &dst1);
+        assert_eq!(point1, point1_again, "hash_to_curve_sswu should be deterministic");
+
+        // Point should be NonNormal
+        let _: Point<NonNormal, Public, NonZero> = point1;
+
+        // Points should never be zero
+        assert!(!point1.is_zero(), "hash_to_curve_sswu should never produce zero point");
+
+        // Different messages with same DST should produce different points (with high probability)
+        if msg1 != msg2 {
+            let point2 = Point::hash_to_curve_sswu::<Sha256>(&msg2, &dst1);
+            assert_ne!(point1, point2, "Different messages should produce different points");
+            assert!(!point2.is_zero(), "hash_to_curve_sswu should never produce zero point");
+        }
+
+        // Same message with different DSTs should produce different points (with high probability)
+        if dst1 != dst2 {
+            let point3 = Point::hash_to_curve_sswu::<Sha256>(&msg1, &dst2);
+            assert_ne!(point1, point3, "Different DSTs should produce different points");
+            assert!(!point3.is_zero(), "hash_to_curve_sswu should never produce zero point");
+        }
+    }
+
+    #[test]
+    fn test_hash_to_curve_properties(
+        msg1 in prop::collection::vec(any::<u8>(), 0..1000),
+        msg2 in prop::collection::vec(any::<u8>(), 0..1000),
+    ) {
+        // Test determinism - same message should produce same point
+        let point1 = Point::hash_to_curve(Sha256::default().add(msg1.as_slice()));
+        let point1_again = Point::hash_to_curve(Sha256::default().add(msg1.as_slice()));
+        assert_eq!(point1, point1_again, "hash_to_curve should be deterministic");
+
+        // Point should be Normal
+        let _: Point<Normal, Public, NonZero> = point1;
+
+        // Points should never be zero
+        assert!(!point1.is_zero(), "hash_to_curve should never produce zero point");
+
+        // Different messages should produce different points (with high probability)
+        if msg1 != msg2 {
+            let point2 = Point::hash_to_curve(Sha256::default().add(msg2.as_slice()));
+            assert_ne!(point1, point2, "Different messages should produce different points");
+            assert!(!point2.is_zero(), "hash_to_curve should never produce zero point");
+        }
+    }
+}
+
+#[test]
+fn test_hash_to_curve_test_vectors() {
+    // Test vectors for hash_to_curve method
+    // Format: (message, expected_point_bytes)
+    let test_vectors: &[(&[u8], &str)] = &[
+        // Empty message
+        (
+            b"",
+            "026e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d",
+        ),
+        // Simple message
+        (
+            b"abc",
+            "039ec4bc6eb63eba8718769cd80a0350e55a1372b09081a1fb6ecd3be235ec1690",
+        ),
+        // Binary data including null bytes
+        (
+            &[0x00, 0x01, 0x02, 0x03, 0xff, 0xfe, 0xfd],
+            "03e8f0f84f444ef4b79f067e6cf00df7121c053b338facf4d48e28d44ca23eaea8",
+        ),
+        // Longer message
+        (
+            b"The quick brown fox jumps over the lazy dog",
+            "03b2ad65c3817347a655c515ac1e5e6a6620407d39b53bad8355312911de249e1d",
+        ),
+    ];
+
+    for (i, (msg, expected_hex)) in test_vectors.iter().enumerate() {
+        let point = Point::hash_to_curve(Sha256::default().add(*msg));
+        let actual_bytes = point.to_bytes();
+        let expected_bytes = hex::decode_array::<33>(expected_hex).unwrap();
+
+        assert_eq!(
+            actual_bytes, expected_bytes,
+            "Test vector {} failed: msg={:?}",
+            i, msg
+        );
+
+        // Verify determinism
+        let point2 = Point::hash_to_curve(Sha256::default().add(*msg));
+        assert_eq!(point, point2, "Point generation should be deterministic");
+
+        // Verify the point is valid and non-zero
+        assert!(!point.is_zero());
+    }
+}
+
+#[test]
+fn test_hash_to_curve_rfc9381_tai() {
+    // Test vectors for RFC 9381 TAI (try-and-increment) method
+    // Format: (message, salt, expected_point_bytes)
+    let test_vectors: &[(&[u8], &[u8], &str)] = &[
+        // Empty message, empty salt
+        (
+            b"",
+            b"",
+            "020fadef9b80ca733f36f5dad4bdce241534ac605ed352a1c3570a38913dc92204",
+        ),
+        // Message with empty salt
+        (
+            b"abc",
+            b"",
+            "026d72997180b59ffed2e9fef657f392ea3aa869dae4a441feac861eaca9f00985",
+        ),
+        // Message with salt
+        (
+            b"test message",
+            b"test salt",
+            "02b4e185a9c8535748a9fe89b287a0bf6a24c5bd5f25a9cb50b0e5770a41abc550",
+        ),
+        // VRF test case with public key as salt
+        (
+            b"sample",
+            &hex::decode_array::<33>(
+                "032c8c31fc9f990c6b55e3865a184a4ce50e09481f2eaeb3e60ec1cea13a6ae645",
+            )
+            .unwrap(),
+            "0221ceb1ce22cd34d8b73a619164ed64e917ca31fd454075d02e4bdfa9c5ce0b48",
+        ),
+        // Binary data with binary salt
+        (
+            &[0x00, 0x01, 0x02, 0x03, 0xff, 0xfe, 0xfd],
+            &[0xde, 0xad, 0xbe, 0xef],
+            "025b9c20016d733cab83dda56f283e68d574cbc39ef2d77cb343241daa54a91b79",
+        ),
+    ];
+
+    for (i, (msg, salt, expected_hex)) in test_vectors.iter().enumerate() {
+        let point = Point::hash_to_curve_rfc9381_tai::<Sha256>(msg, salt);
+        let actual_bytes = point.to_bytes();
+        let expected_bytes = hex::decode_array::<33>(expected_hex).unwrap();
+
+        assert_eq!(
+            actual_bytes, expected_bytes,
+            "Test vector {} failed: msg={:?}, salt={:?}",
+            i, msg, salt
+        );
+
+        // Verify determinism
+        let point2 = Point::hash_to_curve_rfc9381_tai::<Sha256>(msg, salt);
+        assert_eq!(point, point2, "Point generation should be deterministic");
+
+        // Verify the point is valid and non-zero
+        assert!(!point.is_zero());
+        assert_eq!(
+            actual_bytes[0], 0x02,
+            "Point should always have even y-coordinate"
+        );
+    }
+
+    // Additional property tests
+    // Test that different messages produce different points
+    let point1 = Point::hash_to_curve_rfc9381_tai::<Sha256>(b"message1", b"");
+    let point2 = Point::hash_to_curve_rfc9381_tai::<Sha256>(b"message2", b"");
+    assert_ne!(point1, point2);
+
+    // Test that same message with different salts produces different points
+    let point3 = Point::hash_to_curve_rfc9381_tai::<Sha256>(b"message", b"salt1");
+    let point4 = Point::hash_to_curve_rfc9381_tai::<Sha256>(b"message", b"salt2");
+    assert_ne!(point3, point4);
+}


### PR DESCRIPTION
## Summary

Implements hash-to-curve functionality for secp256k1 following the IETF draft specification:
https://datatracker.ietf.org/doc/draft-irtf-cfrg-hash-to-curve/

This was necessary because the upstream k256 implementation couldn't be directly copied into secp256kfun due to dependency and API differences.

## Changes

- Added `hash_to_curve` module in vendor directory
- Exposed through `BackendPoint` trait 
- Added public API on `Point` that returns `NonNormal` points
- Made `pow2k` method `pub(crate)` in vendor/k256/field.rs to reuse it
- Comprehensive tests including RFC test vectors and property-based tests

<details>
<summary>Conversation History</summary>

**User**: implement hash_to_curve using https://github.com/RustCrypto/elliptic-curves/blob/master/k256/src/arithmetic/hash2curve.rs as a guide for the implementation. It should pass the exact same test vectors. It should use the Hash32 trait as a type parameter for the hash function. It should use sha2 in the tests. it should be using the vendor module. Do not expose the vendor types outside of the vendor module. First create an API skeleton with todo\!() and complete test vectors. Make sure it all compiles. Then implement it.

**Assistant**: [Created initial skeleton with test vectors and API structure]

**User**: You can just condition the whole test block on `alloc`. std implies alloc. I want you to implement the test vectors completely. They won't pass of course but they should be fully there. Don't worry about writing the function signatures for the API if you're not implementing it just leave the body as empty or todo\!() for now. Use the hex.rs decode fns to decode the test vectros.

**Assistant**: [Implemented complete test vectors]

**User**: Can we make a sort of dummy `hex\!` macro here that just does decode_array and unwrap. to clean up the test vectors.

**Assistant**: [Created hex\! macro and cleaned up test vectors]

**User**: ok great now try and implement hash_to_curve exactly like in elliptic-curves k256 and pass the tests\!

**Assistant**: [Implemented hash_to_curve following k256]

**User**: the hash to curve impls shouldn't need alloc. All the sizes should be known up front. Just make arrays.

**Assistant**: [Refactored to use fixed-size arrays instead of Vec]

**User**: on top of that why are you directly using the particular backend field element type like `FieldElement5x52`. You should only be using the public `FieldElement` type we have re-exported. You seem to have avoided using FieldElement::from_bytes_unchecked for all these little field element constants. This is a mistake. This is a const function you can use to declare all these constants in a similar manner to the k256 original implementation.

**Assistant**: [Fixed to use public FieldElement API and from_bytes_unchecked for constants]

**User**: [After debugging] Did you realize that pow2k is a method on FieldElement already you didn't have to define it?

**User**: well it's not part of the public api but I wouldn't mind if we made it pub(super) or something like that.

**Assistant**: [Made pow2k pub(crate) and removed duplicate implementation]

**User**: I think the same thing with 48? This is fixed in the spec right? If so let's just make a const for it and don't pass it in as a parameter anywhere.

**Assistant**: [Made L a constant = 48]

**User**: it seems like from_okm can take a fixed length array now

**Assistant**: [Updated from_okm to take &[u8; L]]

**User**: can you explain a bit why we need to know the BlockSize of the hash function for this. Why does the spec care?

**Assistant**: [Explained Z_pad security padding in expand_message_xmd]

**User**: ok let's get rid of the OutputSizeUser thing at least. It's Hash32 which has a fixed output size.

**Assistant**: [Removed OutputSizeUser trait bound]

**User**: You have these comments like `// Compute x_num = XNUM[0] + XNUM[1] * x + XNUM[2] * x^2 + XNUM[3] * x^3` why not just define the constants as arrays so you could just refer to them as XNUM[0] etc.

**Assistant**: [Refactored isogeny constants to arrays]

**User**: These comments seem very redundant now. Can you not have a comment above the line of code saying almost the exact same thing.

**Assistant**: [Removed redundant comments]

**User**: map_to_curve doesn't make sense. It for some reason turns the return value into Affine and then returns Projective. why don't you just return an AffinePoint directly.

**Assistant**: [Fixed map_to_curve to return AffinePoint]

**User**: please remove the clear cofactor stuff.

**Assistant**: [Removed clear_cofactor as secp256k1 has cofactor=1]

**User**: Ok so what we're going to do is expose this hash_to_curve on the BackendPoint trait and impl it using what you've done.

**Assistant**: [Added hash_to_curve to BackendPoint trait and implemented it]

**User**: Err I don't think that hash_to_curve returns a Normal point. It should be NonNormal. It comes from a projective point. Don't normalize it aggressively.

**Assistant**: [Fixed to return NonNormal point]

**User**: nooo you shouldn't use the internals in the point.rs tests. Ok to make sure you don't make this mistake put the tests in tests/test_hash_to_curve.rs so they can only use the public API.

**Assistant**: [Moved tests to integration tests using only public API]

**User**: can you turn the test_hash_to_curve_public_api thing into a proptest with different random strings.

**Assistant**: [Added proptest for property-based testing]

**User**: proptest is a dev dependency it doesn't need a feature gate in test files

**Assistant**: [Removed unnecessary feature gates]

**User**: In `expand_message_xmd` the final parameter is an invariant.

**Assistant**: [Made len_in_bytes parameter an invariant]

**User**: ell is also an invariant now

**Assistant**: [Made ell an invariant]

**User**: ok I feel like I've made a mess of this. I think you should return it to the more spec comparable version which took the argument and implemented this whole crazy construction. I thought it would get less crazy as you take care of the invariants but it doesn't at all.

**Assistant**: [Reverted expand_message_xmd to spec-compliant version with parameters]

</details>

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>