### PR TITLE
feat: Add manual trait implementations for ShareImage

### DIFF
--- a/schnorr_fun/src/frost/share.rs
+++ b/schnorr_fun/src/frost/share.rs
@@ -532,9 +532,45 @@ pub struct ShareImage<T = Normal> {
     pub image: Point<T, Public, Zero>,
 }
 
-impl<T: PointType> PartialEq for ShareImage<T> {
+impl<T> PartialEq for ShareImage<T>
+where
+    Point<T, Public, Zero>: PartialEq,
+{
     fn eq(&self, other: &Self) -> bool {
         self.index == other.index && self.image == other.image
+    }
+}
+
+impl<T> Eq for ShareImage<T> where Point<T, Public, Zero>: Eq {}
+
+impl<T> PartialOrd for ShareImage<T>
+where
+    Point<T, Public, Zero>: Ord,
+{
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<T> Ord for ShareImage<T>
+where
+    Point<T, Public, Zero>: Ord,
+{
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        match self.index.cmp(&other.index) {
+            core::cmp::Ordering::Equal => self.image.cmp(&other.image),
+            ord => ord,
+        }
+    }
+}
+
+impl<T> core::hash::Hash for ShareImage<T>
+where
+    Point<T, Public, Zero>: core::hash::Hash,
+{
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+        self.index.hash(state);
+        self.image.hash(state);
     }
 }
 


### PR DESCRIPTION
## Summary

This PR adds manual trait implementations for ShareImage to properly handle the generic type parameter.

## Changes

- Implemented PartialEq, Eq, PartialOrd, Ord, and Hash for ShareImage<T>
- All implementations are properly bounded - they only exist when Point<T, Public, Zero> supports the corresponding trait
- This ensures ShareImage works correctly with different PointType parameters (Normal vs NonNormal)

## Technical Details

The manual implementations are necessary because Rust's built-in derives can't specify custom bounds for generic types. By implementing these traits manually with proper bounds, we ensure:
- ShareImage<Normal> gets all the traits when the underlying Point type supports them
- ShareImage<NonNormal> only gets the traits that Point<NonNormal, _, _> actually implements (excludes Hash and Ord traits)
- VerificationShare (which wraps ShareImage<NonNormal>) automatically gets the correct set of traits

This is a follow-up to #226 with additional improvements based on review feedback.