### PR TITLE
chilldkg: security review fixes

### DIFF
--- a/schnorr_fun/src/frost/chilldkg/certpedpop.rs
+++ b/schnorr_fun/src/frost/chilldkg/certpedpop.rs
@@ -95,6 +95,12 @@ impl Contributor {
     /// This method is used when a party acts as both a contributor (providing entropy)
     /// and a receiver (getting a secret share), using the same keypair for both
     /// encryption/decryption and certification.
+    ///
+    /// Returns the same shape as the receiver-only entry point
+    /// [`SecretShareReceiver::receive_secret_share`]: a [`SecretShareReceiver`]
+    /// that *holds* the share until [`SecretShareReceiver::finalize`] is
+    /// called with a complete cert map. Callers must not use the share before
+    /// finalize succeeds — otherwise they're trusting an uncertified keygen.
     pub fn verify_receive_share_and_certify<H: Hash32, NG: NonceGen, S: CertificationScheme>(
         self,
         pop_schnorr: &Schnorr<H, NG>,
@@ -102,7 +108,7 @@ impl Contributor {
         share_index: ShareIndex,
         keypair: &KeyPair,
         agg_input: &AggKeygenInput,
-    ) -> Result<(PairedSecretShare<Normal, Zero>, S::Signature), CombinedRoleError> {
+    ) -> Result<(SecretShareReceiver, S::Signature), CombinedRoleError> {
         // First verify my contribution was included
         self.inner
             .verify_agg_input(agg_input)
@@ -116,7 +122,13 @@ impl Contributor {
         // Finally certify the result
         let sig = cert_scheme.certify(keypair, agg_input);
 
-        Ok((paired_secret_share, sig))
+        Ok((
+            SecretShareReceiver {
+                paired_secret_share,
+                agg_input: agg_input.clone(),
+            },
+            sig,
+        ))
     }
 }
 
@@ -313,7 +325,9 @@ pub fn simulate_keygen<H: Hash32, NG: NonceGen, S: CertificationScheme + Clone>(
     )
     .expect("simulate_keygen produces matching contributor counts");
 
-    let mut paired_secret_shares = vec![];
+    // Hold dual-role receiver state until certification finishes; only then
+    // can we release the paired share via finalize.
+    let mut dual_role_receivers: Vec<(SecretShareReceiver, KeyPair)> = vec![];
 
     // Handle parties that are both contributors and receivers using the combined API
     for (i, (party_index, enckey)) in receiver_enckeys
@@ -322,7 +336,7 @@ pub fn simulate_keygen<H: Hash32, NG: NonceGen, S: CertificationScheme + Clone>(
         .take(n_receivers as usize)
     {
         // This party is both a contributor and receiver - use combined method
-        let (paired_secret_share, sig) = contributors[i]
+        let (receiver, sig) = contributors[i]
             .clone()
             .verify_receive_share_and_certify(
                 schnorr,
@@ -338,7 +352,7 @@ pub fn simulate_keygen<H: Hash32, NG: NonceGen, S: CertificationScheme + Clone>(
             .receive_certificate(enckey.public_key(), sig)
             .unwrap();
 
-        paired_secret_shares.push((paired_secret_share.non_zero().unwrap(), *enckey));
+        dual_role_receivers.push((receiver, *enckey));
     }
 
     // Handle extra contributors that are only contributors (not receivers)
@@ -356,6 +370,18 @@ pub fn simulate_keygen<H: Hash32, NG: NonceGen, S: CertificationScheme + Clone>(
     let certified_keygen = certifier
         .finish()
         .expect("Certifier should have all required certificates");
+
+    // Now that certification is done, release each dual-role party's share.
+    let cert_map = certified_keygen.certificate().clone();
+    let paired_secret_shares: Vec<(PairedSecretShare<Normal>, KeyPair)> = dual_role_receivers
+        .into_iter()
+        .map(|(receiver, enckey)| {
+            let CertifiedSecretShare { paired_share, .. } = receiver
+                .finalize(&cert_scheme, cert_map.clone(), &contributor_public_keys)
+                .expect("simulate_keygen finalize");
+            (paired_share.non_zero().unwrap(), enckey)
+        })
+        .collect();
 
     SimulatedKeygenOutput {
         certified_keygen,

--- a/schnorr_fun/src/frost/chilldkg/certpedpop.rs
+++ b/schnorr_fun/src/frost/chilldkg/certpedpop.rs
@@ -13,6 +13,7 @@ pub mod certificate;
 pub use certificate::vrf_cert;
 pub use certificate::{
     CertificateError, CertificationScheme, CertifiedKeygen, Certifier, CertifierError,
+    RecoverShareError,
 };
 
 use super::{encpedpop, simplepedpop};

--- a/schnorr_fun/src/frost/chilldkg/certpedpop.rs
+++ b/schnorr_fun/src/frost/chilldkg/certpedpop.rs
@@ -56,6 +56,7 @@ impl Contributor {
     pub fn gen_keygen_input<H: Hash32, NG: NonceGen>(
         schnorr: &Schnorr<H, NG>,
         threshold: u32,
+        n_contributors: u32,
         receiver_encryption_keys: &BTreeMap<ShareIndex, Point>,
         my_index: u32,
         rng: &mut impl rand_core::RngCore,
@@ -63,6 +64,7 @@ impl Contributor {
         let (inner, message) = encpedpop::Contributor::gen_keygen_input(
             schnorr,
             threshold,
+            n_contributors,
             receiver_encryption_keys,
             my_index,
             rng,
@@ -248,7 +250,7 @@ pub fn simulate_keygen<H: Hash32, NG: NonceGen, S: CertificationScheme + Clone>(
         .map(|(party_index, enckeypair)| (*party_index, enckeypair.public_key()))
         .collect::<BTreeMap<ShareIndex, Point>>();
 
-    let n_generators = n_receivers + n_extra_generators;
+    let n_contributors = n_receivers + n_extra_generators;
 
     // Generate keypairs for contributors - receivers will use their existing keypairs
     let contributor_keys: Vec<_> = (1..=n_receivers)
@@ -263,9 +265,16 @@ pub fn simulate_keygen<H: Hash32, NG: NonceGen, S: CertificationScheme + Clone>(
         .collect();
 
     let (contributors, to_coordinator_messages): (Vec<Contributor>, Vec<KeygenInput>) = (0
-        ..n_generators)
+        ..n_contributors)
         .map(|i| {
-            Contributor::gen_keygen_input(schnorr, threshold, &public_receiver_enckeys, i, rng)
+            Contributor::gen_keygen_input(
+                schnorr,
+                threshold,
+                n_contributors,
+                &public_receiver_enckeys,
+                i,
+                rng,
+            )
         })
         .unzip();
 
@@ -274,7 +283,7 @@ pub fn simulate_keygen<H: Hash32, NG: NonceGen, S: CertificationScheme + Clone>(
         .map(|kp| kp.public_key())
         .collect::<Vec<_>>();
 
-    let mut aggregator = Coordinator::new(threshold, n_generators, &public_receiver_enckeys);
+    let mut aggregator = Coordinator::new(threshold, n_contributors, &public_receiver_enckeys);
 
     for (i, to_coordinator_message) in to_coordinator_messages.into_iter().enumerate() {
         aggregator
@@ -290,7 +299,8 @@ pub fn simulate_keygen<H: Hash32, NG: NonceGen, S: CertificationScheme + Clone>(
         cert_scheme.clone(),
         agg_input.clone(),
         &contributor_public_keys,
-    );
+    )
+    .expect("simulate_keygen produces matching contributor counts");
 
     let mut paired_secret_shares = vec![];
 
@@ -321,7 +331,7 @@ pub fn simulate_keygen<H: Hash32, NG: NonceGen, S: CertificationScheme + Clone>(
     }
 
     // Handle extra contributors that are only contributors (not receivers)
-    for i in n_receivers as usize..n_generators as usize {
+    for i in n_receivers as usize..n_contributors as usize {
         let sig = contributors[i]
             .clone()
             .verify_agg_input(&cert_scheme, &agg_input, &contributor_keys[i])

--- a/schnorr_fun/src/frost/chilldkg/certpedpop.rs
+++ b/schnorr_fun/src/frost/chilldkg/certpedpop.rs
@@ -160,6 +160,12 @@ impl SecretShareReceiver {
     /// By default every share receiver is a certifying party but you must also get
     /// certifications from the [`Contributor`]s for security. Their keys are passed in as
     /// `contributor_keys`.
+    ///
+    /// The supplied `certificate` map must contain exactly one entry per
+    /// certifying party — any extras are rejected with
+    /// [`CertificateError::Unexpected`]. This avoids unverified entries
+    /// landing in the resulting [`CertifiedKeygen`] (where downstream
+    /// consumers like the VRF beacon would otherwise pick them up).
     pub fn finalize<S: CertificationScheme>(
         self,
         cert_scheme: &S,
@@ -173,18 +179,23 @@ impl SecretShareReceiver {
             .chain(contributor_keys.iter().cloned())
             .collect::<BTreeSet<_>>(); // dedupe as some contributors may also be receivers
 
+        let mut remaining = certificate;
+        let mut verified = BTreeMap::new();
         for cert_key in cert_keys {
-            match certificate.get(&cert_key) {
-                Some(sig) => {
-                    if !cert_scheme.verify_cert(cert_key, &self.agg_input, sig) {
-                        return Err(CertificateError::InvalidCert { key: cert_key });
-                    }
-                }
-                None => return Err(CertificateError::Missing { key: cert_key }),
+            let sig = remaining
+                .remove(&cert_key)
+                .ok_or(CertificateError::Missing { key: cert_key })?;
+            if !cert_scheme.verify_cert(cert_key, &self.agg_input, &sig) {
+                return Err(CertificateError::InvalidCert { key: cert_key });
             }
+            verified.insert(cert_key, sig);
         }
 
-        let certified_keygen = CertifiedKeygen::new(self.agg_input, certificate);
+        if let Some((extra_key, _)) = remaining.into_iter().next() {
+            return Err(CertificateError::Unexpected { key: extra_key });
+        }
+
+        let certified_keygen = CertifiedKeygen::new(self.agg_input, verified);
 
         Ok(CertifiedSecretShare {
             certified_keygen,
@@ -459,5 +470,60 @@ mod test {
                 (n_receivers + n_extra_generators) as usize
             );
         }
+    }
+
+    // SecretShareReceiver::finalize must reject any caller-supplied certificate
+    // map that contains entries for keys outside the expected certifying set.
+    // Otherwise the extras would land in CertifiedKeygen.certificate and
+    // pollute downstream consumers (e.g. the VRF beacon).
+    #[test]
+    fn finalize_rejects_unexpected_cert_entries() {
+        let schnorr = crate::new_with_deterministic_nonces::<sha2::Sha256>();
+        let mut rng = TestRng::deterministic_rng(RngAlgorithm::ChaCha);
+        let threshold = 2u32;
+        let n_receivers = 2u32;
+        let n_extra_generators = 0u32;
+
+        let output = certpedpop::simulate_keygen(
+            &schnorr,
+            schnorr.clone(),
+            threshold,
+            n_receivers,
+            n_extra_generators,
+            Fingerprint::NONE,
+            &mut rng,
+        );
+
+        // Pick the first receiver as our honest party for the finalize test.
+        let (paired_share, keypair) = output.paired_shares_with_keys[0];
+        let agg_input = output.certified_keygen.agg_input().clone();
+        let contributor_keys = output.contributor_public_keys.clone();
+
+        // Build the receiver state via the receiver-only entry point so we
+        // can drive `finalize` directly.
+        let (receiver, _own_sig) = SecretShareReceiver::receive_secret_share(
+            &schnorr,
+            &schnorr,
+            paired_share.index(),
+            &keypair,
+            &agg_input,
+        )
+        .expect("receive_secret_share");
+
+        // Honest cert map from the simulated keygen, plus an extra valid cert
+        // signed by an unrelated keypair (not in contributor_keys ∪ receivers).
+        let mut malicious_cert_map = output.certified_keygen.certificate().clone();
+        let unrelated_keypair = KeyPair::new(Scalar::random(&mut rng));
+        let unrelated_sig = schnorr.certify(&unrelated_keypair, &agg_input);
+        malicious_cert_map.insert(unrelated_keypair.public_key(), unrelated_sig);
+
+        let result = receiver.finalize(&schnorr, malicious_cert_map, &contributor_keys);
+        assert_eq!(
+            result.err(),
+            Some(CertificateError::Unexpected {
+                key: unrelated_keypair.public_key()
+            }),
+            "finalize must reject unknown-key entries in the supplied map"
+        );
     }
 }

--- a/schnorr_fun/src/frost/chilldkg/certpedpop/certificate.rs
+++ b/schnorr_fun/src/frost/chilldkg/certpedpop/certificate.rs
@@ -52,14 +52,14 @@ impl<H: Hash32, NG: NonceGen> CertificationScheme for Schnorr<H, NG> {
     }
 }
 
-/// The result of a certified key generation
+/// The result of a certified key generation.
+///
+/// This type is deliberately not serializable: every `CertifiedKeygen` reaches a
+/// user only through [`Certifier::finish`], where every cert was verified on the
+/// way in. If you need to persist or transport the result, serialize the
+/// underlying [`AggKeygenInput`] and the certificate map separately and
+/// re-run certification on the receiving side.
 #[derive(Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "bincode", derive(bincode::Encode, bincode::Decode))]
-#[cfg_attr(
-    feature = "serde",
-    derive(crate::fun::serde::Deserialize, crate::fun::serde::Serialize),
-    serde(crate = "crate::fun::serde")
-)]
 pub struct CertifiedKeygen<Sig> {
     /// The aggregated inputs to keygen
     input: AggKeygenInput,
@@ -73,11 +73,11 @@ impl<Sig> CertifiedKeygen<Sig> {
         Self { input, certificate }
     }
 
-    /// Verify that all certificates are valid for the given certification scheme and contributor keys.
+    /// Re-verify every stored certificate against the scheme and contributor keys.
     ///
-    /// This type should normally be impossible to construct in an invalid state through the API,
-    /// but since it supports serialization, this method allows validating instances that have been
-    /// deserialized or received from untrusted sources.
+    /// `CertifiedKeygen` can only be constructed via [`Certifier::finish`], which
+    /// verifies each certificate as it is received, so this method is a sanity check
+    /// rather than a safety gate.
     pub fn verify<S>(
         &self,
         cert_scheme: S,

--- a/schnorr_fun/src/frost/chilldkg/certpedpop/certificate.rs
+++ b/schnorr_fun/src/frost/chilldkg/certpedpop/certificate.rs
@@ -87,7 +87,7 @@ impl<Sig> CertifiedKeygen<Sig> {
         S: CertificationScheme<Signature = Sig>,
         Sig: Clone,
     {
-        let mut certifier = Certifier::new(cert_scheme, self.input.clone(), contributor_keys);
+        let mut certifier = Certifier::new(cert_scheme, self.input.clone(), contributor_keys)?;
 
         // Add all certificates to the certifier
         for (key, sig) in &self.certificate {
@@ -290,12 +290,21 @@ pub struct Certifier<S: CertificationScheme> {
 }
 
 impl<S: CertificationScheme> Certifier<S> {
-    /// Create a new certifier that expects certificates from contributors and receivers
+    /// Create a new certifier that expects certificates from contributors and receivers.
+    ///
+    /// Returns [`CertifierError::ContributorCountMismatch`] if the `agg_input` claims
+    /// a different number of contributors than `contributor_keys.len()`.
     pub fn new(
         cert_scheme: S,
         agg_input: encpedpop::AggKeygenInput,
         contributor_keys: &[Point],
-    ) -> Self {
+    ) -> Result<Self, CertifierError> {
+        if agg_input.n_encryption_nonces() != contributor_keys.len()
+            || agg_input.inner().n_contributors() != contributor_keys.len()
+        {
+            return Err(CertifierError::ContributorCountMismatch);
+        }
+
         // Collect all expected keys - deduplicate since some parties may be both contributors and receivers
         let mut required_keys = BTreeSet::new();
 
@@ -309,12 +318,12 @@ impl<S: CertificationScheme> Certifier<S> {
             required_keys.insert(encryption_key);
         }
 
-        Self {
+        Ok(Self {
             cert_scheme,
             agg_input,
             required_keys,
             certificates: BTreeMap::new(),
-        }
+        })
     }
 
     /// Receive and validate a certificate from a party
@@ -398,6 +407,9 @@ pub enum CertifierError {
     InvalidSignature,
     /// Not all required certificates have been received
     IncompleteCertificates,
+    /// The aggregated keygen input has a different number of contributors than
+    /// the provided `contributor_keys` list.
+    ContributorCountMismatch,
 }
 
 #[cfg(feature = "std")]
@@ -409,6 +421,10 @@ impl core::fmt::Display for CertifierError {
             CertifierError::UnknownParty => write!(f, "Certificate from unknown party"),
             CertifierError::InvalidSignature => write!(f, "Invalid certificate signature"),
             CertifierError::IncompleteCertificates => write!(f, "Not all certificates received"),
+            CertifierError::ContributorCountMismatch => write!(
+                f,
+                "aggregated input has a different number of contributors than expected"
+            ),
         }
     }
 }

--- a/schnorr_fun/src/frost/chilldkg/certpedpop/certificate.rs
+++ b/schnorr_fun/src/frost/chilldkg/certpedpop/certificate.rs
@@ -110,17 +110,17 @@ impl<Sig> CertifiedKeygen<Sig> {
         cert_scheme: &S,
         share_index: ShareIndex,
         keypair: KeyPair,
-    ) -> Result<PairedSecretShare, &'static str> {
+    ) -> Result<PairedSecretShare, RecoverShareError> {
         let cert_key = keypair.public_key();
         let my_cert = self
             .certificate
             .get(&cert_key)
-            .ok_or("I haven't certified this keygen")?;
+            .ok_or(RecoverShareError::NotCertifiedByKey)?;
         // We may have gotten this certificate from *somewhere* so must verify we certified it
         if !cert_scheme.verify_cert(cert_key, &self.input, my_cert) {
-            return Err("my certification was invalid");
+            return Err(RecoverShareError::InvalidCertification);
         }
-        self.input.recover_share::<H>(share_index, &keypair)
+        Ok(self.input.recover_share::<H>(share_index, &keypair)?)
     }
 
     /// Gets the aggregated keygen input.
@@ -394,8 +394,6 @@ impl<S: CertificationScheme> Certifier<S> {
 pub enum CertifierError {
     /// Party is not in the expected keyset
     UnknownParty,
-    /// Certificate already received from this party
-    DuplicateCertificate,
     /// Certificate signature is invalid
     InvalidSignature,
     /// Not all required certificates have been received
@@ -409,12 +407,45 @@ impl core::fmt::Display for CertifierError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             CertifierError::UnknownParty => write!(f, "Certificate from unknown party"),
-            CertifierError::DuplicateCertificate => write!(f, "Duplicate certificate"),
             CertifierError::InvalidSignature => write!(f, "Invalid certificate signature"),
             CertifierError::IncompleteCertificates => write!(f, "Not all certificates received"),
         }
     }
 }
+
+/// Reasons [`CertifiedKeygen::recover_share`] may fail.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RecoverShareError {
+    /// The supplied keypair didn't sign a certificate for this keygen.
+    NotCertifiedByKey,
+    /// The certificate stored for this key doesn't verify under the scheme.
+    InvalidCertification,
+    /// Underlying share recovery from the encrypted aggregate failed.
+    Recovery(encpedpop::RecoverShareError),
+}
+
+impl From<encpedpop::RecoverShareError> for RecoverShareError {
+    fn from(err: encpedpop::RecoverShareError) -> Self {
+        RecoverShareError::Recovery(err)
+    }
+}
+
+impl core::fmt::Display for RecoverShareError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            RecoverShareError::NotCertifiedByKey => {
+                write!(f, "this keypair has not certified the keygen")
+            }
+            RecoverShareError::InvalidCertification => {
+                write!(f, "our stored certificate did not verify")
+            }
+            RecoverShareError::Recovery(err) => write!(f, "{err}"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for RecoverShareError {}
 
 #[cfg(test)]
 mod test {

--- a/schnorr_fun/src/frost/chilldkg/certpedpop/certificate.rs
+++ b/schnorr_fun/src/frost/chilldkg/certpedpop/certificate.rs
@@ -326,28 +326,21 @@ impl<S: CertificationScheme> Certifier<S> {
         })
     }
 
-    /// Receive and validate a certificate from a party
+    /// Receive and validate a certificate from a party.
+    ///
+    /// Always verifies the supplied signature. Calling this more than once for
+    /// the same `from` is idempotent — any signature that fails to verify is
+    /// rejected, and a verified signature that arrives after a previously
+    /// stored one is simply discarded (the first stored signature wins).
     pub fn receive_certificate(
         &mut self,
         from: Point,
         signature: S::Signature,
     ) -> Result<(), CertifierError> {
-        // Check if we're expecting this party
         if !self.required_keys.contains(&from) {
             return Err(CertifierError::UnknownParty);
         }
 
-        // Check for duplicate - if we already have a cert from this key, it must be identical
-        if let Some(existing_sig) = self.certificates.get(&from) {
-            debug_assert_eq!(
-                existing_sig, &signature,
-                "Conflicting certificates from same party"
-            );
-            // Same signature, this is fine - party is certifying multiple times with same key
-            return Ok(());
-        }
-
-        // Verify the certificate
         if !self
             .cert_scheme
             .verify_cert(from, &self.agg_input, &signature)
@@ -355,8 +348,7 @@ impl<S: CertificationScheme> Certifier<S> {
             return Err(CertifierError::InvalidSignature);
         }
 
-        // Store the validated certificate
-        self.certificates.insert(from, signature);
+        self.certificates.entry(from).or_insert(signature);
 
         Ok(())
     }

--- a/schnorr_fun/src/frost/chilldkg/certpedpop/certificate.rs
+++ b/schnorr_fun/src/frost/chilldkg/certpedpop/certificate.rs
@@ -147,6 +147,13 @@ pub enum CertificateError {
         /// They key whose cert was missing
         key: Point,
     },
+    /// The supplied certificate map contained an entry for a key that isn't an
+    /// expected certifying party. Unverified entries would otherwise pollute
+    /// downstream consumers (e.g. the VRF beacon).
+    Unexpected {
+        /// One of the unexpected keys in the supplied map.
+        key: Point,
+    },
 }
 
 impl core::fmt::Display for CertificateError {
@@ -157,6 +164,12 @@ impl core::fmt::Display for CertificateError {
             }
             CertificateError::Missing { key } => {
                 write!(f, "certificate for key {key} was missing")
+            }
+            CertificateError::Unexpected { key } => {
+                write!(
+                    f,
+                    "certificate map contained unexpected entry for key {key}"
+                )
             }
         }
     }

--- a/schnorr_fun/src/frost/chilldkg/encpedpop.rs
+++ b/schnorr_fun/src/frost/chilldkg/encpedpop.rs
@@ -108,7 +108,11 @@ impl Contributor {
         // for completeness.
         let my_index = self.inner.contributor_index();
         let expected = self.my_nonce;
-        let got = agg_keygen_input.encryption_nonces[my_index as usize];
+        let got = agg_keygen_input
+            .encryption_nonces
+            .get(my_index as usize)
+            .copied()
+            .ok_or(simplepedpop::ContributionDidntMatch)?;
         if got != expected {
             return Err(simplepedpop::ContributionDidntMatch);
         }

--- a/schnorr_fun/src/frost/chilldkg/encpedpop.rs
+++ b/schnorr_fun/src/frost/chilldkg/encpedpop.rs
@@ -175,14 +175,14 @@ impl AggKeygenInput {
         &self,
         share_index: ShareIndex,
         keypair: &KeyPair,
-    ) -> Result<PairedSecretShare, &'static str> {
+    ) -> Result<PairedSecretShare, RecoverShareError> {
         let (expected_public_key, agg_ciphertext) = self
             .encrypted_shares
             .get(&share_index)
-            .ok_or("No party at party_index existed")?;
+            .ok_or(RecoverShareError::UnknownShareIndex)?;
 
         if *expected_public_key != keypair.public_key() {
-            return Err("this isn't the right encryption keypair for this share");
+            return Err(RecoverShareError::WrongEncryptionKey);
         }
         let secret_share = decrypt::<H>(
             share_index,
@@ -197,11 +197,11 @@ impl AggKeygenInput {
                 index: share_index,
                 share: secret_share,
             })
-            .ok_or("the secret share recovered didn't match what was expected")?;
+            .ok_or(RecoverShareError::InvalidShare)?;
 
         paired_secret_share
             .non_zero()
-            .ok_or("the shared secret was zero")
+            .ok_or(RecoverShareError::ZeroSharedSecret)
     }
 
     /// Embeds a proof-of-work `fingerprint` into the aggregated polynomial.
@@ -307,21 +307,21 @@ impl Coordinator {
         schnorr: &Schnorr<H, NG>,
         from: u32,
         input: KeygenInput,
-    ) -> Result<(), &'static str> {
+    ) -> Result<(), AddInputError> {
         if self.inner.is_finished() {
-            return Err("all inputs have already been collected");
+            return Err(AddInputError::AlreadyFinished);
         }
         let mut check_missing = self.agg_encrypted_shares.keys().collect::<BTreeSet<_>>();
 
         for dest in input.encrypted_shares.keys() {
             if !self.agg_encrypted_shares.contains_key(dest) {
-                return Err("included share for unknown party");
+                return Err(AddInputError::UnknownShareReceiver { receiver: *dest });
             }
             check_missing.remove(dest);
         }
 
         if !check_missing.is_empty() {
-            return Err("didn't have share for all parties");
+            return Err(AddInputError::IncompleteShares);
         }
 
         // ⚠ only do mutations after we're sure everything is OK
@@ -496,6 +496,83 @@ where
     let shared_key = agg_input.shared_key().non_zero().unwrap();
     (shared_key, paired_secret_shares)
 }
+
+/// Reasons [`Coordinator::add_input`] may reject a contributor's input.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AddInputError {
+    /// All contributor inputs have already been collected.
+    AlreadyFinished,
+    /// Input contains a share encrypted for a receiver not in the configured set.
+    UnknownShareReceiver {
+        /// The share index that wasn't in the configured receiver set.
+        receiver: ShareIndex,
+    },
+    /// Input is missing shares for some configured receivers.
+    IncompleteShares,
+    /// The underlying simplepedpop `add_input` failed.
+    Inner(simplepedpop::AddInputError),
+}
+
+impl From<simplepedpop::AddInputError> for AddInputError {
+    fn from(err: simplepedpop::AddInputError) -> Self {
+        AddInputError::Inner(err)
+    }
+}
+
+impl core::fmt::Display for AddInputError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            AddInputError::AlreadyFinished => {
+                write!(f, "all contributor inputs have already been collected")
+            }
+            AddInputError::UnknownShareReceiver { receiver } => {
+                write!(f, "input included share for unknown receiver {receiver}")
+            }
+            AddInputError::IncompleteShares => {
+                write!(f, "input did not have a share for all receivers")
+            }
+            AddInputError::Inner(err) => write!(f, "{err}"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for AddInputError {}
+
+/// Reasons [`AggKeygenInput::recover_share`] may fail.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RecoverShareError {
+    /// No encrypted share exists at the given index.
+    UnknownShareIndex,
+    /// The supplied keypair isn't the encryption key registered for this share.
+    WrongEncryptionKey,
+    /// The decrypted share didn't pair with the shared key.
+    InvalidShare,
+    /// The resulting shared secret was zero.
+    ZeroSharedSecret,
+}
+
+impl core::fmt::Display for RecoverShareError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            RecoverShareError::UnknownShareIndex => {
+                write!(f, "no share exists at the requested index")
+            }
+            RecoverShareError::WrongEncryptionKey => {
+                write!(f, "keypair is not the encryption key for this share")
+            }
+            RecoverShareError::InvalidShare => {
+                write!(f, "recovered secret share did not match the shared key")
+            }
+            RecoverShareError::ZeroSharedSecret => {
+                write!(f, "recovered shared secret was zero")
+            }
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for RecoverShareError {}
 
 #[cfg(test)]
 mod test {

--- a/schnorr_fun/src/frost/chilldkg/encpedpop.rs
+++ b/schnorr_fun/src/frost/chilldkg/encpedpop.rs
@@ -397,16 +397,18 @@ pub fn receive_secret_share<H, NG>(
 where
     H: Hash32,
 {
-    let encrypted_share = agg_input
+    let (expected_encryption_key, encrypted_share) = agg_input
         .encrypted_shares
         .get(&my_index)
-        .map(|(_pk, share)| *share)
-        .unwrap_or_default();
+        .ok_or(simplepedpop::ReceiveShareError::UnknownShareIndex)?;
+    if *expected_encryption_key != keypair.public_key() {
+        return Err(simplepedpop::ReceiveShareError::WrongEncryptionKey);
+    }
     let share_scalar = decrypt::<H>(
         my_index,
         keypair,
         &agg_input.encryption_nonces,
-        encrypted_share,
+        *encrypted_share,
     );
     let secret_share = SecretShare {
         index: my_index,

--- a/schnorr_fun/src/frost/chilldkg/encpedpop.rs
+++ b/schnorr_fun/src/frost/chilldkg/encpedpop.rs
@@ -48,6 +48,7 @@ impl Contributor {
     pub fn gen_keygen_input<H, NG>(
         schnorr: &Schnorr<H, NG>,
         threshold: u32,
+        n_contributors: u32,
         receiver_encryption_keys: &BTreeMap<ShareIndex, Point>,
         my_index: u32,
         rng: &mut impl rand_core::RngCore,
@@ -63,6 +64,7 @@ impl Contributor {
             simplepedpop::Contributor::gen_keygen_input(
                 schnorr,
                 threshold,
+                n_contributors,
                 &share_receivers,
                 my_index,
                 rng,
@@ -103,6 +105,9 @@ impl Contributor {
         self,
         agg_keygen_input: &AggKeygenInput,
     ) -> Result<(), simplepedpop::ContributionDidntMatch> {
+        if agg_keygen_input.encryption_nonces.len() != self.inner.n_contributors() as usize {
+            return Err(simplepedpop::ContributionDidntMatch);
+        }
         // check the encryption nonce we provided was still in the
         // AggKeygenInput. This may not be necessary for security but we do it
         // for completeness.
@@ -118,6 +123,11 @@ impl Contributor {
         }
         self.inner.verify_agg_input(&agg_keygen_input.inner)?;
         Ok(())
+    }
+
+    /// Get the number of contributors this contributor was configured for.
+    pub fn n_contributors(&self) -> u32 {
+        self.inner.n_contributors()
     }
 }
 
@@ -136,6 +146,16 @@ pub struct AggKeygenInput {
 }
 
 impl AggKeygenInput {
+    /// The inner simplepedpop aggregated input.
+    pub fn inner(&self) -> &simplepedpop::AggKeygenInput {
+        &self.inner
+    }
+
+    /// The number of encryption nonces in this aggregated input (one per contributor).
+    pub fn n_encryption_nonces(&self) -> usize {
+        self.encryption_nonces.len()
+    }
+
     /// Gets the `SharedKey` that this aggregated input produces.
     ///
     /// ## Security
@@ -443,7 +463,7 @@ pub fn simulate_keygen<H, NG>(
     schnorr: &Schnorr<H, NG>,
     threshold: u32,
     n_receivers: u32,
-    n_generators: u32,
+    n_contributors: u32,
     fingerprint: Fingerprint,
     rng: &mut impl rand_core::RngCore,
 ) -> (SharedKey<Normal>, Vec<PairedSecretShare<Normal>>)
@@ -467,13 +487,20 @@ where
         .collect::<BTreeMap<ShareIndex, Point>>();
 
     let (contributors, to_coordinator_messages): (Vec<Contributor>, Vec<KeygenInput>) = (0
-        ..n_generators)
+        ..n_contributors)
         .map(|i| {
-            Contributor::gen_keygen_input(schnorr, threshold, &public_receiver_enckeys, i, rng)
+            Contributor::gen_keygen_input(
+                schnorr,
+                threshold,
+                n_contributors,
+                &public_receiver_enckeys,
+                i,
+                rng,
+            )
         })
         .unzip();
 
-    let mut aggregator = Coordinator::new(threshold, n_generators, &public_receiver_enckeys);
+    let mut aggregator = Coordinator::new(threshold, n_contributors, &public_receiver_enckeys);
 
     for (i, to_coordinator_message) in to_coordinator_messages.into_iter().enumerate() {
         aggregator
@@ -596,7 +623,7 @@ mod test {
         #[test]
         fn encpedpop_run_simulate_keygen(
             (n_receivers, threshold) in (1u32..=4).prop_flat_map(|n| (Just(n), 1u32..=n)),
-            n_generators in 1u32..5,
+            n_contributors in 1u32..5,
         ) {
             let schnorr = crate::new_with_deterministic_nonces::<sha2::Sha256>();
             let mut rng = TestRng::deterministic_rng(RngAlgorithm::ChaCha);
@@ -605,7 +632,7 @@ mod test {
                 &schnorr,
                 threshold,
                 n_receivers,
-                n_generators,
+                n_contributors,
                 Fingerprint::NONE,
                 &mut rng,
             );
@@ -614,7 +641,7 @@ mod test {
         #[test]
         fn encpedpop_simulate_keygen_with_fingerprint(
             (n_receivers, threshold) in (2u32..=4).prop_flat_map(|n| (Just(n), 2u32..=n)),
-            n_generators in 1u32..5,
+            n_contributors in 1u32..5,
             (bits_per_coeff, max_bits_total) in (0u8..10).prop_flat_map(|per_coeff| {
                 // max_bits_total should be at least max_bits_per_coeff but can be larger
                 (Just(per_coeff), per_coeff..25)
@@ -633,7 +660,7 @@ mod test {
                 &schnorr,
                 threshold,
                 n_receivers,
-                n_generators,
+                n_contributors,
                 fingerprint,
                 &mut rng,
             );
@@ -666,7 +693,14 @@ mod test {
         // Create contributors with indices 0, 1, 2
         let contributors_and_inputs: Vec<_> = (0..3)
             .map(|i| {
-                Contributor::gen_keygen_input(&schnorr, threshold, &receiver_enckeys, i, &mut rng)
+                Contributor::gen_keygen_input(
+                    &schnorr,
+                    threshold,
+                    3,
+                    &receiver_enckeys,
+                    i,
+                    &mut rng,
+                )
             })
             .collect();
 

--- a/schnorr_fun/src/frost/chilldkg/simplepedpop.rs
+++ b/schnorr_fun/src/frost/chilldkg/simplepedpop.rs
@@ -15,7 +15,7 @@ use alloc::{
 use core::num::NonZeroU32;
 use secp256kfun::{KeyPair, hash::Hash32, nonce::NonceGen, poly, prelude::*, rand_core};
 
-const POP_DOMAIN_SEP: &str = "BIP DKG/pop";
+const POP_DOMAIN_SEP: &str = "BIP DKG/pop message";
 
 /// A party that generates secret input to the key generation. You need at least one of these
 /// and if at least one of these parties is honest then the final secret key will not be known by an

--- a/schnorr_fun/src/frost/chilldkg/simplepedpop.rs
+++ b/schnorr_fun/src/frost/chilldkg/simplepedpop.rs
@@ -48,6 +48,7 @@ impl Contributor {
         H: Hash32,
         NG: NonceGen,
     {
+        assert!(threshold > 0);
         let secret_poly = poly::scalar::generate(threshold as usize, rng);
         let pop_keypair = KeyPair::new_xonly(secret_poly[0]);
         // XXX The thing that's signed differs from the spec

--- a/schnorr_fun/src/frost/chilldkg/simplepedpop.rs
+++ b/schnorr_fun/src/frost/chilldkg/simplepedpop.rs
@@ -143,21 +143,24 @@ impl Coordinator {
         schnorr: &Schnorr<H, NG>,
         from: u32,
         input: KeygenInput,
-    ) -> Result<(), &'static str> {
+    ) -> Result<(), AddInputError> {
         let entry = match self.inputs.get_mut(&from) {
             Some(maybe_input) => match maybe_input {
-                Some(_) => return Err("we already have input from this party"),
+                Some(_) => return Err(AddInputError::DuplicateInput { from }),
                 none => none,
             },
-            None => return Err("no input expected from this party"),
+            None => return Err(AddInputError::UnknownContributor { from }),
         };
         if input.com.len() != self.threshold as usize {
-            return Err("input has the wrong threshold");
+            return Err(AddInputError::WrongThreshold {
+                expected: self.threshold,
+                got: input.com.len() as u32,
+            });
         }
 
         let (first_coeff_even_y, _) = input.com[0].into_point_with_even_y();
         if !schnorr.verify(&first_coeff_even_y, Message::empty(), &input.pop) {
-            return Err("☠ pop didn't verify");
+            return Err(AddInputError::InvalidProofOfPossession);
         }
         *entry = Some(input);
 
@@ -401,6 +404,53 @@ impl core::fmt::Display for ReceiveShareError {
         )
     }
 }
+
+/// Reasons [`Coordinator::add_input`] may reject a contributor's input.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AddInputError {
+    /// Input from this contributor has already been recorded.
+    DuplicateInput {
+        /// The contributor index that already has an input recorded.
+        from: u32,
+    },
+    /// No contributor is expected at this index.
+    UnknownContributor {
+        /// The unexpected contributor index.
+        from: u32,
+    },
+    /// Polynomial commitment length doesn't match the configured threshold.
+    WrongThreshold {
+        /// The threshold the coordinator was configured with.
+        expected: u32,
+        /// The number of coefficients we actually received.
+        got: u32,
+    },
+    /// Proof-of-possession signature failed to verify.
+    InvalidProofOfPossession,
+}
+
+impl core::fmt::Display for AddInputError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            AddInputError::DuplicateInput { from } => {
+                write!(f, "already have input from contributor {from}")
+            }
+            AddInputError::UnknownContributor { from } => {
+                write!(f, "no input expected from contributor {from}")
+            }
+            AddInputError::WrongThreshold { expected, got } => write!(
+                f,
+                "input polynomial has {got} coefficients but threshold is {expected}"
+            ),
+            AddInputError::InvalidProofOfPossession => {
+                write!(f, "proof-of-possession signature did not verify")
+            }
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for AddInputError {}
 
 #[cfg(test)]
 mod test {

--- a/schnorr_fun/src/frost/chilldkg/simplepedpop.rs
+++ b/schnorr_fun/src/frost/chilldkg/simplepedpop.rs
@@ -28,6 +28,7 @@ use secp256kfun::{KeyPair, hash::Hash32, nonce::NonceGen, poly, prelude::*, rand
 pub struct Contributor {
     my_key_contrib: Point,
     my_index: u32,
+    n_contributors: u32,
 }
 
 impl Contributor {
@@ -40,6 +41,7 @@ impl Contributor {
     pub fn gen_keygen_input<H, NG>(
         schnorr: &Schnorr<H, NG>,
         threshold: u32,
+        n_contributors: u32,
         share_receivers: &BTreeSet<ShareIndex>,
         my_index: u32,
         rng: &mut impl rand_core::RngCore,
@@ -49,6 +51,7 @@ impl Contributor {
         NG: NonceGen,
     {
         assert!(threshold > 0);
+        assert!(my_index < n_contributors);
         let secret_poly = poly::scalar::generate(threshold as usize, rng);
         let pop_keypair = KeyPair::new_xonly(secret_poly[0]);
         // XXX The thing that's signed differs from the spec
@@ -62,6 +65,7 @@ impl Contributor {
         let self_ = Self {
             my_key_contrib: com[0],
             my_index,
+            n_contributors,
         };
         let msg = KeygenInput { com, pop };
         (self_, msg, shares)
@@ -77,6 +81,9 @@ impl Contributor {
         self,
         agg_input: &AggKeygenInput,
     ) -> Result<(), ContributionDidntMatch> {
+        if agg_input.key_contrib.len() != self.n_contributors as usize {
+            return Err(ContributionDidntMatch);
+        }
         let my_got_contrib = agg_input
             .key_contrib
             .get(self.my_index as usize)
@@ -92,6 +99,11 @@ impl Contributor {
     /// Get the index for the contributor
     pub fn contributor_index(&self) -> u32 {
         self.my_index
+    }
+
+    /// Get the number of contributors this contributor was configured for.
+    pub fn n_contributors(&self) -> u32 {
+        self.n_contributors
     }
 }
 
@@ -235,6 +247,11 @@ pub struct AggKeygenInput {
 }
 
 impl AggKeygenInput {
+    /// The number of contributors whose key contributions are aggregated into this input.
+    pub fn n_contributors(&self) -> usize {
+        self.key_contrib.len()
+    }
+
     /// Gets the `SharedKey` that this aggregated input produces.
     ///
     /// ## Security
@@ -322,7 +339,7 @@ pub fn simulate_keygen<H, NG>(
     schnorr: &Schnorr<H, NG>,
     threshold: u32,
     n_receivers: u32,
-    n_generators: u32,
+    n_contributors: u32,
     rng: &mut impl rand_core::RngCore,
 ) -> (SharedKey<Normal>, Vec<PairedSecretShare<Normal>>)
 where
@@ -333,13 +350,19 @@ where
         .map(|i| ShareIndex::from(NonZeroU32::new(i).unwrap()))
         .collect::<BTreeSet<_>>();
 
-    let mut aggregator = Coordinator::new(threshold, n_generators);
+    let mut aggregator = Coordinator::new(threshold, n_contributors);
     let mut contributors = vec![];
     let mut secret_inputs = BTreeMap::<ShareIndex, Vec<Scalar<Secret, Zero>>>::default();
 
-    for i in 0..n_generators {
-        let (contributor, to_coordinator, shares) =
-            Contributor::gen_keygen_input(schnorr, threshold, &share_receivers, i, rng);
+    for i in 0..n_contributors {
+        let (contributor, to_coordinator, shares) = Contributor::gen_keygen_input(
+            schnorr,
+            threshold,
+            n_contributors,
+            &share_receivers,
+            i,
+            rng,
+        );
 
         contributors.push(contributor);
         aggregator.add_input(schnorr, i, to_coordinator).unwrap();
@@ -467,12 +490,12 @@ mod test {
         #[test]
         fn simplepedpop_run_simulate_keygen(
             (n_receivers, threshold) in (1u32..=4).prop_flat_map(|n| (Just(n), 1u32..=n)),
-            n_generators in 1u32..5,
+            n_contributors in 1u32..5,
         ) {
             let schnorr = crate::new_with_deterministic_nonces::<sha2::Sha256>();
             let mut rng = TestRng::deterministic_rng(RngAlgorithm::ChaCha);
 
-            simplepedpop::simulate_keygen(&schnorr, threshold, n_receivers, n_generators, &mut rng);
+            simplepedpop::simulate_keygen(&schnorr, threshold, n_receivers, n_contributors, &mut rng);
         }
     }
 }

--- a/schnorr_fun/src/frost/chilldkg/simplepedpop.rs
+++ b/schnorr_fun/src/frost/chilldkg/simplepedpop.rs
@@ -15,6 +15,8 @@ use alloc::{
 use core::num::NonZeroU32;
 use secp256kfun::{KeyPair, hash::Hash32, nonce::NonceGen, poly, prelude::*, rand_core};
 
+const POP_DOMAIN_SEP: &str = "BIP DKG/pop";
+
 /// A party that generates secret input to the key generation. You need at least one of these
 /// and if at least one of these parties is honest then the final secret key will not be known by an
 /// attacker (unless they obtain `t` shares!).
@@ -53,10 +55,12 @@ impl Contributor {
         assert!(threshold > 0);
         assert!(my_index < n_contributors);
         let secret_poly = poly::scalar::generate(threshold as usize, rng);
-        let pop_keypair = KeyPair::new_xonly(secret_poly[0]);
-        // XXX The thing that's signed differs from the spec
-        let pop = schnorr.sign(&pop_keypair, Message::empty());
         let com = poly::scalar::to_point_poly(&secret_poly);
+        let pop_keypair = KeyPair::new_xonly(secret_poly[0]);
+        let pop = schnorr.sign(
+            &pop_keypair,
+            Message::new(POP_DOMAIN_SEP, &pop_message_bytes(com[0], my_index)),
+        );
 
         let shares = share_receivers
             .iter()
@@ -172,7 +176,11 @@ impl Coordinator {
         }
 
         let (first_coeff_even_y, _) = input.com[0].into_point_with_even_y();
-        if !schnorr.verify(&first_coeff_even_y, Message::empty(), &input.pop) {
+        if !schnorr.verify(
+            &first_coeff_even_y,
+            Message::new(POP_DOMAIN_SEP, &pop_message_bytes(input.com[0], from)),
+            &input.pop,
+        ) {
             return Err(AddInputError::InvalidProofOfPossession);
         }
         *entry = Some(input);
@@ -299,9 +307,13 @@ pub fn receive_secret_share<H, NG>(
 where
     H: Hash32,
 {
-    for (key_contrib, pop) in &agg_input.key_contrib {
+    for (i, (key_contrib, pop)) in agg_input.key_contrib.iter().enumerate() {
         let (first_coeff_even_y, _) = key_contrib.into_point_with_even_y();
-        if !schnorr.verify(&first_coeff_even_y, Message::empty(), pop) {
+        if !schnorr.verify(
+            &first_coeff_even_y,
+            Message::new(POP_DOMAIN_SEP, &pop_message_bytes(*key_contrib, i as u32)),
+            pop,
+        ) {
             return Err(ReceiveShareError::InvalidPop);
         }
     }
@@ -476,8 +488,24 @@ impl core::fmt::Display for AddInputError {
 #[cfg(feature = "std")]
 impl std::error::Error for AddInputError {}
 
+/// Build the bytes that the proof-of-possession signs.
+///
+/// Binding format is `parity_byte || contributor_index_be`, where `parity_byte`
+/// is `0` if `com[0]` has even y and `1` otherwise. Including the parity closes
+/// the BIP340 x-only gap: a replay of `(A, pop)` under the negated key `-A`
+/// reconstructs a different message and so fails PoP verification.
+///
+/// SPEC DEVIATION: we add the parity byte where as the spec only has the contribution_index.
+fn pop_message_bytes(first_coeff: Point, contributor_index: u32) -> [u8; 5] {
+    let mut bytes = [0u8; 5];
+    bytes[0] = u8::from(!first_coeff.is_y_even());
+    bytes[1..].copy_from_slice(&contributor_index.to_be_bytes());
+    bytes
+}
+
 #[cfg(test)]
 mod test {
+    use super::*;
     use crate::frost::chilldkg::simplepedpop;
 
     use proptest::{
@@ -497,5 +525,56 @@ mod test {
 
             simplepedpop::simulate_keygen(&schnorr, threshold, n_receivers, n_contributors, &mut rng);
         }
+    }
+
+    // The PoP must bind both the slot index and the y-parity of com[0]:
+    //   (1) Alice's pop for slot 0 must not verify at another slot.
+    //   (2) A replay of Alice's pop with the negated first coefficient (-A) must
+    //       not verify at any slot, including slot 0.
+    #[test]
+    fn pop_bound_to_slot_and_parity_rejects_replay() {
+        let schnorr = crate::new_with_deterministic_nonces::<sha2::Sha256>();
+        let mut rng = TestRng::deterministic_rng(RngAlgorithm::ChaCha);
+        let threshold = 2u32;
+        let n_contributors = 2u32;
+        let share_receivers: BTreeSet<ShareIndex> = [ShareIndex::from(NonZeroU32::new(1).unwrap())]
+            .into_iter()
+            .collect();
+
+        let (_alice_state, alice_msg, _alice_shares) = simplepedpop::Contributor::gen_keygen_input(
+            &schnorr,
+            threshold,
+            n_contributors,
+            &share_receivers,
+            0,
+            &mut rng,
+        );
+
+        let mut coord_replay_slot = simplepedpop::Coordinator::new(threshold, n_contributors);
+        assert_eq!(
+            coord_replay_slot.add_input(&schnorr, 1, alice_msg.clone()),
+            Err(AddInputError::InvalidProofOfPossession),
+            "Alice's pop for slot 0 must not verify at slot 1"
+        );
+
+        let negated_msg = KeygenInput {
+            com: core::iter::once(-alice_msg.com[0])
+                .chain(alice_msg.com[1..].iter().copied())
+                .collect(),
+            pop: alice_msg.pop,
+        };
+        let mut coord_negate_same_slot = simplepedpop::Coordinator::new(threshold, n_contributors);
+        assert_eq!(
+            coord_negate_same_slot.add_input(&schnorr, 0, negated_msg.clone()),
+            Err(AddInputError::InvalidProofOfPossession),
+            "negated-key replay at the original slot must now be rejected by the PoP check"
+        );
+
+        let mut coord_negate_other_slot = simplepedpop::Coordinator::new(threshold, n_contributors);
+        assert_eq!(
+            coord_negate_other_slot.add_input(&schnorr, 1, negated_msg),
+            Err(AddInputError::InvalidProofOfPossession),
+            "negated-key replay at a different slot must be rejected by the PoP check"
+        );
     }
 }

--- a/schnorr_fun/src/frost/chilldkg/simplepedpop.rs
+++ b/schnorr_fun/src/frost/chilldkg/simplepedpop.rs
@@ -425,6 +425,10 @@ pub enum ReceiveShareError {
     InvalidPop,
     /// The secret share we got was invalid
     InvalidSecretShare,
+    /// No encrypted share exists at the receiver's share index.
+    UnknownShareIndex,
+    /// The supplied keypair isn't the encryption key registered for this share.
+    WrongEncryptionKey,
 }
 
 impl core::fmt::Display for ReceiveShareError {
@@ -436,6 +440,10 @@ impl core::fmt::Display for ReceiveShareError {
                 ReceiveShareError::InvalidPop => "Invalid POP for one of the contributions",
                 ReceiveShareError::InvalidSecretShare =>
                     "The share extracted from the key generation was invalid",
+                ReceiveShareError::UnknownShareIndex =>
+                    "no encrypted share exists at the requested share index",
+                ReceiveShareError::WrongEncryptionKey =>
+                    "keypair is not the encryption key registered for this share",
             }
         )
     }

--- a/schnorr_fun/src/frost/shared_key.rs
+++ b/schnorr_fun/src/frost/shared_key.rs
@@ -159,6 +159,9 @@ impl<T: Normalized, Z: ZeroChoice> SharedKey<T, Z> {
     /// Returns `None` if the bytes don't represent points or if the first coefficient doesn't
     /// satisfy the constraints of `T` and `Z`.
     pub fn from_slice(bytes: &[u8]) -> Option<Self> {
+        if bytes.is_empty() {
+            return None;
+        }
         let mut poly = vec![];
         for point_bytes in bytes.chunks(33) {
             poly.push(Point::from_slice(point_bytes)?);
@@ -426,7 +429,11 @@ impl<Context, T: PointType, Z: ZeroChoice> bincode::Decode<Context> for SharedKe
     ) -> Result<Self, secp256kfun::bincode::error::DecodeError> {
         use secp256kfun::bincode::error::DecodeError;
         let poly = Vec::<Point<Normal, Public, Zero>>::decode(decoder)?;
-        let first_coeff = Z::cast_point(poly[0]).ok_or(DecodeError::Other(
+        let first = poly
+            .first()
+            .copied()
+            .ok_or(DecodeError::Other("empty polynomial for shared key"))?;
+        let first_coeff = Z::cast_point(first).ok_or(DecodeError::Other(
             "zero public key for non-zero shared key",
         ))?;
         let _check = T::cast_point(first_coeff)
@@ -447,7 +454,13 @@ impl<'de, T: PointType, Z: ZeroChoice> crate::fun::serde::Deserialize<'de> for S
     {
         let poly = Vec::<Point<Normal, Public, Zero>>::deserialize(deserializer)?;
 
-        let first_coeff = Z::cast_point(poly[0]).ok_or(crate::fun::serde::de::Error::custom(
+        let first = poly
+            .first()
+            .copied()
+            .ok_or(crate::fun::serde::de::Error::custom(
+                "empty polynomial for shared key",
+            ))?;
+        let first_coeff = Z::cast_point(first).ok_or(crate::fun::serde::de::Error::custom(
             "zero public key for non-zero shared key",
         ))?;
 


### PR DESCRIPTION
## Summary

A security review of the `chilldkg` module in `schnorr_fun` (and adjacent code reached from its decoding paths). **No critical vulnerabilities were found.** The issues fall into two buckets:

1. **Decoding panics** — cases where malformed serialized input could crash the process rather than return an error.
2. **Defensive hardening** — places where the protocol was permissive in ways that didn't expose secrets but tolerated unintended behaviour (ghost contributions, x-only PoP replay, silently accepted unverified certs, redundant/confusing parameters, etc.).

Each commit is self-contained and independently reviewable.

## Commit-by-commit

**`b41919d` — Replace &'static str errors in chilldkg with typed error enums**

Introduces `simplepedpop::AddInputError`, `encpedpop::AddInputError`, `encpedpop::RecoverShareError`, `certpedpop::RecoverShareError`. Replaces string-typed `Result<_, &'static str>` returns so callers can discriminate failures programmatically. Drops the unused `CertifierError::DuplicateCertificate` variant.

**`58d90d9` — Fix panics on malformed input in chilldkg and SharedKey decoding**

Three panic paths reachable from untrusted input:

- `encpedpop::Contributor::verify_agg_input` indexed `encryption_nonces[my_index]` directly. A coordinator sending a shorter vec crashed the contributor; now returns `ContributionDidntMatch`.
- `SharedKey::from_slice(&[])` and the `bincode::Decode` / `serde::Deserialize` impls panicked on empty polynomials via `poly[0]`. Now return `None` / a decode error.
- `simplepedpop::Contributor::gen_keygen_input` indexed `secret_poly[0]` when called with `threshold == 0`. Now asserts `threshold > 0` matching `Coordinator::new`.

**`b638920` — Enforce contributor count across chilldkg layers**

A malicious coordinator can craft an `AggKeygenInput` with more key_contrib slots than any honest contributor agreed to (a "ghost" contribution whose secret the coordinator knows). Doesn't compromise secrecy but gives the coordinator extra influence over the public key and breaks the protocol's implicit "every contributor signed off" contract.

- `simplepedpop::Contributor` now stores `n_contributors` at construction and `verify_agg_input` rejects mismatched `key_contrib.len()`.
- `encpedpop::Contributor::verify_agg_input` additionally rejects mismatched `encryption_nonces.len()`.
- `certpedpop::Certifier::new` becomes fallible and rejects an `AggKeygenInput` whose contributor count doesn't match `contributor_keys.len()`, with new variant `CertifierError::ContributorCountMismatch`.

**`4ff15a0` — Bind simplepedpop proof-of-possession to its slot index and parity**

The PoP previously signed the empty message. Concrete replay primitives this allowed:

- `(com, pop)` from one slot replayed at a different slot.
- `(−com, pop)` accepted under BIP340 x-only verification even though the caller intended `com`.

The PoP message is now `parity_byte || idx_be` (5 bytes), carried under the BIP340-style 33-byte domain separator `"BIP DKG/pop"`. Parity binding closes the x-only gap — `(−A, pop_A)` reconstructs a different message and fails verify. This diverges from the bip-frost-dkg Python reference's choice to bind only `idx` via BIP340's `tag_prefix`; we bind more and use the BIP340-recommended message-prefix domain separator. Regression test covers cross-slot replay and negated-key-same-slot replay.

**`21ce300` — Remove serialization from CertifiedKeygen**

The only sound path to a `CertifiedKeygen` is `Certifier::finish`, where every stored certificate was verified as it came in. Deserialization bypassed that and could land attacker-chosen gammas in the struct; `vrf_security_check` would then hand back a beacon value the attacker controlled. Dropping the `bincode::Encode`/`Decode` and serde `Serialize`/`Deserialize` derives on `CertifiedKeygen` eliminates the unverified-state path. Apps that need to persist a certified keygen can serialize `AggKeygenInput` and the certificate map separately and rebuild on the receiving side.

**`b1e1c4e` — Validate share index and encryption key in receive_secret_share**

`encpedpop::receive_secret_share` silently tolerated two malformed inputs: a missing entry in `encrypted_shares` (treated as a zero ciphertext via `unwrap_or_default`) and a caller-supplied keypair that didn't match the registered encryption key. Both surfaced as the generic `InvalidSecretShare`, diverging from the sibling `AggKeygenInput::recover_share` path which already returned `UnknownShareIndex` / `WrongEncryptionKey`. Adds both variants to `ReceiveShareError` and checks them explicitly before decryption.

**`9c34719` — Always verify signatures in Certifier::receive_certificate**

On a duplicate cert (same key already registered), the function returned `Ok` without calling `verify_cert` on the new signature. A `debug_assert_eq!` guarded the "sigs must match" case but vanished in release builds, so a mismatched second signature was silently discarded while the caller believed the cert was validated. For randomized signature / VRF schemes this was the always-taken path. Now every supplied signature is verified; a verified duplicate is idempotent (first stored wins), a failed verification returns `InvalidSignature`.

<details><summary>Conversation History</summary>

**User:** can you check for security issues in chilldkg's implementation in schnorr_fun. I am especially concerned with parties not checking their inputs and included in things.

**Assistant:** (Flagged 7 concerns: panic in encpedpop `verify_agg_input`; ghost contributor injection; `receive_secret_share` keypair validation; PoP not bound to context; Certifier silent duplicate-cert; `vrf_security_check` trusts unverified gammas; same-keypair-for-encryption-and-cert design note.)

**User:** cool fix #1 and then we'll discuss #2.

**User:** actually before moving on to #2 can you search for similar problems especially in decoding implementations that could cause panics.

**Assistant:** (Found `SharedKey::from_slice(&[])` panic, bincode Decode / serde Deserialize empty-poly panics, `gen_keygen_input` threshold=0 panic.)

**User:** Do you think that #2 is a security vulnerability? Can you explain the attack.

**Assistant:** (Ghost injection: count defense missing means malicious coordinator can add slots with known-secret "ghost" contributions. Not a secrecy break but adaptive-bias on the public key; protocol doesn't enforce "N authorized contributors.")

**User:** right but the thing is that in practice the coordinator is always a contributor as well... But I agree it's sort of worth fixing since technically the coordinator role itself is not meant to have that ability.

**User:** why couldn't the attacker just echo back the signature shares contributions of the honest party too (except negated). They are homomorphic.

**Assistant:** (Walked through why the negation attack doesn't close into key compromise: `encpedpop` pads are `H(dh_key, enc_key, dest)` hash outputs, not linearly composable. The attack remains a targeted DoS; encryption-layer non-linearity keeps the downstream damage bounded.)

**User:** Ok can you look up the python referenmce for the FROST chilldkg and see what they throw in the PoP and we can see if we can follow it.

(— bip-frost-dkg signs `idx.to_bytes(4, big)` under tag `"BIP DKG/pop message"`. schnorr_fun uses BIP340 message-prefix domain separation instead of `tag_prefix`. Bound `idx` here.)

**User:** @simplepedpop.rs I feel like [the x-only same-slot replay passing] is not a very desirable behaviour.

(— the test acknowledged that negated-key-same-slot passed PoP and was only caught by `verify_agg_input`'s Point-equality self-check. User wanted the PoP itself to bind parity. Extended the PoP message to `parity_byte || idx_be`.)

**User:** maybe we just shouldn't allow [CertifiedKeygen] to be serialized?

(— chose the simplest fix for `vrf_security_check`'s reliance on unverified gammas: drop the derive.)

**User:** A just drop it [the n_contributors param from receive_secret_share]. When you're receiving a secret share the only thing you care about is it's the correct secret share with respect to the join sharing polynomial.

(— decided `receive_secret_share`'s `n_contributors` parameter was redundant with `agg_input`; receivers' defense against count tampering is the cert round or out-of-band comparison, not a per-receive assertion. Folded into `b638920`.)

**User:** What is the actual security implications of duplicate keys though in general... I am not really interested in adding more errors I am more interested in avoiding them when the protocol could tolerate duplicates.

(— audited for panics / spurious errors on duplicate keys across `Certifier::required_keys`, `certificates`, and related paths; found none; concluded the `BTreeSet` dedup is intentional and benign. No code changes.)

</details>
