### PR TITLE
feat: implement bincode encode/decode for CompactProof with any challenge length

### DIFF
--- a/sigma_fun/src/eq.rs
+++ b/sigma_fun/src/eq.rs
@@ -200,6 +200,27 @@ mod test {
             assert_eq!(decoded, proof);
         }
 
+        #[test]
+        #[cfg(all(feature = "bincode", feature = "alloc"))]
+        fn bincode_roundtrip_u16() {
+            use crate::typenum::U16;
+            type DLEQ = Eq<secp256k1::DLG<U16>, secp256k1::DL<U16>>;
+            let x = s!(42);
+            let H = Point::random(&mut rand::thread_rng());
+            let xG = g!(x * G).normalize();
+            let xH = g!(x * H).normalize();
+            let statement = ((xG), (H, xH));
+            let proof_system = FiatShamir::<DLEQ, HashTranscript<Sha256, ChaCha20Rng>>::default();
+            let proof = proof_system.prove(&x, &statement, Some(&mut rand::thread_rng()));
+            let encoded = bincode::encode_to_vec(&proof, bincode::config::standard()).unwrap();
+            let (decoded, _) = bincode::decode_from_slice::<crate::CompactProof<DLEQ>, _>(
+                &encoded[..],
+                bincode::config::standard(),
+            )
+            .unwrap();
+            assert_eq!(decoded, proof);
+        }
+
         proptest! {
             #[test]
             fn test_dleq_secp256k1(


### PR DESCRIPTION
## Summary

Generalized bincode serialization for `CompactProof` to work with any challenge length instead of only U32.

## Test plan

- [x] Added test `bincode_roundtrip_u16` to verify serialization works with U16 challenge length
- [x] Existing `bincode_roundtrip` test still passes with U32 challenge length
- [x] cargo fmt and clippy pass

<details><summary>Conversation History</summary>

User: looking at sigma_fun do you see the bincode encode/decode implementations. Can you see how they are only implemented where challenge length is U32. Can you see if you can do it for any challenge length? You might have to do a deep dive into the particular version fo generic_array that I'm using.
Assistant: I successfully implemented bincode encode/decode for CompactProof with any challenge length by:
- Removing the U32 type constraint on ChallengeLength
- Using direct byte operations with bincode's Writer/Reader traits
- Maintaining backwards compatibility with existing serialized data

User: Sorry before doing the PR can you just use the qualified path to import things from bincode for the trait implementations.

Assistant: I updated the imports to use qualified paths for the bincode traits.

</details>

🤖 Generated with [Claude Code](https://claude.ai/code)
