### PR TITLE
chilldkg: tighten API and internal representation

### DIFF
--- a/schnorr_fun/src/frost/chilldkg.rs
+++ b/schnorr_fun/src/frost/chilldkg.rs
@@ -14,23 +14,49 @@
 //! - *Contributors*: parties that provide secret input into the key generation
 //! - *Receivers*: parties that receive a secret share from the protocol.
 //!
-//! We see a benefit to having parties that provide secret input but do not receive secret output.
-//! The main example of this is having the coordinator itself be an *Contributor* too. In the context
-//! of a Bitcoin hardware wallet, the coordinator is usually the only party with access to the
-//! internet therefore, if the coordinator contributes input honestly, even if all the non-internet
-//! connected devices are malicious the *remote* adversary (who set the code of the malicious
-//! device) will not know the secret key. In fact, the adversary would have to recover `t` devices
-//! and extract their internal state to reconstruct the key. This is nice, because *in theory* and
-//! in this limited sense it gives the attacker no advantage from controlling the code of the
-//! signing devices (anyone who wants to reconstruct the key already needs `t` shares).
+//! We see a benefit to having parties that provide secret input but do not receive secret output —
+//! we call these *aux contributors* (and the parties that do both *receiver-contributors*; every
+//! receiver is also a contributor by protocol invariant). The main example of an aux contributor
+//! is the coordinator itself. In the context of a Bitcoin hardware wallet, the coordinator is
+//! usually the only party with access to the internet therefore, if the coordinator contributes
+//! input honestly, even if all the non-internet connected devices are malicious the *remote*
+//! adversary (who set the code of the malicious device) will not know the secret key. In fact,
+//! the adversary would have to recover `t` devices and extract their internal state to
+//! reconstruct the key. This is nice, because *in theory* and in this limited sense it gives the
+//! attacker no advantage from controlling the code of the signing devices (anyone who wants to
+//! reconstruct the key already needs `t` shares).
 //!
 //! ## Variants
 //!
-//! The spec comes in three variants:
+//! The spec comes in three variants. Most applications want [`certpedpop`].
 //!
-//! - [`simplepedpop`]: bare bones FROST key generation
-//! - [`encpedpop`]: Adds encryption to the secret input so the coordinator can aggregate encrypted secret shares.
-//! - [`certpedpop`]: `encpedpop` where each party also certifies the output so they can cryptographically convince each other that the key generation was successful.
+//! - [`simplepedpop`]: bare-bones FROST key generation. The application is responsible
+//!   for transporting per-receiver secret shares out-of-band and for confirming all parties
+//!   agree on the result.
+//! - [`encpedpop`]: adds share encryption so the coordinator can aggregate encrypted shares
+//!   into a single message. The application still has to confirm agreement.
+//! - [`certpedpop`]: adds certification, so once the protocol completes every party holds a
+//!   cryptographic proof that everyone else certified the same result.
+//!
+//! ## Lifecycle
+//!
+//! Each layer follows the same pipeline:
+//!
+//! 1. Each contributor calls `Contributor::gen_keygen_input` and sends the resulting
+//!    `KeygenInput` to the coordinator.
+//! 2. The coordinator collects inputs via `Coordinator::add_input`/`finish` and broadcasts
+//!    the resulting `AggKeygenInput` back.
+//! 3. Each contributor calls `verify_agg_input` to obtain a `VerifiedAggKeygenInput`.
+//!    Receivers also extract their secret share at this step. In `certpedpop`, a
+//!    certificate from every party must be collected before the share is released.
+//!
+//! ## Roles
+//!
+//! Use [`ShareReceiver`] (a contributor that also receives a share) or [`AuxContributor`]
+//! (a contributor-only party, e.g. an internet-connected coordinator) as the type
+//! parameter `R` on the layered `Contributor<R>` types. Pick the role with turbofish at
+//! the call site, e.g.
+//! `Contributor::<ShareReceiver>::gen_keygen_input(...)`.
 //!
 //! [ChillDKG]: https://github.com/BlockstreamResearch/bip-frost-dkg
 
@@ -40,3 +66,51 @@ pub mod simplepedpop;
 
 // Re-export CertificationScheme trait from certpedpop
 pub use certpedpop::CertificationScheme;
+
+/// The role a contributor plays in the protocol. Implemented by
+/// [`ShareReceiver`] and [`AuxContributor`]; sealed so no other types can.
+///
+/// Picked via turbofish on `Contributor<R>::gen_keygen_input` at every layer.
+pub trait Role: simplepedpop::role_sealed::Sealed {}
+
+/// A contributor that also receives a secret share. The main case: a participant
+/// (e.g. a hardware wallet) that contributes entropy and gets a share back.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ShareReceiver;
+
+/// A contributor that does not receive a share. The main case: an
+/// internet-connected coordinator that contributes entropy so a remote attacker
+/// who controls every receiver still cannot reconstruct the key without
+/// physical access to `t` devices.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AuxContributor;
+
+impl Role for ShareReceiver {}
+impl Role for AuxContributor {}
+
+/// Identifies a contributor by role-relative index. Use this anywhere the API
+/// asks for a party — the absolute slot translation is the protocol's job.
+///
+/// `Receiver(i)` is the receiver at slot `i` (`i < n_receivers`).
+/// `AuxContributor(i)` is the aux at offset `i` (`i < n_aux_contributors`).
+/// Ordering matches absolute slot order: every `Receiver` precedes every
+/// `AuxContributor`, and within each variant the inner index orders.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Party {
+    /// A share-receiving contributor at receiver-slot `i`.
+    Receiver(u32),
+    /// A contributor-only party at aux-slot `i`.
+    AuxContributor(u32),
+}
+
+impl Party {
+    /// Translate to the absolute slot index in `[0..n_contributors)`. Used
+    /// internally where a positional index is required (PoP signing/verifying,
+    /// indexing into per-slot vectors).
+    pub fn slot_index(self, n_receivers: u32) -> u32 {
+        match self {
+            Party::Receiver(i) => i,
+            Party::AuxContributor(i) => n_receivers + i,
+        }
+    }
+}

--- a/schnorr_fun/src/frost/chilldkg/certpedpop.rs
+++ b/schnorr_fun/src/frost/chilldkg/certpedpop.rs
@@ -1,22 +1,22 @@
 //! `certpedpop` is built on top of [`encpedpop`] to add certification of the outcome.
 //!
-//! In [`encpedpop`] and [`simplepedpop`] it's left up to the application to figure out whether all
-//! the parties agree on the `AggKeygenInput`. In `certpedpop` the relevant methods return
-//! certification signatures on `AggKeygenInput` once they've been validated so they can be
-//! collected by the share receivers. Once the share receivers have got all the certificates they
-//! can finally output the key.
-//!
-//! Certificates are collected from other share receivers as well as `Contributor`s.
+//! At the simplepedpop and encpedpop layers, confirming every party has the same
+//! [`AggKeygenInput`] is the application's problem. `certpedpop` packages it: each
+//! party's verify produces a certificate signature (collected via [`Certifier`])
+//! and a receiver's secret share is withheld in [`SecretShareReceiver`] until every
+//! certificate is in.
 
 pub mod certificate;
 #[cfg(feature = "vrf_cert_keygen")]
 pub use certificate::vrf_cert;
 pub use certificate::{
-    CertificateError, CertificationScheme, CertifiedKeygen, Certifier, CertifierError,
-    RecoverShareError,
+    CertificateError, CertificationScheme, CertifiedKeygen, Certifier, IncompleteCertificates,
+    ReceiveCertError, RecoverShareError,
 };
 
-use super::{encpedpop, simplepedpop};
+use super::encpedpop;
+pub use super::encpedpop::{AggKeygenInput, Coordinator, KeygenInput, ShareReceiverError};
+pub use super::{AuxContributor, Party, Role, ShareReceiver};
 use crate::{Schnorr, frost::*};
 use alloc::{
     collections::{BTreeMap, BTreeSet},
@@ -24,388 +24,431 @@ use alloc::{
 };
 use secp256kfun::{KeyPair, hash::Hash32, nonce::NonceGen, prelude::*, rand_core};
 
-/// Produced by [`Contributor::gen_keygen_input`]. This is sent from the each
-/// `Contributor` to the *coordinator*.
-pub type KeygenInput = encpedpop::KeygenInput;
-/// Key generation inputs after being aggregated by the coordinator
-pub type AggKeygenInput = encpedpop::AggKeygenInput;
-
-pub use encpedpop::Coordinator;
-
-/// A party that generates secret input to the key generation. You need at least one of these
-/// and if at least one of these parties is honest then the final secret key will not be known by an
-/// attacker (unless they obtain `t` shares!).
+/// One party's protocol state for a `certpedpop` keygen. Construct with
+/// [`gen_keygen_input`] and consume with `verify_agg_input` (the role-typed
+/// method on `Contributor<ShareReceiver>` / `Contributor<AuxContributor>`),
+/// which produces a self-certificate alongside the verified state.
+///
+/// See the [module-level docs] for `R`.
+///
+/// [`gen_keygen_input`]: Self::gen_keygen_input
+/// [module-level docs]: super
 #[derive(Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "bincode", derive(bincode::Encode, bincode::Decode))]
-#[cfg_attr(
-    feature = "serde",
-    derive(crate::fun::serde::Deserialize, crate::fun::serde::Serialize),
-    serde(crate = "crate::fun::serde")
-)]
-pub struct Contributor {
-    inner: encpedpop::Contributor,
+pub struct Contributor<R: Role> {
+    inner: encpedpop::Contributor<R>,
+    aux_contributor_keys: Vec<Point>,
 }
 
-impl Contributor {
-    /// Generates the keygen input for a party at `my_index`. Note that `my_index`
-    /// has nothing to do with the "receiver" index (the `ShareIndex` of share receivers). If
-    /// there are `n` `KeyGenInputParty`s then each party must be assigned an index from `0` to `n-1`.
+impl<R: Role> Contributor<R> {
+    /// Generate this contributor's keygen input.
     ///
-    /// This method return `Self` to retain the state of the protocol which is needded to verify
-    /// the aggregated input later on.
+    /// For [`ShareReceiver`], `my_role_index` is the receiver slot in
+    /// `[0..receiver_keys.len())` and the contributor's `ShareIndex`
+    /// is `my_role_index + 1`. For [`AuxContributor`], `my_role_index` is in
+    /// `[0..aux_contributor_keys.len())`.
     pub fn gen_keygen_input<H: Hash32, NG: NonceGen>(
         schnorr: &Schnorr<H, NG>,
         threshold: u32,
-        n_contributors: u32,
-        receiver_encryption_keys: &BTreeMap<ShareIndex, Point>,
-        my_index: u32,
+        aux_contributor_keys: &[Point],
+        receiver_keys: &[Point],
+        my_role_index: u32,
         rng: &mut impl rand_core::RngCore,
-    ) -> (Self, KeygenInput) {
-        let (inner, message) = encpedpop::Contributor::gen_keygen_input(
+    ) -> Result<(Self, KeygenInput), GenKeygenInputError> {
+        let aux_unique: BTreeSet<Point> = aux_contributor_keys.iter().copied().collect();
+        if aux_unique.len() != aux_contributor_keys.len() {
+            return Err(GenKeygenInputError::DuplicateAuxKey);
+        }
+        let receiver_unique: BTreeSet<Point> = receiver_keys.iter().copied().collect();
+        if !aux_unique.is_disjoint(&receiver_unique) {
+            return Err(GenKeygenInputError::AuxReceiverOverlap);
+        }
+        let n_aux_contributors =
+            u32::try_from(aux_contributor_keys.len()).expect("too many aux contributors");
+        let (inner, message) = encpedpop::Contributor::<R>::gen_keygen_input(
             schnorr,
             threshold,
-            n_contributors,
-            receiver_encryption_keys,
-            my_index,
+            n_aux_contributors,
+            receiver_keys,
+            my_role_index,
             rng,
-        );
-        (Self { inner }, message)
+        )?;
+        Ok((
+            Self {
+                inner,
+                aux_contributor_keys: aux_contributor_keys.to_vec(),
+            },
+            message,
+        ))
     }
+}
 
-    /// Verifies that the coordinator has honestly included this party's input into the
-    /// aggregated input and returns a certification signature to that effect.
-    ///
-    /// This passing by itself doesn't mean that the key generation was successful. You must
-    /// first collect the signatures from all the certifying parties (contributors and share
-    /// receivers).
-    pub fn verify_agg_input<S: CertificationScheme>(
-        self,
-        cert_scheme: &S,
-        agg_keygen_input: &AggKeygenInput,
-        cert_keypair: &KeyPair,
-    ) -> Result<S::Signature, simplepedpop::ContributionDidntMatch> {
-        self.inner.verify_agg_input(agg_keygen_input)?;
-        let sig = cert_scheme.certify(cert_keypair, agg_keygen_input);
-        Ok(sig)
-    }
-
-    /// For parties that are both contributors and receivers: verify contribution,
-    /// receive secret share, and certify with a single keypair.
-    ///
-    /// This method is used when a party acts as both a contributor (providing entropy)
-    /// and a receiver (getting a secret share), using the same keypair for both
-    /// encryption/decryption and certification.
-    ///
-    /// Returns the same shape as the receiver-only entry point
-    /// [`SecretShareReceiver::receive_secret_share`]: a [`SecretShareReceiver`]
-    /// that *holds* the share until [`SecretShareReceiver::finalize`] is
-    /// called with a complete cert map. Callers must not use the share before
-    /// finalize succeeds — otherwise they're trusting an uncertified keygen.
-    pub fn verify_receive_share_and_certify<H: Hash32, NG: NonceGen, S: CertificationScheme>(
+impl Contributor<AuxContributor> {
+    /// Verify the aggregated input and produce this aux contributor's certificate
+    /// signature. The keygen is only complete once every party's signature has
+    /// been collected via [`Certifier`].
+    pub fn verify_agg_input<H: Hash32, NG, S: CertificationScheme>(
         self,
         pop_schnorr: &Schnorr<H, NG>,
         cert_scheme: &S,
-        share_index: ShareIndex,
+        agg_input: AggKeygenInput,
         keypair: &KeyPair,
-        agg_input: &AggKeygenInput,
-    ) -> Result<(SecretShareReceiver, S::Signature), CombinedRoleError> {
-        // First verify my contribution was included
-        self.inner
-            .verify_agg_input(agg_input)
-            .map_err(|_| CombinedRoleError::ContributionDidntMatch)?;
+    ) -> Result<(VerifiedAggKeygenInput, S::Signature), VerifyAggInputError> {
+        let my_aux_index = self.inner.role_index() as usize;
+        let Self {
+            inner,
+            aux_contributor_keys,
+            ..
+        } = self;
 
-        // Then receive my secret share
-        let paired_secret_share =
-            encpedpop::receive_secret_share(pop_schnorr, share_index, keypair, agg_input)
-                .map_err(CombinedRoleError::ReceiveShareError)?;
+        let inner_verified = inner.verify_agg_input(pop_schnorr, agg_input)?;
+        let expected_cert_key = aux_contributor_keys[my_aux_index];
+        if expected_cert_key != keypair.public_key() {
+            return Err(VerifyAggInputError::WrongCertificationKey);
+        }
 
-        // Finally certify the result
-        let sig = cert_scheme.certify(keypair, agg_input);
+        let verified = VerifiedAggKeygenInput {
+            inner: inner_verified,
+            aux_contributor_keys,
+        };
+        let sig = cert_scheme.certify(keypair, &verified);
+        Ok((verified, sig))
+    }
+}
 
+impl Contributor<ShareReceiver> {
+    /// Verify the aggregated input, extract the secret share, and produce this
+    /// receiver's certificate signature. The returned [`SecretShareReceiver`]
+    /// holds the share until [`SecretShareReceiver::finalize`] runs with a
+    /// complete certificate map — callers must not use the share before then.
+    pub fn verify_agg_input<H: Hash32, NG, S: CertificationScheme>(
+        self,
+        pop_schnorr: &Schnorr<H, NG>,
+        cert_scheme: &S,
+        agg_input: AggKeygenInput,
+        keypair: &KeyPair,
+    ) -> Result<(SecretShareReceiver, S::Signature), ShareReceiverError> {
+        let Self {
+            inner,
+            aux_contributor_keys,
+            ..
+        } = self;
+        let (inner_verified, paired_secret_share) =
+            inner.verify_agg_input(pop_schnorr, agg_input, keypair)?;
+        let verified = VerifiedAggKeygenInput {
+            inner: inner_verified,
+            aux_contributor_keys,
+        };
+        let sig = cert_scheme.certify(keypair, &verified);
         Ok((
             SecretShareReceiver {
                 paired_secret_share,
-                agg_input: agg_input.clone(),
+                verified_agg_input: verified,
             },
             sig,
         ))
     }
 }
 
-/// Stores the state of share recipient who first receives their share and then waits to get
-/// signatures from all the certifying parties on the keygeneration before accepting it.
+/// An [`AggKeygenInput`] that this contributor has verified and is the bytes
+/// covered by certpedpop's certificate.
+#[derive(Clone, Debug, PartialEq)]
+pub struct VerifiedAggKeygenInput {
+    inner: encpedpop::VerifiedAggKeygenInput,
+    aux_contributor_keys: Vec<Point>,
+}
+
+impl VerifiedAggKeygenInput {
+    /// Certifying keys for contributor-only parties, in slot order.
+    pub fn aux_contributor_keys(&self) -> &[Point] {
+        &self.aux_contributor_keys
+    }
+
+    pub(in crate::frost::chilldkg::certpedpop) fn required_keys(&self) -> BTreeSet<Point> {
+        self.aux_contributor_keys
+            .iter()
+            .copied()
+            .chain(self.receiver_keys().map(|(_, key)| key))
+            .collect()
+    }
+
+    /// `n_aux_contributors + n_receivers`.
+    pub fn n_contributors(&self) -> usize {
+        self.inner.n_contributors()
+    }
+
+    /// Number of contributor-only parties.
+    pub fn n_aux_contributors(&self) -> usize {
+        self.inner.n_aux_contributors()
+    }
+
+    /// Number of share receivers.
+    pub fn n_receivers(&self) -> usize {
+        self.inner.n_receivers()
+    }
+
+    /// The [`SharedKey`] this aggregated input produces.
+    pub fn shared_key(&self) -> SharedKey {
+        self.inner.shared_key()
+    }
+
+    /// Bytes covered by every certpedpop certificate. Extends
+    /// [`encpedpop::VerifiedAggKeygenInput::cert_bytes`] with this layer's
+    /// `aux_contributor_keys`, so disagreement on either keyset produces
+    /// different bytes per victim and certification fails.
+    pub fn cert_bytes(&self) -> Vec<u8> {
+        let mut cert_bytes = self.inner.cert_bytes();
+        // No length prefix needed: encpedpop commits to n_contributors and
+        // n_receivers, so aux_contributor_keys.len() is fixed.
+        for aux_key in &self.aux_contributor_keys {
+            cert_bytes.extend(aux_key.to_bytes());
+        }
+        cert_bytes
+    }
+
+    /// Encryption key for every receiver, paired with its `ShareIndex`.
+    pub fn receiver_keys(&self) -> impl Iterator<Item = (ShareIndex, Point)> + '_ {
+        self.inner.receiver_keys()
+    }
+
+    /// Recover a receiver's share from this verified aggregate using their
+    /// decryption keypair.
+    pub fn recover_share<H: Hash32>(
+        &self,
+        share_index: ShareIndex,
+        keypair: &KeyPair,
+    ) -> Result<PairedSecretShare, encpedpop::RecoverShareError> {
+        self.inner.recover_share::<H>(share_index, keypair)
+    }
+}
+
+/// A receiver's secret share, withheld until every certifying party has signed.
+/// Returned by [`Contributor::<ShareReceiver>::verify_agg_input`]; release the
+/// share with [`finalize`] once you have a complete cert map.
+///
+/// [`finalize`]: Self::finalize
 #[derive(Debug, Clone, PartialEq)]
 pub struct SecretShareReceiver {
-    paired_secret_share: PairedSecretShare<Normal, Zero>,
-    agg_input: AggKeygenInput,
+    paired_secret_share: PairedSecretShare,
+    verified_agg_input: VerifiedAggKeygenInput,
 }
 
 impl SecretShareReceiver {
-    /// Extract your `keypair` and certify the key generation. Before you actually
-    /// can use the share you must call [`finalize`] with a completed certificate.
-    ///
-    /// [`finalize`]: Self::finalize
-    pub fn receive_secret_share<H, NG, S>(
-        schnorr: &Schnorr<H, NG>,
-        cert_scheme: &S,
-        my_index: ShareIndex,
-        keypair: &KeyPair,
-        agg_input: &AggKeygenInput,
-    ) -> Result<(Self, S::Signature), simplepedpop::ReceiveShareError>
-    where
-        H: Hash32,
-        NG: NonceGen,
-        S: CertificationScheme,
-    {
-        let paired_secret_share =
-            encpedpop::receive_secret_share(schnorr, my_index, keypair, agg_input)?;
-        let sig = cert_scheme.certify(keypair, agg_input);
-        let self_ = Self {
-            paired_secret_share,
-            agg_input: agg_input.clone(),
-        };
-        Ok((self_, sig))
+    /// The verified aggregated input this receiver was constructed against.
+    pub fn verified_agg_input(&self) -> &VerifiedAggKeygenInput {
+        &self.verified_agg_input
     }
 
-    /// Check the certificate contains a signature from each certifying party.
-    ///
-    /// By default every share receiver is a certifying party but you must also get
-    /// certifications from the [`Contributor`]s for security. Their keys are passed in as
-    /// `contributor_keys`.
-    ///
-    /// The supplied `certificate` map must contain exactly one entry per
-    /// certifying party — any extras are rejected with
-    /// [`CertificateError::Unexpected`]. This avoids unverified entries
-    /// landing in the resulting [`CertifiedKeygen`] (where downstream
-    /// consumers like the VRF beacon would otherwise pick them up).
+    /// Release the secret share once `certificate` covers every certifying
+    /// party (every aux contributor key plus every receiver's encryption key).
+    /// Extras are rejected with [`CertificateError::Unexpected`].
     pub fn finalize<S: CertificationScheme>(
         self,
         cert_scheme: &S,
         certificate: BTreeMap<Point, S::Signature>,
-        contributor_keys: &[Point],
-    ) -> Result<CertifiedSecretShare<S::Signature>, CertificateError> {
-        let cert_keys = self
-            .agg_input
-            .encryption_keys()
-            .map(|(_, encryption_key)| encryption_key)
-            .chain(contributor_keys.iter().cloned())
-            .collect::<BTreeSet<_>>(); // dedupe as some contributors may also be receivers
-
-        let mut remaining = certificate;
-        let mut verified = BTreeMap::new();
-        for cert_key in cert_keys {
-            let sig = remaining
-                .remove(&cert_key)
-                .ok_or(CertificateError::Missing { key: cert_key })?;
-            if !cert_scheme.verify_cert(cert_key, &self.agg_input, &sig) {
-                return Err(CertificateError::InvalidCert { key: cert_key });
-            }
-            verified.insert(cert_key, sig);
-        }
-
-        if let Some((extra_key, _)) = remaining.into_iter().next() {
-            return Err(CertificateError::Unexpected { key: extra_key });
-        }
-
-        let certified_keygen = CertifiedKeygen::new(self.agg_input, verified);
-
-        Ok(CertifiedSecretShare {
-            certified_keygen,
-            paired_share: self.paired_secret_share,
-        })
+    ) -> Result<(CertifiedKeygen<S::Signature>, PairedSecretShare), CertificateError> {
+        let Self {
+            paired_secret_share,
+            verified_agg_input,
+        } = self;
+        let certified_keygen = CertifiedKeygen::new(cert_scheme, verified_agg_input, certificate)?;
+        Ok((certified_keygen, paired_secret_share))
     }
 }
 
-/// Errors that can occur when a party acts as both contributor and receiver
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub enum CombinedRoleError {
-    /// The contribution we provided was not included correctly
-    ContributionDidntMatch,
-    /// Could not receive the secret share
-    ReceiveShareError(simplepedpop::ReceiveShareError),
+/// Reasons [`Contributor::gen_keygen_input`] may fail.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum GenKeygenInputError {
+    /// `aux_contributor_keys` contained a duplicate point.
+    DuplicateAuxKey,
+    /// A key appeared in both `aux_contributor_keys` and `receiver_keys`.
+    AuxReceiverOverlap,
+    /// The underlying encrypted DKG input generation rejected the parameters.
+    Inner(encpedpop::GenKeygenInputError),
 }
 
-impl core::fmt::Display for CombinedRoleError {
+impl From<encpedpop::GenKeygenInputError> for GenKeygenInputError {
+    fn from(err: encpedpop::GenKeygenInputError) -> Self {
+        GenKeygenInputError::Inner(err)
+    }
+}
+
+impl core::fmt::Display for GenKeygenInputError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            CombinedRoleError::ContributionDidntMatch => {
-                write!(f, "contribution was not included correctly")
+            GenKeygenInputError::DuplicateAuxKey => {
+                write!(f, "aux_contributor_keys contained a duplicate")
             }
-            CombinedRoleError::ReceiveShareError(e) => write!(f, "failed to receive share: {}", e),
+            GenKeygenInputError::AuxReceiverOverlap => write!(
+                f,
+                "a key appeared in both aux_contributor_keys and receiver_keys"
+            ),
+            GenKeygenInputError::Inner(err) => write!(f, "{err}"),
         }
     }
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for CombinedRoleError {}
+impl std::error::Error for GenKeygenInputError {}
 
-/// Simulate running a key generation with `certpedpop`.
+/// Errors that can occur while verifying and preparing to certify an aggregated input.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum VerifyAggInputError {
+    /// The underlying encrypted DKG verification failed.
+    Inner(encpedpop::VerifyAggInputError),
+    /// The supplied certification keypair does not belong to this contributor slot.
+    WrongCertificationKey,
+}
+
+impl From<encpedpop::VerifyAggInputError> for VerifyAggInputError {
+    fn from(err: encpedpop::VerifyAggInputError) -> Self {
+        VerifyAggInputError::Inner(err)
+    }
+}
+
+impl core::fmt::Display for VerifyAggInputError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            VerifyAggInputError::Inner(err) => write!(f, "{err}"),
+            VerifyAggInputError::WrongCertificationKey => {
+                write!(
+                    f,
+                    "certification keypair does not match this contributor slot"
+                )
+            }
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for VerifyAggInputError {}
+
+/// Test/example helper: run every `certpedpop` party in-process. Not for production.
 ///
-/// This calls all the other functions defined in this module to get the whole job done on a
-/// single computer by simulating all the other parties.
-///
-/// A fingerprint can be provided to grind into the polynomial coefficients.
-///
-/// Returns:
-/// - The `CertifiedKeygen` containing the aggregated keygen input and all certificates
-/// - A vector of paired secret shares along with their corresponding keypairs. The keypairs
-///   are returned so that callers can test the `recover_share` functionality, which allows
-///   parties to recover their share from the certified keygen using their keypair (verifying
-///   both that they certified the keygen and can decrypt their share).
-pub fn simulate_keygen<H: Hash32, NG: NonceGen, S: CertificationScheme + Clone>(
+/// Returns the [`CertifiedKeygen`] together with each receiver's paired share
+/// and the keypair that decrypted it (so callers can exercise `recover_share`).
+pub fn simulate_keygen<H: Hash32, NG: NonceGen, S: CertificationScheme>(
     schnorr: &Schnorr<H, NG>,
-    cert_scheme: S,
+    cert_scheme: &S,
     threshold: u32,
     n_receivers: u32,
-    n_extra_generators: u32,
+    n_aux_contributors: u32,
     fingerprint: Fingerprint,
     rng: &mut impl rand_core::RngCore,
 ) -> SimulatedKeygenOutput<S::Signature> {
-    let receiver_enckeys = (1..=n_receivers)
-        .map(|i| {
-            let party_index = Scalar::from(i).non_zero().unwrap();
-            (party_index, KeyPair::new(Scalar::random(rng)))
-        })
-        .collect::<BTreeMap<_, _>>();
+    // Slot order: receiver-contributors at [0..n_receivers) in ascending
+    // ShareIndex order (ShareIndex = slot + 1), aux contributors at
+    // [n_receivers..n_receivers + n_aux).
+    let receiver_keypairs: Vec<KeyPair> =
+        core::iter::repeat_with(|| KeyPair::new(Scalar::random(rng)))
+            .take(n_receivers as usize)
+            .collect();
+    let receiver_keys: Vec<Point> = receiver_keypairs.iter().map(|kp| kp.public_key()).collect();
 
-    let public_receiver_enckeys = receiver_enckeys
-        .iter()
-        .map(|(party_index, enckeypair)| (*party_index, enckeypair.public_key()))
-        .collect::<BTreeMap<ShareIndex, Point>>();
-
-    let n_contributors = n_receivers + n_extra_generators;
-
-    // Generate keypairs for contributors - receivers will use their existing keypairs
-    let contributor_keys: Vec<_> = (1..=n_receivers)
-        .map(|i| {
-            let party_index = Scalar::from(i).non_zero().unwrap();
-            receiver_enckeys[&party_index]
-        })
-        .chain(
-            core::iter::repeat_with(|| KeyPair::new(Scalar::random(rng)))
-                .take(n_extra_generators as _),
-        )
-        .collect();
-
-    let (contributors, to_coordinator_messages): (Vec<Contributor>, Vec<KeygenInput>) = (0
-        ..n_contributors)
-        .map(|i| {
-            Contributor::gen_keygen_input(
-                schnorr,
-                threshold,
-                n_contributors,
-                &public_receiver_enckeys,
-                i,
-                rng,
-            )
-        })
-        .unzip();
-
-    let contributor_public_keys = contributor_keys
+    let aux_contributor_keys: Vec<KeyPair> =
+        core::iter::repeat_with(|| KeyPair::new(Scalar::random(rng)))
+            .take(n_aux_contributors as usize)
+            .collect();
+    let aux_contributor_public_keys: Vec<Point> = aux_contributor_keys
         .iter()
         .map(|kp| kp.public_key())
-        .collect::<Vec<_>>();
+        .collect();
 
-    let mut aggregator = Coordinator::new(threshold, n_contributors, &public_receiver_enckeys);
+    let mut aggregator = Coordinator::new(threshold, n_aux_contributors, n_receivers);
+    let mut receiver_contributors: Vec<(Contributor<ShareReceiver>, KeyPair)> = vec![];
+    let mut aux_contributors: Vec<(Contributor<AuxContributor>, KeyPair)> = vec![];
 
-    for (i, to_coordinator_message) in to_coordinator_messages.into_iter().enumerate() {
+    for receiver_idx in 0..n_receivers {
+        let (contributor, msg) = Contributor::<ShareReceiver>::gen_keygen_input(
+            schnorr,
+            threshold,
+            &aux_contributor_public_keys,
+            &receiver_keys,
+            receiver_idx,
+            rng,
+        )
+        .unwrap();
         aggregator
-            .add_input(schnorr, i as u32, to_coordinator_message)
+            .add_input(schnorr, Party::Receiver(receiver_idx), msg)
             .unwrap();
+        receiver_contributors.push((contributor, receiver_keypairs[receiver_idx as usize]));
+    }
+    for aux_idx in 0..n_aux_contributors {
+        let (contributor, msg) = Contributor::<AuxContributor>::gen_keygen_input(
+            schnorr,
+            threshold,
+            &aux_contributor_public_keys,
+            &receiver_keys,
+            aux_idx,
+            rng,
+        )
+        .unwrap();
+        aggregator
+            .add_input(schnorr, Party::AuxContributor(aux_idx), msg)
+            .unwrap();
+        aux_contributors.push((contributor, aux_contributor_keys[aux_idx as usize]));
     }
 
-    let mut agg_input = aggregator.finish().unwrap();
-    agg_input.grind_fingerprint::<H>(fingerprint);
+    let agg_input = aggregator
+        .finish_with_fingerprint::<H>(fingerprint)
+        .unwrap();
 
-    // Create a Certifier to validate certificates as they're received
+    let mut share_receivers: Vec<(SecretShareReceiver, KeyPair)> = vec![];
+    let mut signatures: Vec<(Point, S::Signature)> = vec![];
+    let mut verified_agg_input: Option<VerifiedAggKeygenInput> = None;
+    for (contributor, keypair) in receiver_contributors {
+        let (receiver, sig) = contributor
+            .verify_agg_input(schnorr, cert_scheme, agg_input.clone(), &keypair)
+            .unwrap();
+        signatures.push((keypair.public_key(), sig));
+        verified_agg_input.get_or_insert_with(|| receiver.verified_agg_input().clone());
+        share_receivers.push((receiver, keypair));
+    }
+    for (contributor, aux_keypair) in aux_contributors {
+        let (verified, sig) = contributor
+            .verify_agg_input(schnorr, cert_scheme, agg_input.clone(), &aux_keypair)
+            .unwrap();
+        signatures.push((aux_keypair.public_key(), sig));
+        verified_agg_input.get_or_insert(verified);
+    }
     let mut certifier = Certifier::new(
         cert_scheme.clone(),
-        agg_input.clone(),
-        &contributor_public_keys,
-    )
-    .expect("simulate_keygen produces matching contributor counts");
-
-    // Hold dual-role receiver state until certification finishes; only then
-    // can we release the paired share via finalize.
-    let mut dual_role_receivers: Vec<(SecretShareReceiver, KeyPair)> = vec![];
-
-    // Handle parties that are both contributors and receivers using the combined API
-    for (i, (party_index, enckey)) in receiver_enckeys
-        .iter()
-        .enumerate()
-        .take(n_receivers as usize)
-    {
-        // This party is both a contributor and receiver - use combined method
-        let (receiver, sig) = contributors[i]
-            .clone()
-            .verify_receive_share_and_certify(
-                schnorr,
-                &cert_scheme,
-                *party_index,
-                enckey,
-                &agg_input,
-            )
-            .unwrap();
-
-        // Only one certificate for this dual-role party
-        certifier
-            .receive_certificate(enckey.public_key(), sig)
-            .unwrap();
-
-        dual_role_receivers.push((receiver, *enckey));
+        verified_agg_input.expect("at least one contributor"),
+    );
+    for (key, sig) in signatures {
+        certifier.receive_certificate(key, sig).unwrap();
     }
 
-    // Handle extra contributors that are only contributors (not receivers)
-    for i in n_receivers as usize..n_contributors as usize {
-        let sig = contributors[i]
-            .clone()
-            .verify_agg_input(&cert_scheme, &agg_input, &contributor_keys[i])
-            .unwrap();
-        certifier
-            .receive_certificate(contributor_keys[i].public_key(), sig)
-            .unwrap();
-    }
-
-    // Finish certification and get the CertifiedKeygen
     let certified_keygen = certifier
         .finish()
         .expect("Certifier should have all required certificates");
 
-    // Now that certification is done, release each dual-role party's share.
     let cert_map = certified_keygen.certificate().clone();
-    let paired_secret_shares: Vec<(PairedSecretShare<Normal>, KeyPair)> = dual_role_receivers
+    let paired_secret_shares: Vec<(PairedSecretShare, KeyPair)> = share_receivers
         .into_iter()
-        .map(|(receiver, enckey)| {
-            let CertifiedSecretShare { paired_share, .. } = receiver
-                .finalize(&cert_scheme, cert_map.clone(), &contributor_public_keys)
+        .map(|(receiver, keypair)| {
+            let (receiver_certified, paired_share) = receiver
+                .finalize(cert_scheme, cert_map.clone())
                 .expect("simulate_keygen finalize");
-            (paired_share.non_zero().unwrap(), enckey)
+            assert_eq!(receiver_certified, certified_keygen);
+            (paired_share, keypair)
         })
         .collect();
 
     SimulatedKeygenOutput {
         certified_keygen,
         paired_shares_with_keys: paired_secret_shares,
-        contributor_public_keys,
+        aux_contributor_public_keys,
     }
 }
 
-/// The result of finalizing a share receiver's key generation
-pub struct CertifiedSecretShare<Sig> {
-    /// The certified keygen containing the shared key and certificates
-    pub certified_keygen: CertifiedKeygen<Sig>,
-    /// The secret share for this receiver
-    pub paired_share: PairedSecretShare<Normal, Zero>,
-}
-
-/// The result of simulating a complete key generation ceremony
+/// Output of [`simulate_keygen`].
 pub struct SimulatedKeygenOutput<Sig> {
-    /// The certified keygen containing the shared key and certificates
+    /// Certified keygen — shared key plus every party's certificate.
     pub certified_keygen: CertifiedKeygen<Sig>,
-    /// All paired shares with their corresponding keypairs
-    pub paired_shares_with_keys: Vec<(PairedSecretShare<Normal>, KeyPair)>,
-    /// The public keys of all contributors
-    pub contributor_public_keys: Vec<Point>,
+    /// Each receiver's paired share with the keypair that decrypted it.
+    pub paired_shares_with_keys: Vec<(PairedSecretShare, KeyPair)>,
+    /// Public keys of the aux contributors.
+    pub aux_contributor_public_keys: Vec<Point>,
 }
 
 #[cfg(test)]
@@ -423,23 +466,27 @@ mod test {
         #[test]
         fn certified_run_simulate_keygen(
             (n_receivers, threshold) in (1u32..=4).prop_flat_map(|n| (Just(n), 1u32..=n)),
-            n_extra_generators in 0u32..=3,
+            n_aux_contributors in 0u32..=3,
         ) {
             let schnorr = crate::new_with_deterministic_nonces::<sha2::Sha256>();
             let mut rng = TestRng::deterministic_rng(RngAlgorithm::ChaCha);
 
             let output = certpedpop::simulate_keygen(
                 &schnorr,
-                schnorr.clone(),
+                &schnorr,
                 threshold,
                 n_receivers,
-                n_extra_generators,
+                n_aux_contributors,
                 Fingerprint::NONE,
                 &mut rng
             );
 
-            // Verify the certified keygen is valid
-            output.certified_keygen.verify(schnorr.clone(), &output.contributor_public_keys).expect("CertifiedKeygen should be valid");
+            CertifiedKeygen::new(
+                &schnorr,
+                output.certified_keygen.verified_agg_input().clone(),
+                output.certified_keygen.certificate().clone(),
+            )
+            .expect("CertifiedKeygen should be valid");
 
             for (paired_secret_share, keypair) in output.paired_shares_with_keys {
                 let recovered = output.certified_keygen.recover_share::<sha2::Sha256, _>(&schnorr, paired_secret_share.index(), keypair).unwrap();
@@ -449,7 +496,7 @@ mod test {
             // Verify we have the expected number of VRF certificates
             assert_eq!(
                 output.certified_keygen.certificate().len(),
-                (n_receivers + n_extra_generators) as usize
+                (n_receivers + n_aux_contributors) as usize
             );
 
         }
@@ -460,7 +507,7 @@ mod test {
         #[cfg(feature = "vrf_cert_keygen")]
         fn vrf_certified_keygen_randomness_beacon(
             (n_receivers, threshold) in (1u32..=4).prop_flat_map(|n| (Just(n), 1u32..=n)),
-            n_extra_generators in 0u32..=3,
+            n_aux_contributors in 0u32..=3,
         ) {
             use proptest::test_runner::{RngAlgorithm, TestRng};
 
@@ -470,18 +517,20 @@ mod test {
 
             let output = certpedpop::simulate_keygen(
                 &schnorr,
-                vrf_certifier.clone(),
+                &vrf_certifier,
                 threshold,
                 n_receivers,
-                n_extra_generators,
+                n_aux_contributors,
                 Fingerprint::NONE,
                 &mut rng,
             );
 
-            // Verify the certified keygen is valid
-            output.certified_keygen
-                .verify(vrf_certifier, &output.contributor_public_keys)
-                .expect("CertifiedKeygen should be valid");
+            CertifiedKeygen::new(
+                &vrf_certifier,
+                output.certified_keygen.verified_agg_input().clone(),
+                output.certified_keygen.certificate().clone(),
+            )
+            .expect("CertifiedKeygen should be valid");
 
             // Compute randomness beacon from the VRF outputs
             let randomness = output.certified_keygen.vrf_security_check(sha2::Sha256::default());
@@ -493,63 +542,161 @@ mod test {
             // Verify we have the expected number of VRF certificates
             assert_eq!(
                 output.certified_keygen.certificate().len(),
-                (n_receivers + n_extra_generators) as usize
+                (n_receivers + n_aux_contributors) as usize
             );
         }
     }
 
-    // SecretShareReceiver::finalize must reject any caller-supplied certificate
-    // map that contains entries for keys outside the expected certifying set.
-    // Otherwise the extras would land in CertifiedKeygen.certificate and
-    // pollute downstream consumers (e.g. the VRF beacon).
-    #[test]
-    fn finalize_rejects_unexpected_cert_entries() {
+    fn run_input_aggregation_stage(
+        threshold: u32,
+        n_aux_contributors: u32,
+        n_receivers: u32,
+    ) -> (Vec<Contributor<AuxContributor>>, AggKeygenInput) {
         let schnorr = crate::new_with_deterministic_nonces::<sha2::Sha256>();
         let mut rng = TestRng::deterministic_rng(RngAlgorithm::ChaCha);
-        let threshold = 2u32;
-        let n_receivers = 2u32;
-        let n_extra_generators = 0u32;
+        let receiver_keys: Vec<Point> = (0..n_receivers)
+            .map(|_| KeyPair::new(Scalar::random(&mut rng)).public_key())
+            .collect();
+        let aux_contributor_keys: Vec<Point> = (0..n_aux_contributors)
+            .map(|_| KeyPair::new(Scalar::random(&mut rng)).public_key())
+            .collect();
 
-        let output = certpedpop::simulate_keygen(
-            &schnorr,
-            schnorr.clone(),
-            threshold,
-            n_receivers,
-            n_extra_generators,
-            Fingerprint::NONE,
-            &mut rng,
+        let mut coordinator = Coordinator::new(threshold, n_aux_contributors, n_receivers);
+        for receiver_idx in 0..n_receivers {
+            let (_, msg) = Contributor::<ShareReceiver>::gen_keygen_input(
+                &schnorr,
+                threshold,
+                &aux_contributor_keys,
+                &receiver_keys,
+                receiver_idx,
+                &mut rng,
+            )
+            .unwrap();
+            coordinator
+                .add_input(&schnorr, Party::Receiver(receiver_idx), msg)
+                .unwrap();
+        }
+        let mut auxes = vec![];
+        for aux_idx in 0..n_aux_contributors {
+            let (contributor, msg) = Contributor::<AuxContributor>::gen_keygen_input(
+                &schnorr,
+                threshold,
+                &aux_contributor_keys,
+                &receiver_keys,
+                aux_idx,
+                &mut rng,
+            )
+            .unwrap();
+            coordinator
+                .add_input(&schnorr, Party::AuxContributor(aux_idx), msg)
+                .unwrap();
+            auxes.push(contributor);
+        }
+        (auxes, coordinator.finish().unwrap())
+    }
+
+    #[test]
+    fn verify_agg_input_rejects_wrong_certification_key() {
+        let schnorr = crate::new_with_deterministic_nonces::<sha2::Sha256>();
+        let mut rng = TestRng::deterministic_rng(RngAlgorithm::ChaCha);
+        let (auxes, agg_input) = run_input_aggregation_stage(2, 1, 2);
+        let wrong_keypair = KeyPair::new(Scalar::random(&mut rng));
+
+        assert_eq!(
+            auxes
+                .into_iter()
+                .next()
+                .unwrap()
+                .verify_agg_input(&schnorr, &schnorr, agg_input, &wrong_keypair)
+                .err(),
+            Some(VerifyAggInputError::WrongCertificationKey)
+        );
+    }
+
+    // CertifiedKeygen::new (and SecretShareReceiver::finalize, which shares the
+    // validation) must reject caller-supplied certificate maps that contain
+    // entries for keys outside the expected certifying set. Otherwise the
+    // extras would pollute downstream consumers (e.g. the VRF beacon).
+    #[test]
+    fn certified_keygen_new_rejects_unexpected_cert_entries() {
+        let schnorr = crate::new_with_deterministic_nonces::<sha2::Sha256>();
+        let mut rng = TestRng::deterministic_rng(RngAlgorithm::ChaCha);
+        let output =
+            certpedpop::simulate_keygen(&schnorr, &schnorr, 2, 2, 1, Fingerprint::NONE, &mut rng);
+        let verified_input = output.certified_keygen.verified_agg_input().clone();
+
+        let mut bad_certs = output.certified_keygen.certificate().clone();
+        let unrelated = KeyPair::new(Scalar::random(&mut rng));
+        bad_certs.insert(
+            unrelated.public_key(),
+            schnorr.certify(&unrelated, &verified_input),
         );
 
-        // Pick the first receiver as our honest party for the finalize test.
-        let (paired_share, keypair) = output.paired_shares_with_keys[0];
-        let agg_input = output.certified_keygen.agg_input().clone();
-        let contributor_keys = output.contributor_public_keys.clone();
-
-        // Build the receiver state via the receiver-only entry point so we
-        // can drive `finalize` directly.
-        let (receiver, _own_sig) = SecretShareReceiver::receive_secret_share(
-            &schnorr,
-            &schnorr,
-            paired_share.index(),
-            &keypair,
-            &agg_input,
-        )
-        .expect("receive_secret_share");
-
-        // Honest cert map from the simulated keygen, plus an extra valid cert
-        // signed by an unrelated keypair (not in contributor_keys ∪ receivers).
-        let mut malicious_cert_map = output.certified_keygen.certificate().clone();
-        let unrelated_keypair = KeyPair::new(Scalar::random(&mut rng));
-        let unrelated_sig = schnorr.certify(&unrelated_keypair, &agg_input);
-        malicious_cert_map.insert(unrelated_keypair.public_key(), unrelated_sig);
-
-        let result = receiver.finalize(&schnorr, malicious_cert_map, &contributor_keys);
+        let result = CertifiedKeygen::new(&schnorr, verified_input, bad_certs);
         assert_eq!(
             result.err(),
             Some(CertificateError::Unexpected {
-                key: unrelated_keypair.public_key()
-            }),
-            "finalize must reject unknown-key entries in the supplied map"
+                key: unrelated.public_key()
+            })
         );
+    }
+
+    // The aux contributor keys live on the contributor's verified state. Two
+    // contributors who disagree on aux_contributor_keys must produce
+    // different cert_bytes — that's how mutual certification fails when a
+    // malicious party tries to substitute an aux key.
+    #[test]
+    fn cert_bytes_binds_aux_contributor_keys() {
+        let schnorr = crate::new_with_deterministic_nonces::<sha2::Sha256>();
+        let mut rng = TestRng::deterministic_rng(RngAlgorithm::ChaCha);
+        let output =
+            certpedpop::simulate_keygen(&schnorr, &schnorr, 2, 2, 1, Fingerprint::NONE, &mut rng);
+        let honest = output.certified_keygen.verified_agg_input().clone();
+
+        let fake_aux = KeyPair::new(Scalar::random(&mut rng)).public_key();
+        let mut tampered_aux = honest.aux_contributor_keys.clone();
+        tampered_aux[0] = fake_aux;
+        let tampered = VerifiedAggKeygenInput {
+            inner: honest.inner.clone(),
+            aux_contributor_keys: tampered_aux,
+        };
+
+        assert_ne!(
+            honest.cert_bytes(),
+            tampered.cert_bytes(),
+            "cert_bytes must bind aux_contributor_keys"
+        );
+    }
+
+    // Duplicate aux keys would let the same party play multiple aux roles;
+    // an aux key that's also a receiver-encryption key would silently merge
+    // the two roles. gen_keygen_input must reject either up front (honest
+    // random keys collide with negligible probability).
+    #[test]
+    fn gen_keygen_input_rejects_invalid_keysets() {
+        let schnorr = crate::new_with_deterministic_nonces::<sha2::Sha256>();
+        let mut rng = TestRng::deterministic_rng(RngAlgorithm::ChaCha);
+        let a = KeyPair::new(Scalar::random(&mut rng)).public_key();
+        let b = KeyPair::new(Scalar::random(&mut rng)).public_key();
+
+        for (name, aux, receivers, expected) in [
+            (
+                "duplicate aux",
+                &[a, a][..],
+                &[b][..],
+                GenKeygenInputError::DuplicateAuxKey,
+            ),
+            (
+                "aux/receiver overlap",
+                &[a][..],
+                &[a, b][..],
+                GenKeygenInputError::AuxReceiverOverlap,
+            ),
+        ] {
+            let result = Contributor::<ShareReceiver>::gen_keygen_input(
+                &schnorr, 1, aux, receivers, 0, &mut rng,
+            );
+            assert_eq!(result.err(), Some(expected), "{name}");
+        }
     }
 }

--- a/schnorr_fun/src/frost/chilldkg/certpedpop/certificate.rs
+++ b/schnorr_fun/src/frost/chilldkg/certpedpop/certificate.rs
@@ -1,39 +1,50 @@
-//! Certificate types and certification schemes for ChillDKG
+//! Certificate types and certification schemes for [`certpedpop`].
 //!
-//! This module contains:
-//! - Certificate: A collection of certification signatures
-//! - CertifiedKeygen: The result of a successfully certified key generation
-//! - CertificationScheme: Trait for certification methods
-//! - Certifier: A stateful validator that checks certificates as they are received
+//! [`certpedpop`]: super
 
-use super::{AggKeygenInput, encpedpop};
+use super::{VerifiedAggKeygenInput, encpedpop};
 use crate::{Schnorr, frost::*};
 use alloc::collections::{BTreeMap, BTreeSet};
 use secp256kfun::{hash::*, prelude::*};
 
-/// A trait for different ways of certifying the aggregated keygen input in certpedpop.
-pub trait CertificationScheme {
-    /// The signature type produced by this scheme
+/// How a [`certpedpop`] party signs a [`VerifiedAggKeygenInput`] and how others
+/// verify that signature. The default implementation is BIP340 Schnorr; the
+/// `vrf_cert_keygen` feature provides a VRF variant whose certificates double
+/// as a randomness beacon.
+///
+/// [`certpedpop`]: super
+pub trait CertificationScheme: Clone {
+    /// Signature type produced by this scheme.
     type Signature: Clone + core::fmt::Debug + PartialEq;
 
-    /// Sign the AggKeygenInput with the given keypair
-    fn certify(&self, keypair: &KeyPair, agg_input: &encpedpop::AggKeygenInput) -> Self::Signature;
+    /// Sign the verified aggregate's [`cert_bytes`] with `keypair`.
+    ///
+    /// [`cert_bytes`]: VerifiedAggKeygenInput::cert_bytes
+    fn certify(
+        &self,
+        keypair: &KeyPair,
+        verified_input: &VerifiedAggKeygenInput,
+    ) -> Self::Signature;
 
-    /// Verify a certification signature
+    /// Verify a certification signature against the verified aggregate.
     fn verify_cert(
         &self,
         cert_key: Point,
-        agg_input: &encpedpop::AggKeygenInput,
+        verified_input: &VerifiedAggKeygenInput,
         signature: &Self::Signature,
     ) -> bool;
 }
 
-/// Standard Schnorr (BIP340) implementation of the CertificationScheme trait
-impl<H: Hash32, NG: NonceGen> CertificationScheme for Schnorr<H, NG> {
+/// BIP340 Schnorr certification.
+impl<H: Hash32, NG: NonceGen + Clone> CertificationScheme for Schnorr<H, NG> {
     type Signature = crate::Signature;
 
-    fn certify(&self, keypair: &KeyPair, agg_input: &encpedpop::AggKeygenInput) -> Self::Signature {
-        let cert_bytes = agg_input.cert_bytes();
+    fn certify(
+        &self,
+        keypair: &KeyPair,
+        verified_input: &VerifiedAggKeygenInput,
+    ) -> Self::Signature {
+        let cert_bytes = verified_input.cert_bytes();
         let message = crate::Message::new("BIP DKG/cert", cert_bytes.as_ref());
         let keypair_even_y = (*keypair).into();
         self.sign(&keypair_even_y, message)
@@ -42,69 +53,72 @@ impl<H: Hash32, NG: NonceGen> CertificationScheme for Schnorr<H, NG> {
     fn verify_cert(
         &self,
         cert_key: Point,
-        agg_input: &encpedpop::AggKeygenInput,
+        verified_input: &VerifiedAggKeygenInput,
         signature: &Self::Signature,
     ) -> bool {
-        let cert_bytes = agg_input.cert_bytes();
+        let cert_bytes = verified_input.cert_bytes();
         let message = crate::Message::new("BIP DKG/cert", cert_bytes.as_ref());
         let cert_key_even_y = cert_key.into_point_with_even_y().0;
         self.verify(&cert_key_even_y, message, signature)
     }
 }
 
-/// The result of a certified key generation.
+/// Final output of a `certpedpop` keygen — the verified aggregate paired with
+/// every party's certificate. Hold this; it proves the whole group certified
+/// the same result. Use [`recover_share`] to re-derive a share later from a
+/// stored decryption keypair.
 ///
-/// This type is deliberately not serializable: every `CertifiedKeygen` reaches a
-/// user only through [`Certifier::finish`], where every cert was verified on the
-/// way in. If you need to persist or transport the result, serialize the
-/// underlying [`AggKeygenInput`] and the certificate map separately and
-/// re-run certification on the receiving side.
+/// Not serializable: a `CertifiedKeygen` is only ever produced through paths
+/// that re-verify every certificate ([`Certifier::finish`] or [`new`]).
+///
+/// [`recover_share`]: Self::recover_share
+/// [`new`]: Self::new
 #[derive(Clone, Debug, PartialEq)]
 pub struct CertifiedKeygen<Sig> {
-    /// The aggregated inputs to keygen
-    input: AggKeygenInput,
-    /// The collected certificates from each party
+    verified_input: VerifiedAggKeygenInput,
     certificate: BTreeMap<Point, Sig>,
 }
 
 impl<Sig> CertifiedKeygen<Sig> {
-    /// Internal constructor for use within the crate.
-    pub(crate) fn new(input: AggKeygenInput, certificate: BTreeMap<Point, Sig>) -> Self {
-        Self { input, certificate }
+    fn from_verified(
+        verified_input: VerifiedAggKeygenInput,
+        certificate: BTreeMap<Point, Sig>,
+    ) -> Self {
+        Self {
+            verified_input,
+            certificate,
+        }
     }
 
-    /// Re-verify every stored certificate against the scheme and contributor keys.
-    ///
-    /// `CertifiedKeygen` can only be constructed via [`Certifier::finish`], which
-    /// verifies each certificate as it is received, so this method is a sanity check
-    /// rather than a safety gate.
-    pub fn verify<S>(
-        &self,
-        cert_scheme: S,
-        contributor_keys: &[Point],
-    ) -> Result<(), CertifierError>
+    /// Build a `CertifiedKeygen` from a verified aggregate and complete
+    /// certificate map; every signature is verified on the way in. Use this
+    /// when you have all the certificates at once; otherwise build a
+    /// [`Certifier`] and feed them in incrementally.
+    pub fn new<S>(
+        cert_scheme: &S,
+        verified_input: VerifiedAggKeygenInput,
+        certificates: BTreeMap<Point, Sig>,
+    ) -> Result<Self, CertificateError>
     where
         S: CertificationScheme<Signature = Sig>,
-        Sig: Clone,
     {
-        let mut certifier = Certifier::new(cert_scheme, self.input.clone(), contributor_keys)?;
-
-        // Add all certificates to the certifier
-        for (key, sig) in &self.certificate {
-            certifier.receive_certificate(*key, sig.clone())?;
+        let mut certifier = Certifier::new(cert_scheme.clone(), verified_input);
+        for (key, sig) in certificates {
+            certifier
+                .receive_certificate(key, sig)
+                .map_err(|err| match err {
+                    ReceiveCertError::UnknownParty => CertificateError::Unexpected { key },
+                    ReceiveCertError::InvalidSignature => CertificateError::InvalidCert { key },
+                })?;
         }
-
-        // Check if all required certificates are present
-        if !certifier.is_finished() {
-            return Err(CertifierError::IncompleteCertificates);
+        if let Some(key) = certifier.first_missing() {
+            return Err(CertificateError::Missing { key });
         }
-
-        Ok(())
+        Ok(certifier.finish().expect("just verified completeness"))
     }
 
-    /// Recover a share from a certified key generation with the decryption key.
-    ///
-    /// This checks that the `keypair` has signed the key generation first.
+    /// Recover a share with `keypair`'s decryption key. Confirms `keypair`
+    /// itself certified this keygen before decrypting.
     pub fn recover_share<H: Hash32, S: CertificationScheme<Signature = Sig>>(
         &self,
         cert_scheme: &S,
@@ -117,39 +131,43 @@ impl<Sig> CertifiedKeygen<Sig> {
             .get(&cert_key)
             .ok_or(RecoverShareError::NotCertifiedByKey)?;
         // We may have gotten this certificate from *somewhere* so must verify we certified it
-        if !cert_scheme.verify_cert(cert_key, &self.input, my_cert) {
+        if !cert_scheme.verify_cert(cert_key, self.verified_agg_input(), my_cert) {
             return Err(RecoverShareError::InvalidCertification);
         }
-        Ok(self.input.recover_share::<H>(share_index, &keypair)?)
+        Ok(self
+            .verified_agg_input()
+            .recover_share::<H>(share_index, &keypair)?)
     }
 
-    /// Gets the aggregated keygen input.
-    pub fn agg_input(&self) -> &AggKeygenInput {
-        &self.input
+    /// The verified aggregated keygen input this certificate covers.
+    pub fn verified_agg_input(&self) -> &VerifiedAggKeygenInput {
+        &self.verified_input
     }
 
-    /// Gets the certificate.
+    /// The certificate map: one signature per certifying party.
     pub fn certificate(&self) -> &BTreeMap<Point, Sig> {
         &self.certificate
     }
 }
 
-/// There was a problem with the keygen certificate so the key generation can't be trusted.
-#[derive(Clone, Debug, Copy, PartialEq)]
+/// Reasons a caller-supplied certificate map can be rejected by [`CertifiedKeygen::new`]
+/// or [`SecretShareReceiver::finalize`].
+///
+/// [`SecretShareReceiver::finalize`]: super::SecretShareReceiver::finalize
+#[derive(Clone, Debug, Copy, PartialEq, Eq)]
 pub enum CertificateError {
-    /// A certificate was invalid
+    /// A certificate was present but did not verify.
     InvalidCert {
-        /// The key that had the invalid cert
+        /// The key whose certificate failed verification.
         key: Point,
     },
-    /// A certificate was missing
+    /// A certifying party's certificate is missing.
     Missing {
-        /// They key whose cert was missing
+        /// The key whose certificate is missing.
         key: Point,
     },
-    /// The supplied certificate map contained an entry for a key that isn't an
-    /// expected certifying party. Unverified entries would otherwise pollute
-    /// downstream consumers (e.g. the VRF beacon).
+    /// The certificate map contained an entry for a key outside the expected
+    /// certifying set.
     Unexpected {
         /// One of the unexpected keys in the supplied map.
         key: Point,
@@ -223,10 +241,10 @@ pub mod vrf_cert {
         fn certify(
             &self,
             keypair: &KeyPair,
-            agg_input: &encpedpop::AggKeygenInput,
+            verified_input: &VerifiedAggKeygenInput,
         ) -> Self::Signature {
             // Use the certification bytes as the VRF input
-            let cert_bytes = agg_input.cert_bytes();
+            let cert_bytes = verified_input.cert_bytes();
             let h =
                 Point::hash_to_curve(H::default().ds(self.name).add(&cert_bytes[..])).normalize();
             let vrf = SimpleVrf::<H>::default().with_name(self.name);
@@ -236,11 +254,11 @@ pub mod vrf_cert {
         fn verify_cert(
             &self,
             cert_key: Point,
-            agg_input: &encpedpop::AggKeygenInput,
+            verified_input: &VerifiedAggKeygenInput,
             signature: &Self::Signature,
         ) -> bool {
             // Use the certification bytes as the VRF input
-            let cert_bytes = agg_input.cert_bytes();
+            let cert_bytes = verified_input.cert_bytes();
             let h =
                 Point::hash_to_curve(H::default().ds(self.name).add(&cert_bytes[..])).normalize();
             let vrf = SimpleVrf::<H>::default().with_name(self.name);
@@ -276,8 +294,8 @@ pub mod vrf_cert {
         /// 2. The honest party verifies its contribution to the keygen is included (which are always sampled randomly)
         /// 3. The VRF is over the transcript and every transcript with an honest party will always be unique (because of #2).
         /// 4. The honest party's VRF output will be both hidden and uniformly distributed.
-        /// 5. All honest parties with the same `AggKeygenInput::cert_bytes` will output the same check
-        /// 6. All honest parties with a different `AggKeygenInput::cert_bytes` are statistically likely to output different bytes.
+        /// 5. All honest parties with the same `VerifiedAggKeygenInput::cert_bytes` will output the same check
+        /// 6. All honest parties with a different `VerifiedAggKeygenInput::cert_bytes` are statistically likely to output different bytes.
         ///
         /// This check is *statistically* secure -- per keygen the attacker only
         /// has 1/2ⁿ chance of succeeding to collide the checks where `n` is the
@@ -293,72 +311,49 @@ pub mod vrf_cert {
     }
 }
 
-/// A certifier that validates certificates as they are received
+/// Collects certificates from each certifying party and yields a
+/// [`CertifiedKeygen`] once they're all in. Construct after
+/// `Contributor::<R>::verify_agg_input` and feed each incoming certificate
+/// through [`receive_certificate`].
+///
+/// [`receive_certificate`]: Self::receive_certificate
 #[derive(Clone, Debug, PartialEq)]
 pub struct Certifier<S: CertificationScheme> {
     cert_scheme: S,
-    agg_input: encpedpop::AggKeygenInput,
-    required_keys: BTreeSet<Point>,
+    verified_agg_input: VerifiedAggKeygenInput,
     certificates: BTreeMap<Point, S::Signature>,
 }
 
 impl<S: CertificationScheme> Certifier<S> {
-    /// Create a new certifier that expects certificates from contributors and receivers.
+    /// Build a certifier from a verified aggregated input. Feed each
+    /// party's certificate (including your own) via [`receive_certificate`].
     ///
-    /// Returns [`CertifierError::ContributorCountMismatch`] if the `agg_input` claims
-    /// a different number of contributors than `contributor_keys.len()`.
-    pub fn new(
-        cert_scheme: S,
-        agg_input: encpedpop::AggKeygenInput,
-        contributor_keys: &[Point],
-    ) -> Result<Self, CertifierError> {
-        if agg_input.n_encryption_nonces() != contributor_keys.len()
-            || agg_input.inner().n_contributors() != contributor_keys.len()
-        {
-            return Err(CertifierError::ContributorCountMismatch);
-        }
-
-        // Collect all expected keys - deduplicate since some parties may be both contributors and receivers
-        let mut required_keys = BTreeSet::new();
-
-        // Add contributor certification keys
-        for key in contributor_keys {
-            required_keys.insert(*key);
-        }
-
-        // Add receiver encryption keys from the agg_input
-        for (_, encryption_key) in agg_input.encryption_keys() {
-            required_keys.insert(encryption_key);
-        }
-
-        Ok(Self {
+    /// [`receive_certificate`]: Self::receive_certificate
+    pub fn new(cert_scheme: S, verified_agg_input: VerifiedAggKeygenInput) -> Self {
+        Self {
             cert_scheme,
-            agg_input,
-            required_keys,
+            verified_agg_input,
             certificates: BTreeMap::new(),
-        })
+        }
     }
 
-    /// Receive and validate a certificate from a party.
-    ///
-    /// Always verifies the supplied signature. Calling this more than once for
-    /// the same `from` is idempotent — any signature that fails to verify is
-    /// rejected, and a verified signature that arrives after a previously
-    /// stored one is simply discarded (the first stored signature wins).
+    /// Verify and store a certificate from `from`. Idempotent: re-feeding an
+    /// already-stored certificate is a no-op (allows replaying a transport
+    /// without losing progress).
     pub fn receive_certificate(
         &mut self,
         from: Point,
         signature: S::Signature,
-    ) -> Result<(), CertifierError> {
-        if !self.required_keys.contains(&from) {
-            return Err(CertifierError::UnknownParty);
+    ) -> Result<(), ReceiveCertError> {
+        if !self.verified_agg_input.required_keys().contains(&from) {
+            return Err(ReceiveCertError::UnknownParty);
         }
 
         if !self
             .cert_scheme
-            .verify_cert(from, &self.agg_input, &signature)
+            .verify_cert(from, &self.verified_agg_input, &signature)
         {
-            return Err(CertifierError::InvalidSignature);
+            return Err(ReceiveCertError::InvalidSignature);
         }
 
         self.certificates.entry(from).or_insert(signature);
@@ -366,73 +361,90 @@ impl<S: CertificationScheme> Certifier<S> {
         Ok(())
     }
 
-    /// Get the aggregated keygen input
-    pub fn agg_input(&self) -> &encpedpop::AggKeygenInput {
-        &self.agg_input
+    /// The certification scheme this certifier uses.
+    pub fn cert_scheme(&self) -> &S {
+        &self.cert_scheme
     }
 
-    /// Get the set of required keys for certification
-    pub fn required_keys(&self) -> &BTreeSet<Point> {
-        &self.required_keys
+    /// Public keys whose certificates are required.
+    pub fn required_keys(&self) -> BTreeSet<Point> {
+        self.verified_agg_input.required_keys()
     }
 
-    /// Check if all required certificates have been received
+    /// Whether every required certificate has been received.
     pub fn is_finished(&self) -> bool {
-        self.certificates.len() == self.required_keys.len()
+        self.certificates.len() == self.verified_agg_input.required_keys().len()
     }
 
-    /// Get the number of certificates still needed
+    /// First required key still missing a certificate, if any.
+    pub fn first_missing(&self) -> Option<Point> {
+        self.verified_agg_input
+            .required_keys()
+            .iter()
+            .find(|k| !self.certificates.contains_key(k))
+            .copied()
+    }
+
+    /// How many certificates are still missing.
     pub fn missing_count(&self) -> usize {
-        self.required_keys
+        self.verified_agg_input
+            .required_keys()
             .len()
             .saturating_sub(self.certificates.len())
     }
 
-    /// Get the number of required keys
+    /// Number of required keys.
     pub fn required_count(&self) -> usize {
-        self.required_keys.len()
+        self.verified_agg_input.required_keys().len()
     }
 
-    /// Finish certification and return the certified keygen
-    pub fn finish(self) -> Result<CertifiedKeygen<S::Signature>, CertifierError> {
+    /// Yield the [`CertifiedKeygen`] if every certificate has been received.
+    pub fn finish(self) -> Result<CertifiedKeygen<S::Signature>, IncompleteCertificates> {
         if !self.is_finished() {
-            return Err(CertifierError::IncompleteCertificates);
+            return Err(IncompleteCertificates);
         }
 
-        Ok(CertifiedKeygen::new(self.agg_input, self.certificates))
+        Ok(CertifiedKeygen::from_verified(
+            self.verified_agg_input,
+            self.certificates,
+        ))
     }
 }
 
-/// Errors that can occur during certificate validation
-#[derive(Debug, Clone)]
-pub enum CertifierError {
+/// Errors from [`Certifier::receive_certificate`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReceiveCertError {
     /// Party is not in the expected keyset
     UnknownParty,
     /// Certificate signature is invalid
     InvalidSignature,
-    /// Not all required certificates have been received
-    IncompleteCertificates,
-    /// The aggregated keygen input has a different number of contributors than
-    /// the provided `contributor_keys` list.
-    ContributorCountMismatch,
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for CertifierError {}
-
-impl core::fmt::Display for CertifierError {
+impl core::fmt::Display for ReceiveCertError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            CertifierError::UnknownParty => write!(f, "Certificate from unknown party"),
-            CertifierError::InvalidSignature => write!(f, "Invalid certificate signature"),
-            CertifierError::IncompleteCertificates => write!(f, "Not all certificates received"),
-            CertifierError::ContributorCountMismatch => write!(
-                f,
-                "aggregated input has a different number of contributors than expected"
-            ),
+            ReceiveCertError::UnknownParty => write!(f, "Certificate from unknown party"),
+            ReceiveCertError::InvalidSignature => write!(f, "Invalid certificate signature"),
         }
     }
 }
+
+#[cfg(feature = "std")]
+impl std::error::Error for ReceiveCertError {}
+
+/// Returned by [`Certifier::finish`] when not all expected certificates have
+/// been collected.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct IncompleteCertificates;
+
+impl core::fmt::Display for IncompleteCertificates {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "Not all certificates received")
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for IncompleteCertificates {}
 
 /// Reasons [`CertifiedKeygen::recover_share`] may fail.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/schnorr_fun/src/frost/chilldkg/encpedpop.rs
+++ b/schnorr_fun/src/frost/chilldkg/encpedpop.rs
@@ -10,11 +10,9 @@
 //!
 //! [`AggKeygenInput`]: AggKeygenInput
 use super::simplepedpop;
+pub use super::{AuxContributor, Party, Role, ShareReceiver};
 use crate::{Schnorr, frost::*};
-use alloc::{
-    collections::{BTreeMap, BTreeSet},
-    vec::Vec,
-};
+use alloc::{collections::BTreeSet, vec::Vec};
 use secp256kfun::{
     KeyPair,
     hash::{Hash32, HashAdd},
@@ -23,62 +21,65 @@ use secp256kfun::{
     rand_core,
 };
 
-/// A party that generates secret input to the key generation. You need at least one of these
-/// and if at least one of these parties is honest then the final secret key will not be known by an
-/// attacker (unless they obtain `t` shares!).
+/// One party's protocol state for an `encpedpop` keygen. Construct with
+/// [`gen_keygen_input`] and consume with `verify_agg_input` (the role-typed
+/// method on `Contributor<ShareReceiver>` / `Contributor<AuxContributor>`).
+///
+/// See the [module-level docs] for `R`.
+///
+/// [`gen_keygen_input`]: Self::gen_keygen_input
+/// [module-level docs]: super
 #[derive(Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "bincode", derive(bincode::Encode, bincode::Decode))]
-#[cfg_attr(
-    feature = "serde",
-    derive(crate::fun::serde::Deserialize, crate::fun::serde::Serialize),
-    serde(crate = "crate::fun::serde")
-)]
-pub struct Contributor {
-    inner: simplepedpop::Contributor,
+pub struct Contributor<R: Role> {
+    inner: simplepedpop::Contributor<R>,
     my_nonce: Point,
+    receiver_keys: Vec<Point>,
 }
 
-impl Contributor {
-    /// Generates the keygen input for a party at `my_index`. Note that `my_index`
-    /// has nothing to do with the "receiver" index (the `ShareIndex` of share receivers). If
-    /// there are `n` `KeyGenInputParty`s then each party must be assigned an index from `0` to `n-1`.
+impl<R: Role> Contributor<R> {
+    /// Generate this contributor's keygen input.
     ///
-    /// This method returns `Self` to retain the state of the protocol which is needed to verify
-    /// the aggregated input later on.
+    /// For [`ShareReceiver`], `my_role_index` is the receiver slot in
+    /// `[0..receiver_keys.len())` and the contributor's `ShareIndex`
+    /// is `my_role_index + 1`. For [`AuxContributor`], `my_role_index` is in
+    /// `[0..n_aux_contributors)`.
     pub fn gen_keygen_input<H, NG>(
         schnorr: &Schnorr<H, NG>,
         threshold: u32,
-        n_contributors: u32,
-        receiver_encryption_keys: &BTreeMap<ShareIndex, Point>,
-        my_index: u32,
+        n_aux_contributors: u32,
+        receiver_keys: &[Point],
+        my_role_index: u32,
         rng: &mut impl rand_core::RngCore,
-    ) -> (Self, KeygenInput)
+    ) -> Result<(Self, KeygenInput), GenKeygenInputError>
     where
         H: Hash32,
         NG: NonceGen,
     {
-        let multi_nonce_keypair = KeyPair::<Normal>::new(Scalar::random(rng));
+        let unique: BTreeSet<Point> = receiver_keys.iter().copied().collect();
+        if unique.len() != receiver_keys.len() {
+            return Err(GenKeygenInputError::DuplicateReceiverKey);
+        }
 
-        let share_receivers = receiver_encryption_keys.keys().cloned().collect();
-        let (inner_state, inner_keygen_input, mut shares) =
-            simplepedpop::Contributor::gen_keygen_input(
+        let n_receivers = receiver_keys.len() as u32;
+        let (inner_state, inner_keygen_input, shares) =
+            simplepedpop::Contributor::<R>::gen_keygen_input(
                 schnorr,
                 threshold,
-                n_contributors,
-                &share_receivers,
-                my_index,
+                n_aux_contributors,
+                n_receivers,
+                my_role_index,
                 rng,
-            );
-        let encryption_jobs = receiver_encryption_keys
+            )?;
+        let multi_nonce_keypair = KeyPair::<Normal>::new(Scalar::random(rng));
+        let encryption_jobs: Vec<_> = receiver_keys
             .iter()
-            .map(|(receiver, encryption_key)| {
-                (
-                    *receiver,
-                    (*encryption_key, shares.remove(receiver).unwrap()),
-                )
+            .zip(shares)
+            .enumerate()
+            .map(|(i, (encryption_key, share))| {
+                let receiver = ShareIndex::try_from(i as u32 + 1).expect("non-zero");
+                (receiver, *encryption_key, share)
             })
             .collect();
-        assert!(shares.is_empty());
         let encrypted_shares = encrypt::<H>(encryption_jobs, multi_nonce_keypair);
         let keygen_input = KeygenInput {
             inner: inner_keygen_input,
@@ -86,124 +87,271 @@ impl Contributor {
             encryption_nonce: multi_nonce_keypair.public_key(),
         };
 
-        (
+        Ok((
             Contributor {
                 inner: inner_state,
                 my_nonce: multi_nonce_keypair.public_key(),
+                receiver_keys: receiver_keys.to_vec(),
             },
             keygen_input,
-        )
+        ))
     }
 
-    /// Verifies that the coordinator has honestly included this party's input into the
-    /// aggregated input.
-    ///
-    /// This passing by itself doesn't mean that the key generation was successful. All
-    /// `Contributor`s must agree on this fact and all parties must have received the same
-    /// `AggKeygenInput` and validated it.
-    pub fn verify_agg_input(
-        self,
-        agg_keygen_input: &AggKeygenInput,
-    ) -> Result<(), simplepedpop::ContributionDidntMatch> {
-        if agg_keygen_input.encryption_nonces.len() != self.inner.n_contributors() as usize {
-            return Err(simplepedpop::ContributionDidntMatch);
+    fn check_encryption_shape(
+        &self,
+        agg_input: &AggKeygenInput,
+    ) -> Result<(), EncryptionCheckError> {
+        if agg_input.encryption_nonces.len() != self.inner.n_contributors() as usize
+            || agg_input.encrypted_shares.len() != self.inner.n_receivers() as usize
+        {
+            return Err(EncryptionCheckError::CountMismatch);
         }
-        // check the encryption nonce we provided was still in the
-        // AggKeygenInput. This may not be necessary for security but we do it
-        // for completeness.
         let my_index = self.inner.contributor_index();
-        let expected = self.my_nonce;
-        let got = agg_keygen_input
-            .encryption_nonces
-            .get(my_index as usize)
-            .copied()
-            .ok_or(simplepedpop::ContributionDidntMatch)?;
-        if got != expected {
-            return Err(simplepedpop::ContributionDidntMatch);
+        let got = agg_input.encryption_nonces[my_index as usize];
+        if got != self.my_nonce {
+            return Err(EncryptionCheckError::NonceMismatch);
         }
-        self.inner.verify_agg_input(&agg_keygen_input.inner)?;
         Ok(())
     }
 
-    /// Get the number of contributors this contributor was configured for.
+    /// `n_aux_contributors + n_receivers`.
     pub fn n_contributors(&self) -> u32 {
         self.inner.n_contributors()
     }
+
+    /// Number of receivers configured at construction.
+    pub fn n_receivers(&self) -> u32 {
+        self.receiver_keys.len() as u32
+    }
+
+    /// Absolute slot index in `[0..n_contributors)`.
+    pub fn contributor_index(&self) -> u32 {
+        self.inner.contributor_index()
+    }
+
+    /// The `my_role_index` this contributor was constructed with.
+    pub fn role_index(&self) -> u32 {
+        self.inner.role_index()
+    }
 }
 
-/// Key generation inputs after being aggregated by the coordinator
+impl Contributor<AuxContributor> {
+    /// Verify the coordinator faithfully included this contributor's input.
+    /// Parties must still confirm agreement on the result by comparing
+    /// [`VerifiedAggKeygenInput::cert_bytes`] out-of-band.
+    pub fn verify_agg_input<H, NG>(
+        self,
+        schnorr: &Schnorr<H, NG>,
+        agg_input: AggKeygenInput,
+    ) -> Result<VerifiedAggKeygenInput, VerifyAggInputError>
+    where
+        H: Hash32,
+    {
+        self.check_encryption_shape(&agg_input)?;
+        let AggKeygenInput {
+            inner,
+            encrypted_shares,
+            encryption_nonces,
+        } = agg_input;
+        let simple_verified = self.inner.verify_agg_input(schnorr, inner)?;
+        Ok(VerifiedAggKeygenInput {
+            simple_verified,
+            encrypted_shares,
+            encryption_nonces,
+            receiver_keys: self.receiver_keys,
+        })
+    }
+}
+
+impl Contributor<ShareReceiver> {
+    /// Verify the aggregated input, decrypt this receiver's share, and pair it
+    /// with the verified aggregate — all atomically. The verified aggregate is
+    /// only returned if every step succeeds.
+    pub fn verify_agg_input<H, NG>(
+        self,
+        schnorr: &Schnorr<H, NG>,
+        agg_input: AggKeygenInput,
+        keypair: &KeyPair,
+    ) -> Result<(VerifiedAggKeygenInput, PairedSecretShare), ShareReceiverError>
+    where
+        H: Hash32,
+    {
+        let my_position = self.inner.contributor_index();
+        let expected_encryption_key = self.receiver_keys[my_position as usize];
+        if expected_encryption_key != keypair.public_key() {
+            return Err(ShareReceiverError::WrongEncryptionKey);
+        }
+        self.check_encryption_shape(&agg_input)?;
+        let AggKeygenInput {
+            inner,
+            encrypted_shares,
+            encryption_nonces,
+        } = agg_input;
+
+        let my_share_index = ShareIndex::try_from(my_position + 1).expect("non-zero");
+        let encrypted_share = encrypted_shares[my_position as usize];
+        let share_scalar =
+            decrypt::<H>(my_share_index, keypair, &encryption_nonces, encrypted_share);
+        let (simple_verified, paired) =
+            self.inner.verify_agg_input(schnorr, inner, share_scalar)?;
+        Ok((
+            VerifiedAggKeygenInput {
+                simple_verified,
+                encrypted_shares,
+                encryption_nonces,
+                receiver_keys: self.receiver_keys,
+            },
+            paired,
+        ))
+    }
+}
+
+/// Key generation inputs after being aggregated by the coordinator. Broadcast
+/// from the coordinator to every contributor for verification.
 #[derive(Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "bincode", derive(bincode::Encode, bincode::Decode))]
+#[cfg_attr(feature = "bincode", derive(bincode::Encode))]
 #[cfg_attr(
     feature = "serde",
-    derive(crate::fun::serde::Deserialize, crate::fun::serde::Serialize),
+    derive(crate::fun::serde::Serialize),
     serde(crate = "crate::fun::serde")
 )]
 pub struct AggKeygenInput {
     inner: simplepedpop::AggKeygenInput,
-    encrypted_shares: BTreeMap<ShareIndex, (Point, Scalar<Public, Zero>)>,
+    encrypted_shares: Vec<Scalar<Public, Zero>>,
     encryption_nonces: Vec<Point>,
 }
 
-impl AggKeygenInput {
-    /// The inner simplepedpop aggregated input.
-    pub fn inner(&self) -> &simplepedpop::AggKeygenInput {
-        &self.inner
+#[cfg(any(feature = "bincode", feature = "serde"))]
+#[cfg_attr(feature = "bincode", derive(bincode::Decode, bincode::Encode))]
+#[cfg_attr(
+    feature = "serde",
+    derive(crate::fun::serde::Deserialize),
+    serde(crate = "crate::fun::serde")
+)]
+struct WireAggKeygenInput {
+    inner: simplepedpop::AggKeygenInput,
+    encrypted_shares: Vec<Scalar<Public, Zero>>,
+    encryption_nonces: Vec<Point>,
+}
+
+#[cfg(any(feature = "bincode", feature = "serde"))]
+impl WireAggKeygenInput {
+    fn into_validated(self) -> Result<AggKeygenInput, &'static str> {
+        if self.encryption_nonces.len() != self.inner.n_contributors() {
+            return Err("encpedpop AggKeygenInput: encryption_nonces.len() != key_contrib.len()");
+        }
+        Ok(AggKeygenInput {
+            inner: self.inner,
+            encrypted_shares: self.encrypted_shares,
+            encryption_nonces: self.encryption_nonces,
+        })
+    }
+}
+
+#[cfg(feature = "bincode")]
+impl<Context> bincode::Decode<Context> for AggKeygenInput {
+    fn decode<D: secp256kfun::bincode::de::Decoder<Context = Context>>(
+        decoder: &mut D,
+    ) -> Result<Self, secp256kfun::bincode::error::DecodeError> {
+        let wire = WireAggKeygenInput::decode(decoder)?;
+        wire.into_validated()
+            .map_err(secp256kfun::bincode::error::DecodeError::Other)
+    }
+}
+
+#[cfg(feature = "bincode")]
+bincode::impl_borrow_decode!(AggKeygenInput);
+
+#[cfg(feature = "serde")]
+impl<'de> crate::fun::serde::Deserialize<'de> for AggKeygenInput {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: secp256kfun::serde::Deserializer<'de>,
+    {
+        let wire = WireAggKeygenInput::deserialize(deserializer)?;
+        wire.into_validated()
+            .map_err(crate::fun::serde::de::Error::custom)
+    }
+}
+
+/// An [`AggKeygenInput`] that this contributor has verified against its own protocol state.
+#[derive(Clone, Debug, PartialEq)]
+pub struct VerifiedAggKeygenInput {
+    simple_verified: simplepedpop::VerifiedAggKeygenInput,
+    encrypted_shares: Vec<Scalar<Public, Zero>>,
+    encryption_nonces: Vec<Point>,
+    receiver_keys: Vec<Point>,
+}
+
+impl VerifiedAggKeygenInput {
+    /// `n_aux_contributors + n_receivers`.
+    pub fn n_contributors(&self) -> usize {
+        self.simple_verified.agg_input().n_contributors()
     }
 
-    /// The number of encryption nonces in this aggregated input (one per contributor).
-    pub fn n_encryption_nonces(&self) -> usize {
-        self.encryption_nonces.len()
+    /// Number of contributor-only parties (no share to receive).
+    pub fn n_aux_contributors(&self) -> usize {
+        self.n_contributors().saturating_sub(self.n_receivers())
     }
 
-    /// Gets the `SharedKey` that this aggregated input produces.
-    ///
-    /// ## Security
-    ///
-    /// ⚠ Just because you can call this doesn't mean you can use the `SharedKey` securely yet!
-    ///
-    /// You have to have checked that all parties (contributors and receivers) think it's valid
-    /// *and* have the same copy first.
-    pub fn shared_key(&self) -> SharedKey<Normal, Zero> {
-        self.inner.shared_key()
+    /// Number of share receivers.
+    pub fn n_receivers(&self) -> usize {
+        self.encrypted_shares.len()
     }
 
-    /// The *certification* bytes. Checking all parties have the same output of this function is
-    /// enough to check they have the same `AggKeygenInput`.
+    /// The [`SharedKey`] this aggregated input produces.
+    pub fn shared_key(&self) -> SharedKey {
+        self.simple_verified.shared_key()
+    }
+
+    /// Bytes that uniquely identify this verified aggregate. Compare out-of-band
+    /// with every other party — if you all match, you all produced the same key.
+    /// Binds the contributor-side encryption keys, so a coordinator who shows
+    /// different parties different keysets produces different `cert_bytes` per
+    /// victim.
     pub fn cert_bytes(&self) -> Vec<u8> {
-        let mut cert_bytes = self.inner.cert_bytes();
+        let mut cert_bytes = self.simple_verified.cert_bytes();
         cert_bytes.extend((self.encryption_nonces.len() as u32).to_be_bytes());
         cert_bytes.extend(
             self.encryption_nonces
                 .iter()
                 .flat_map(|nonce| nonce.to_bytes()),
         );
-        cert_bytes.extend((self.encrypted_shares.len() as u32).to_be_bytes());
-        for (party_index, (encryption_key, encrypted_share)) in &self.encrypted_shares {
-            cert_bytes.extend(party_index.to_bytes());
+        cert_bytes.extend((self.receiver_keys.len() as u32).to_be_bytes());
+        for (encryption_key, encrypted_share) in
+            self.receiver_keys.iter().zip(self.encrypted_shares.iter())
+        {
             cert_bytes.extend(encryption_key.to_bytes());
             cert_bytes.extend(encrypted_share.to_bytes());
         }
         cert_bytes
     }
 
-    /// Get the encryption key for every party
-    pub fn encryption_keys(&self) -> impl Iterator<Item = (ShareIndex, Point)> + '_ {
-        self.encrypted_shares
+    /// Encryption key for every receiver, paired with its `ShareIndex`.
+    pub fn receiver_keys(&self) -> impl Iterator<Item = (ShareIndex, Point)> + '_ {
+        self.receiver_keys
             .iter()
-            .map(|(party_index, (ek, _))| (*party_index, *ek))
+            .enumerate()
+            .map(|(i, ek)| (ShareIndex::try_from(i as u32 + 1).expect("non-zero"), *ek))
     }
 
-    /// Recover a share with the decryption key from the `AggKeygenInput`.
+    /// Recover a share with the decryption key from the verified aggregate.
     pub fn recover_share<H: Hash32>(
         &self,
         share_index: ShareIndex,
         keypair: &KeyPair,
     ) -> Result<PairedSecretShare, RecoverShareError> {
-        let (expected_public_key, agg_ciphertext) = self
-            .encrypted_shares
-            .get(&share_index)
+        let position = u32::try_from(share_index)
+            .ok()
+            .and_then(|idx| idx.checked_sub(1))
+            .map(|position| position as usize)
+            .filter(|position| *position < self.encrypted_shares.len())
             .ok_or(RecoverShareError::UnknownShareIndex)?;
+        let expected_public_key = self
+            .receiver_keys
+            .get(position)
+            .ok_or(RecoverShareError::UnknownShareIndex)?;
+        let agg_ciphertext = &self.encrypted_shares[position];
 
         if *expected_public_key != keypair.public_key() {
             return Err(RecoverShareError::WrongEncryptionKey);
@@ -215,68 +363,17 @@ impl AggKeygenInput {
             *agg_ciphertext,
         );
 
-        let paired_secret_share = self
-            .shared_key()
+        self.shared_key()
             .pair_secret_share(SecretShare {
                 index: share_index,
                 share: secret_share,
             })
-            .ok_or(RecoverShareError::InvalidShare)?;
-
-        paired_secret_share
-            .non_zero()
-            .ok_or(RecoverShareError::ZeroSharedSecret)
-    }
-
-    /// Embeds a proof-of-work `fingerprint` into the aggregated polynomial.
-    ///
-    /// This coordinator-only operation modifies the DKG output to include
-    /// a verifiable proof of work by grinding the polynomial coefficients.
-    /// The `fingerprint` specifies the required difficulty (number of leading
-    /// zero bits) and an optional tag to include in the hash.
-    ///
-    /// The process:
-    /// 1. Grinds the shared key's polynomial to achieve the fingerprint
-    /// 2. Updates the aggregated polynomial with the ground coefficients
-    /// 3. Homomorphically applies the same tweaks to all encrypted shares
-    ///
-    /// This modification preserves the security of the DKG because:
-    /// - The shared secret (constant term) remains unchanged
-    /// - Only non-constant coefficients are modified, which are already
-    ///   malleable by the coordinator
-    /// - The homomorphic property ensures all shares remain consistent
-    /// - Participants can verify the fingerprint matches the claimed difficulty
-    pub fn grind_fingerprint<H: Hash32>(&mut self, fingerprint: Fingerprint) {
-        if self.inner.agg_poly.is_empty() {
-            return;
-        }
-
-        let mut shared_key = self.shared_key();
-        let tweak_poly = shared_key.grind_fingerprint::<H>(fingerprint);
-        // replace our poly with the one that has the fingerprint
-        self.inner.agg_poly = shared_key.point_polynomial()[1..].to_vec();
-        debug_assert!(
-            self.shared_key()
-                .check_fingerprint::<H>(fingerprint)
-                .is_some()
-        );
-
-        for (share_index, (_encryption_key, encrypted_secret_share)) in &mut self.encrypted_shares {
-            // 💡 The share encryption is homomorphic so we can apply the tweak
-            // operations the same way as if the coordinator had a local copy of
-            // the the unencrypted secret share.
-            let mut tmp = SecretShare {
-                index: *share_index,
-                share: *encrypted_secret_share,
-            };
-            tmp.homomorphic_poly_add(&tweak_poly);
-            *encrypted_secret_share = tmp.share;
-        }
+            .ok_or(RecoverShareError::InvalidShare)
     }
 }
 
-/// Produced by [`Contributor::gen_keygen_input`]. This is sent from the each
-/// `Contributor` to the *coordinator*.
+/// One contributor's message to the coordinator. Produced by
+/// [`Contributor::gen_keygen_input`].
 #[cfg_attr(feature = "bincode", derive(bincode::Encode, bincode::Decode))]
 #[cfg_attr(
     feature = "serde",
@@ -285,83 +382,71 @@ impl AggKeygenInput {
 )]
 #[derive(Clone, Debug, PartialEq)]
 pub struct KeygenInput {
-    /// The input from the inner protocol
+    /// The simplepedpop-layer message.
     pub inner: simplepedpop::KeygenInput,
-    /// The shares encrypted for each receiving party
-    pub encrypted_shares: BTreeMap<ShareIndex, Scalar<Public, Zero>>,
-    /// The multi-encryption nonce for the encryptions in `encrypted_shares`
+    /// Encrypted share for each receiver in slot order
+    /// (position `i` is for `ShareIndex = i + 1`).
+    pub encrypted_shares: Vec<Scalar<Public, Zero>>,
+    /// Multi-encryption nonce used to encrypt `encrypted_shares`.
     pub encryption_nonce: Point,
 }
 
-/// Stores the state of the coordinator as it aggregates inputs from [`Contributor`]s.
+/// Aggregates [`KeygenInput`]s from each contributor into a single
+/// [`AggKeygenInput`] for broadcast.
 #[derive(Clone, Debug, PartialEq)]
 pub struct Coordinator {
     inner: simplepedpop::Coordinator,
-    agg_encrypted_shares: BTreeMap<ShareIndex, (Point, Scalar<Public, Zero>)>,
+    agg_encrypted_shares: Vec<Scalar<Public, Zero>>,
     encryption_nonces: Vec<Point>,
 }
 
 impl Coordinator {
-    /// Creates a new coordinator with:
-    ///
-    /// - `threshold`: of key we're trying to generate
-    /// - `n_contributors`: The number of [`Contributor`]s
-    /// - `receiver_encryption_keys`: The encryption keys of each of the share receivers.
-    pub fn new(
-        threshold: u32,
-        n_contribtors: u32,
-        receiver_encryption_keys: &BTreeMap<ShareIndex, Point>,
-    ) -> Self {
-        let agg_encrypted_shares = receiver_encryption_keys
-            .iter()
-            .map(|(&receiver, encryption_key)| (receiver, (*encryption_key, Scalar::zero())))
-            .collect();
+    /// Total contributor slots = `n_aux_contributors + n_receivers`; receivers
+    /// occupy `[0..n_receivers)`, aux contributors fill the rest.
+    pub fn new(threshold: u32, n_aux_contributors: u32, n_receivers: u32) -> Self {
+        let n_contributors = n_aux_contributors + n_receivers;
+        let agg_encrypted_shares = vec![Scalar::zero(); n_receivers as usize];
         Self {
-            inner: simplepedpop::Coordinator::new(threshold, n_contribtors),
+            inner: simplepedpop::Coordinator::new(threshold, n_aux_contributors, n_receivers),
             agg_encrypted_shares,
-            encryption_nonces: vec![Point::default(); n_contribtors as usize],
+            encryption_nonces: vec![Point::default(); n_contributors as usize],
         }
     }
 
-    /// Adds an `input` from a [`Contributor`].
-    ///
-    /// Note verifying this is the correct input from the correct party is up to your application!
+    /// Adds an `input` from a [`Contributor`]. Authentication of the sender —
+    /// confirming `from` is who you think it is — is up to the application.
     pub fn add_input<H: Hash32, NG>(
         &mut self,
         schnorr: &Schnorr<H, NG>,
-        from: u32,
+        from: super::Party,
         input: KeygenInput,
     ) -> Result<(), AddInputError> {
         if self.inner.is_finished() {
             return Err(AddInputError::AlreadyFinished);
         }
-        let mut check_missing = self.agg_encrypted_shares.keys().collect::<BTreeSet<_>>();
-
-        for dest in input.encrypted_shares.keys() {
-            if !self.agg_encrypted_shares.contains_key(dest) {
-                return Err(AddInputError::UnknownShareReceiver { receiver: *dest });
-            }
-            check_missing.remove(dest);
+        if input.encrypted_shares.len() != self.agg_encrypted_shares.len() {
+            return Err(AddInputError::WrongShareCount {
+                expected: self.agg_encrypted_shares.len() as u32,
+                got: input.encrypted_shares.len() as u32,
+            });
         }
 
-        if !check_missing.is_empty() {
-            return Err(AddInputError::IncompleteShares);
-        }
+        let n_receivers = self.agg_encrypted_shares.len() as u32;
+        let slot = from.slot_index(n_receivers);
 
         // ⚠ only do mutations after we're sure everything is OK
         self.inner.add_input(schnorr, from, input.inner)?;
 
-        for (dest, encrypted_share_contrib) in input.encrypted_shares {
-            let agg_encrypted_share = &mut self.agg_encrypted_shares.get_mut(&dest).unwrap().1;
-            *agg_encrypted_share += encrypted_share_contrib;
+        for (i, encrypted_share_contrib) in input.encrypted_shares.into_iter().enumerate() {
+            self.agg_encrypted_shares[i] += encrypted_share_contrib;
         }
 
-        self.encryption_nonces[from as usize] = input.encryption_nonce;
+        self.encryption_nonces[slot as usize] = input.encryption_nonce;
         Ok(())
     }
 
     /// Which [`Contributor`]s are we missing input from.
-    pub fn missing_from(&self) -> BTreeSet<u32> {
+    pub fn missing_from(&self) -> BTreeSet<super::Party> {
         self.inner.missing_from()
     }
 
@@ -383,55 +468,43 @@ impl Coordinator {
             encryption_nonces: self.encryption_nonces,
         })
     }
-}
 
-/// Extract our secret share from the `AggKeygenInput`.
-///
-/// This also validates `agg_input`.
-pub fn receive_secret_share<H, NG>(
-    schnorr: &Schnorr<H, NG>,
-    my_index: ShareIndex,
-    keypair: &KeyPair,
-    agg_input: &AggKeygenInput,
-) -> Result<PairedSecretShare<Normal, Zero>, simplepedpop::ReceiveShareError>
-where
-    H: Hash32,
-{
-    let (expected_encryption_key, encrypted_share) = agg_input
-        .encrypted_shares
-        .get(&my_index)
-        .ok_or(simplepedpop::ReceiveShareError::UnknownShareIndex)?;
-    if *expected_encryption_key != keypair.public_key() {
-        return Err(simplepedpop::ReceiveShareError::WrongEncryptionKey);
+    /// Like [`finish`] but grinds `fingerprint` into the resulting aggregate's
+    /// polynomial coefficients. Use this if you want the resulting public key
+    /// to encode a few bits of identity (e.g. for paper backups).
+    ///
+    /// [`finish`]: Self::finish
+    pub fn finish_with_fingerprint<H: Hash32>(
+        self,
+        fingerprint: Fingerprint,
+    ) -> Option<AggKeygenInput> {
+        let mut agg_input = self.finish()?;
+        let tweak_poly = agg_input.inner.grind_fingerprint::<H>(fingerprint);
+        // Share encryption is homomorphic — apply the tweak as if to plaintext.
+        for (i, encrypted_secret_share) in agg_input.encrypted_shares.iter_mut().enumerate() {
+            let share_index = ShareIndex::try_from(i as u32 + 1).expect("non-zero");
+            let mut tmp = SecretShare {
+                index: share_index,
+                share: *encrypted_secret_share,
+            };
+            tmp.homomorphic_poly_add(&tweak_poly);
+            *encrypted_secret_share = tmp.share;
+        }
+        Some(agg_input)
     }
-    let share_scalar = decrypt::<H>(
-        my_index,
-        keypair,
-        &agg_input.encryption_nonces,
-        *encrypted_share,
-    );
-    let secret_share = SecretShare {
-        index: my_index,
-        share: share_scalar,
-    };
-    let paired_secret_share =
-        simplepedpop::receive_secret_share(schnorr, &agg_input.inner, secret_share)?;
-
-    Ok(paired_secret_share)
 }
 
 fn encrypt<H: Hash32>(
-    encryption_jobs: BTreeMap<ShareIndex, (Point, Scalar<Secret, Zero>)>,
+    encryption_jobs: Vec<(ShareIndex, Point, Scalar<Secret, Zero>)>,
     multi_nonce_keypair: KeyPair<Normal>,
-) -> BTreeMap<ShareIndex, Scalar<Public, Zero>> {
+) -> Vec<Scalar<Public, Zero>> {
     encryption_jobs
-        .iter()
-        .map(|(dest, (encryption_key, share))| {
+        .into_iter()
+        .map(|(dest, encryption_key, share)| {
             let dh_key = g!(multi_nonce_keypair.secret_key() * encryption_key).normalize();
             // SPEC DEVIATION: Hash inputs are as defined in "Multi-recipient Encryption, Revisited" by Pinto et al.
             let pad = Scalar::from_hash(H::default().add(dh_key).add(encryption_key).add(dest));
-            let payload = s!(pad + share).public();
-            (*dest, payload)
+            s!(pad + share).public()
         })
         .collect()
 }
@@ -439,10 +512,10 @@ fn encrypt<H: Hash32>(
 fn decrypt<H: Hash32>(
     my_index: ShareIndex,
     keypair: &KeyPair<Normal>,
-    multi_nocnes: &[Point],
+    multi_nonces: &[Point],
     mut agg_ciphertext: Scalar<Public, Zero>,
 ) -> Scalar<Secret, Zero> {
-    for nonce in multi_nocnes {
+    for nonce in multi_nonces {
         let dh_key = g!(keypair.secret_key() * nonce).normalize();
         let pad = Scalar::from_hash(
             H::default()
@@ -455,93 +528,124 @@ fn decrypt<H: Hash32>(
     agg_ciphertext.secret()
 }
 
-/// Simulate running a key generation with `encpedpop`.
-///
-/// This calls all the other functions defined in this module to get the whole job done on a
-/// single computer by simulating all the other parties.
-///
-/// A fingerprint can be provided to grind into the polynomial coefficients.
+/// Test/example helper: run every `encpedpop` party in-process. Not for production.
 pub fn simulate_keygen<H, NG>(
     schnorr: &Schnorr<H, NG>,
     threshold: u32,
     n_receivers: u32,
-    n_contributors: u32,
+    n_aux_contributors: u32,
     fingerprint: Fingerprint,
     rng: &mut impl rand_core::RngCore,
-) -> (SharedKey<Normal>, Vec<PairedSecretShare<Normal>>)
+) -> (SharedKey, Vec<PairedSecretShare>)
 where
     H: Hash32,
     NG: NonceGen,
 {
-    let share_receivers = (1..=n_receivers)
-        .map(|i| Scalar::from(i).non_zero().unwrap())
-        .collect::<BTreeSet<_>>();
+    let receiver_keypairs: Vec<KeyPair> = (0..n_receivers)
+        .map(|_| KeyPair::new(Scalar::random(rng)))
+        .collect();
+    let receiver_keys: Vec<Point> = receiver_keypairs.iter().map(|kp| kp.public_key()).collect();
 
-    let receiver_enckeys = share_receivers
-        .iter()
-        .cloned()
-        .map(|party_index| (party_index, KeyPair::new(Scalar::random(rng))))
-        .collect::<BTreeMap<_, _>>();
+    let mut aggregator = Coordinator::new(threshold, n_aux_contributors, n_receivers);
+    let mut receivers: Vec<(Contributor<ShareReceiver>, KeyPair)> = vec![];
+    let mut auxes: Vec<Contributor<AuxContributor>> = vec![];
 
-    let public_receiver_enckeys = receiver_enckeys
-        .iter()
-        .map(|(party_index, enckeypair)| (*party_index, enckeypair.public_key()))
-        .collect::<BTreeMap<ShareIndex, Point>>();
-
-    let (contributors, to_coordinator_messages): (Vec<Contributor>, Vec<KeygenInput>) = (0
-        ..n_contributors)
-        .map(|i| {
-            Contributor::gen_keygen_input(
-                schnorr,
-                threshold,
-                n_contributors,
-                &public_receiver_enckeys,
-                i,
-                rng,
-            )
-        })
-        .unzip();
-
-    let mut aggregator = Coordinator::new(threshold, n_contributors, &public_receiver_enckeys);
-
-    for (i, to_coordinator_message) in to_coordinator_messages.into_iter().enumerate() {
+    for receiver_idx in 0..n_receivers {
+        let (contributor, msg) = Contributor::<ShareReceiver>::gen_keygen_input(
+            schnorr,
+            threshold,
+            n_aux_contributors,
+            &receiver_keys,
+            receiver_idx,
+            rng,
+        )
+        .unwrap();
         aggregator
-            .add_input(schnorr, i as u32, to_coordinator_message)
+            .add_input(schnorr, super::Party::Receiver(receiver_idx), msg)
             .unwrap();
+        receivers.push((contributor, receiver_keypairs[receiver_idx as usize]));
+    }
+    for aux_idx in 0..n_aux_contributors {
+        let (contributor, msg) = Contributor::<AuxContributor>::gen_keygen_input(
+            schnorr,
+            threshold,
+            n_aux_contributors,
+            &receiver_keys,
+            aux_idx,
+            rng,
+        )
+        .unwrap();
+        aggregator
+            .add_input(schnorr, super::Party::AuxContributor(aux_idx), msg)
+            .unwrap();
+        auxes.push(contributor);
     }
 
-    let mut agg_input = aggregator.finish().unwrap();
+    let agg_input = aggregator
+        .finish_with_fingerprint::<H>(fingerprint)
+        .unwrap();
 
-    // Apply fingerprint grinding
-    agg_input.grind_fingerprint::<H>(fingerprint);
-
-    for contributor in contributors {
-        contributor.verify_agg_input(&agg_input).unwrap();
+    let mut verified = None;
+    let mut paired_secret_shares: Vec<PairedSecretShare> = vec![];
+    for (contributor, keypair) in receivers {
+        let (v, paired) = contributor
+            .verify_agg_input(schnorr, agg_input.clone(), &keypair)
+            .unwrap();
+        paired_secret_shares.push(paired);
+        verified.get_or_insert(v);
     }
-
-    let mut paired_secret_shares = vec![];
-    for (party_index, enckey) in receiver_enckeys {
-        let paired_secret_share =
-            receive_secret_share(schnorr, party_index, &enckey, &agg_input).unwrap();
-        paired_secret_shares.push(paired_secret_share.non_zero().unwrap());
+    for contributor in auxes {
+        let v = contributor
+            .verify_agg_input(schnorr, agg_input.clone())
+            .unwrap();
+        verified.get_or_insert(v);
     }
-
-    let shared_key = agg_input.shared_key().non_zero().unwrap();
+    let verified = verified.expect("at least one contributor");
+    let shared_key = verified.shared_key();
     (shared_key, paired_secret_shares)
 }
+
+/// Reasons [`Contributor::gen_keygen_input`] may fail.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum GenKeygenInputError {
+    /// `receiver_keys` contained a duplicate point.
+    DuplicateReceiverKey,
+    /// The underlying simplepedpop input generation rejected the parameters.
+    Inner(simplepedpop::GenKeygenInputError),
+}
+
+impl From<simplepedpop::GenKeygenInputError> for GenKeygenInputError {
+    fn from(err: simplepedpop::GenKeygenInputError) -> Self {
+        GenKeygenInputError::Inner(err)
+    }
+}
+
+impl core::fmt::Display for GenKeygenInputError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            GenKeygenInputError::DuplicateReceiverKey => {
+                write!(f, "receiver_keys contained a duplicate")
+            }
+            GenKeygenInputError::Inner(err) => write!(f, "{err}"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for GenKeygenInputError {}
 
 /// Reasons [`Coordinator::add_input`] may reject a contributor's input.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum AddInputError {
     /// All contributor inputs have already been collected.
     AlreadyFinished,
-    /// Input contains a share encrypted for a receiver not in the configured set.
-    UnknownShareReceiver {
-        /// The share index that wasn't in the configured receiver set.
-        receiver: ShareIndex,
+    /// `input.encrypted_shares.len()` doesn't match the configured receiver count.
+    WrongShareCount {
+        /// The number of receivers configured for the coordinator.
+        expected: u32,
+        /// The number of encrypted shares in the input.
+        got: u32,
     },
-    /// Input is missing shares for some configured receivers.
-    IncompleteShares,
     /// The underlying simplepedpop `add_input` failed.
     Inner(simplepedpop::AddInputError),
 }
@@ -558,11 +662,11 @@ impl core::fmt::Display for AddInputError {
             AddInputError::AlreadyFinished => {
                 write!(f, "all contributor inputs have already been collected")
             }
-            AddInputError::UnknownShareReceiver { receiver } => {
-                write!(f, "input included share for unknown receiver {receiver}")
-            }
-            AddInputError::IncompleteShares => {
-                write!(f, "input did not have a share for all receivers")
+            AddInputError::WrongShareCount { expected, got } => {
+                write!(
+                    f,
+                    "input had {got} encrypted shares but coordinator expected {expected}"
+                )
             }
             AddInputError::Inner(err) => write!(f, "{err}"),
         }
@@ -572,7 +676,112 @@ impl core::fmt::Display for AddInputError {
 #[cfg(feature = "std")]
 impl std::error::Error for AddInputError {}
 
-/// Reasons [`AggKeygenInput::recover_share`] may fail.
+/// Encpedpop-layer encryption shape failures, shared by both the
+/// [`AuxContributor`] and [`ShareReceiver`] verify paths.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum EncryptionCheckError {
+    /// `encryption_nonces.len()` or `encrypted_shares.len()` in the aggregated
+    /// input doesn't match what this contributor was configured for.
+    CountMismatch,
+    /// This contributor's encryption nonce was not faithfully included in the
+    /// aggregated input.
+    NonceMismatch,
+}
+
+impl core::fmt::Display for EncryptionCheckError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            EncryptionCheckError::CountMismatch => write!(
+                f,
+                "aggregated input has a different number of encryption nonces or encrypted shares than expected"
+            ),
+            EncryptionCheckError::NonceMismatch => write!(
+                f,
+                "our encryption nonce was not included in the aggregated input"
+            ),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for EncryptionCheckError {}
+
+/// Reasons [`Contributor::<AuxContributor>::verify_agg_input`] may fail.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum VerifyAggInputError {
+    /// The encpedpop-layer encryption shape check failed.
+    EncryptionCheck(EncryptionCheckError),
+    /// Underlying simplepedpop verification failed.
+    Inner(simplepedpop::VerifyAggInputError),
+}
+
+impl From<EncryptionCheckError> for VerifyAggInputError {
+    fn from(err: EncryptionCheckError) -> Self {
+        VerifyAggInputError::EncryptionCheck(err)
+    }
+}
+
+impl From<simplepedpop::VerifyAggInputError> for VerifyAggInputError {
+    fn from(err: simplepedpop::VerifyAggInputError) -> Self {
+        VerifyAggInputError::Inner(err)
+    }
+}
+
+impl core::fmt::Display for VerifyAggInputError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            VerifyAggInputError::EncryptionCheck(err) => write!(f, "{err}"),
+            VerifyAggInputError::Inner(err) => write!(f, "{err}"),
+        }
+    }
+}
+
+/// Reasons [`Contributor::<ShareReceiver>::verify_agg_input`] may fail.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum ShareReceiverError {
+    /// The supplied keypair isn't the encryption key registered for this share.
+    WrongEncryptionKey,
+    /// The encpedpop-layer encryption shape check failed.
+    EncryptionCheck(EncryptionCheckError),
+    /// The simplepedpop-layer share-receiver verification failed (PoP,
+    /// threshold, or invalid secret share).
+    Inner(simplepedpop::ShareReceiverError),
+}
+
+impl From<EncryptionCheckError> for ShareReceiverError {
+    fn from(err: EncryptionCheckError) -> Self {
+        ShareReceiverError::EncryptionCheck(err)
+    }
+}
+
+impl From<simplepedpop::ShareReceiverError> for ShareReceiverError {
+    fn from(err: simplepedpop::ShareReceiverError) -> Self {
+        ShareReceiverError::Inner(err)
+    }
+}
+
+impl core::fmt::Display for ShareReceiverError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            ShareReceiverError::WrongEncryptionKey => {
+                write!(
+                    f,
+                    "keypair is not the encryption key registered for this share"
+                )
+            }
+            ShareReceiverError::EncryptionCheck(err) => write!(f, "{err}"),
+            ShareReceiverError::Inner(err) => write!(f, "{err}"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for ShareReceiverError {}
+
+#[cfg(feature = "std")]
+impl std::error::Error for VerifyAggInputError {}
+
+/// Reasons [`VerifiedAggKeygenInput::recover_share`] may fail.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum RecoverShareError {
     /// No encrypted share exists at the given index.
@@ -581,8 +790,6 @@ pub enum RecoverShareError {
     WrongEncryptionKey,
     /// The decrypted share didn't pair with the shared key.
     InvalidShare,
-    /// The resulting shared secret was zero.
-    ZeroSharedSecret,
 }
 
 impl core::fmt::Display for RecoverShareError {
@@ -597,9 +804,6 @@ impl core::fmt::Display for RecoverShareError {
             RecoverShareError::InvalidShare => {
                 write!(f, "recovered secret share did not match the shared key")
             }
-            RecoverShareError::ZeroSharedSecret => {
-                write!(f, "recovered shared secret was zero")
-            }
         }
     }
 }
@@ -609,23 +813,79 @@ impl std::error::Error for RecoverShareError {}
 
 #[cfg(test)]
 mod test {
-    use alloc::{collections::BTreeMap, vec::Vec};
+    use alloc::vec::Vec;
 
-    use crate::frost::{Fingerprint, ShareIndex, chilldkg::encpedpop};
+    use crate::frost::{Fingerprint, chilldkg::encpedpop};
 
     use proptest::{
         prelude::*,
         test_runner::{RngAlgorithm, TestRng},
     };
-    use secp256kfun::{KeyPair, Scalar, proptest};
+    use secp256kfun::{KeyPair, Point, Scalar, proptest};
 
-    use super::{Contributor, Coordinator};
+    use super::{
+        AggKeygenInput, AuxContributor, Contributor, Coordinator, KeygenInput, Party, ShareReceiver,
+    };
+
+    fn run_input_aggregation_stage(
+        threshold: u32,
+        n_aux_contributors: u32,
+        n_receivers: u32,
+        arrival_order: impl IntoIterator<Item = Party>,
+    ) -> (Vec<Contributor<AuxContributor>>, AggKeygenInput) {
+        let schnorr = crate::new_with_deterministic_nonces::<sha2::Sha256>();
+        let mut rng = TestRng::deterministic_rng(RngAlgorithm::ChaCha);
+
+        let receiver_keys: Vec<Point> = (0..n_receivers)
+            .map(|_| KeyPair::new(Scalar::random(&mut rng)).public_key())
+            .collect();
+        let n_contributors = n_aux_contributors + n_receivers;
+        let arrival_order: Vec<_> = arrival_order.into_iter().collect();
+        assert_eq!(arrival_order.len(), n_contributors as usize);
+
+        let mut inputs: Vec<KeygenInput> = Vec::with_capacity(n_contributors as usize);
+        let mut auxes: Vec<Contributor<AuxContributor>> = vec![];
+        for receiver_idx in 0..n_receivers {
+            let (_, msg) = Contributor::<ShareReceiver>::gen_keygen_input(
+                &schnorr,
+                threshold,
+                n_aux_contributors,
+                &receiver_keys,
+                receiver_idx,
+                &mut rng,
+            )
+            .unwrap();
+            inputs.push(msg);
+        }
+        for aux_idx in 0..n_aux_contributors {
+            let (contributor, msg) = Contributor::<AuxContributor>::gen_keygen_input(
+                &schnorr,
+                threshold,
+                n_aux_contributors,
+                &receiver_keys,
+                aux_idx,
+                &mut rng,
+            )
+            .unwrap();
+            inputs.push(msg);
+            auxes.push(contributor);
+        }
+        let mut coordinator = Coordinator::new(threshold, n_aux_contributors, n_receivers);
+        for party in arrival_order {
+            let slot = party.slot_index(n_receivers) as usize;
+            coordinator
+                .add_input(&schnorr, party, inputs[slot].clone())
+                .unwrap();
+        }
+
+        (auxes, coordinator.finish().unwrap())
+    }
 
     proptest! {
         #[test]
         fn encpedpop_run_simulate_keygen(
             (n_receivers, threshold) in (1u32..=4).prop_flat_map(|n| (Just(n), 1u32..=n)),
-            n_contributors in 1u32..5,
+            n_aux_contributors in 0u32..5,
         ) {
             let schnorr = crate::new_with_deterministic_nonces::<sha2::Sha256>();
             let mut rng = TestRng::deterministic_rng(RngAlgorithm::ChaCha);
@@ -634,7 +894,7 @@ mod test {
                 &schnorr,
                 threshold,
                 n_receivers,
-                n_contributors,
+                n_aux_contributors,
                 Fingerprint::NONE,
                 &mut rng,
             );
@@ -643,7 +903,7 @@ mod test {
         #[test]
         fn encpedpop_simulate_keygen_with_fingerprint(
             (n_receivers, threshold) in (2u32..=4).prop_flat_map(|n| (Just(n), 2u32..=n)),
-            n_contributors in 1u32..5,
+            n_aux_contributors in 0u32..5,
             (bits_per_coeff, max_bits_total) in (0u8..10).prop_flat_map(|per_coeff| {
                 // max_bits_total should be at least max_bits_per_coeff but can be larger
                 (Just(per_coeff), per_coeff..25)
@@ -662,7 +922,7 @@ mod test {
                 &schnorr,
                 threshold,
                 n_receivers,
-                n_contributors,
+                n_aux_contributors,
                 fingerprint,
                 &mut rng,
             );
@@ -680,44 +940,176 @@ mod test {
     #[test]
     fn test_input_arrival_order() {
         let schnorr = crate::new_with_deterministic_nonces::<sha2::Sha256>();
-        let mut rng = TestRng::deterministic_rng(RngAlgorithm::ChaCha);
         let threshold = 2u32;
+        let n_aux_contributors = 1;
+        let (contributors, agg_input) = run_input_aggregation_stage(
+            threshold,
+            n_aux_contributors,
+            2,
+            [
+                Party::AuxContributor(0),
+                Party::Receiver(0),
+                Party::Receiver(1),
+            ],
+        );
 
-        let receiver_enckeys = [(
-            ShareIndex::from(core::num::NonZeroU32::new(1).unwrap()),
-            KeyPair::new(Scalar::random(&mut rng)).public_key(),
-        )]
-        .into_iter()
-        .collect::<BTreeMap<_, _>>();
-
-        let mut coordinator = Coordinator::new(threshold, 3, &receiver_enckeys);
-
-        // Create contributors with indices 0, 1, 2
-        let contributors_and_inputs: Vec<_> = (0..3)
-            .map(|i| {
-                Contributor::gen_keygen_input(
-                    &schnorr,
-                    threshold,
-                    3,
-                    &receiver_enckeys,
-                    i,
-                    &mut rng,
-                )
-            })
-            .collect();
-
-        // Add them to coordinator in different order
-        let arrival_order = [2, 0, 1];
-        for &contributor_idx in arrival_order.iter() {
-            let (_, input) = &contributors_and_inputs[contributor_idx as usize];
-            coordinator
-                .add_input(&schnorr, contributor_idx, input.clone())
+        // Coordinator slots are keyed by `from`, not arrival order; verify_agg_input
+        // succeeds for every contributor regardless of the order add_input was called in.
+        for (i, contributor) in contributors.into_iter().enumerate() {
+            if i < 2 {
+                // receiver slots — needs a keypair we don't have here, so just pick aux.
+                continue;
+            }
+            contributor
+                .verify_agg_input(&schnorr, agg_input.clone())
                 .unwrap();
         }
+    }
 
-        let agg_input = coordinator.finish().unwrap();
+    // Deserializing a wire form whose encryption_nonces length disagrees with
+    // the inner key_contrib length must fail. This is what gates AggKeygenInput
+    // from carrying inconsistent state across a serialize/deserialize round trip.
+    #[cfg(feature = "bincode")]
+    #[test]
+    fn deser_rejects_inconsistent_contributor_counts() {
+        use super::{AggKeygenInput, WireAggKeygenInput, simplepedpop};
+        use bincode::config::standard;
+        use std::vec;
 
-        let (contributor_1, _) = &contributors_and_inputs[1];
-        contributor_1.clone().verify_agg_input(&agg_input).unwrap(); // This should fail
+        let inner = simplepedpop::Coordinator::new(1, 0, 0).finish().unwrap();
+        let bad_wire = WireAggKeygenInput {
+            inner,
+            encrypted_shares: vec![],
+            // n_contributors() == 0; nonces vec has length 1.
+            encryption_nonces: vec![secp256kfun::G.normalize()],
+        };
+
+        let bytes = bincode::encode_to_vec(&bad_wire, standard()).unwrap();
+        let result: Result<(AggKeygenInput, _), _> = bincode::decode_from_slice(&bytes, standard());
+        assert!(
+            result.is_err(),
+            "deserializing inconsistent encpedpop AggKeygenInput must fail"
+        );
+    }
+
+    // Each contributor signs up for a specific (n_aux_contributors, n_receivers)
+    // pair. verify_agg_input must reject any agg_input whose encryption_nonces
+    // count or encrypted_shares count disagrees with that — both branches of
+    // the OR must fire.
+    #[test]
+    fn verify_agg_input_rejects_count_mismatch() {
+        use super::VerifyAggInputError;
+
+        let schnorr = crate::new_with_deterministic_nonces::<sha2::Sha256>();
+        let threshold = 2u32;
+        let n_aux_contributors = 1u32;
+        let n_receivers = 2u32;
+        let (contributors, valid) = run_input_aggregation_stage(
+            threshold,
+            n_aux_contributors,
+            n_receivers,
+            (0..n_receivers)
+                .map(Party::Receiver)
+                .chain((0..n_aux_contributors).map(Party::AuxContributor)),
+        );
+        let aux = contributors.last().unwrap();
+
+        // Sanity: an unmutated agg_input verifies.
+        aux.clone()
+            .verify_agg_input(&schnorr, valid.clone())
+            .unwrap();
+
+        // First branch: shrink encryption_nonces so n_contributors no longer matches.
+        let mut bad_nonces = valid.clone();
+        bad_nonces.encryption_nonces.pop();
+        assert_eq!(
+            aux.clone().verify_agg_input(&schnorr, bad_nonces),
+            Err(VerifyAggInputError::EncryptionCheck(
+                super::EncryptionCheckError::CountMismatch
+            )),
+            "encryption_nonces count mismatch must be rejected"
+        );
+
+        // Second branch: shrink encrypted_shares so n_receivers no longer matches.
+        let mut bad_shares = valid;
+        bad_shares.encrypted_shares.pop();
+        assert_eq!(
+            aux.clone().verify_agg_input(&schnorr, bad_shares),
+            Err(VerifyAggInputError::EncryptionCheck(
+                super::EncryptionCheckError::CountMismatch
+            )),
+            "encrypted_shares count mismatch must be rejected"
+        );
+    }
+
+    // The receiver encryption keys live on the contributor's verified state,
+    // not in the wire-form agg_input. Two contributors who disagree on the
+    // receiver-keyset must produce different cert_bytes — that's how mutual
+    // certification fails when a malicious coordinator tries to give
+    // different parties different views of the receiver set.
+    #[test]
+    fn cert_bytes_binds_receiver_keys() {
+        use super::VerifiedAggKeygenInput;
+
+        let schnorr = crate::new_with_deterministic_nonces::<sha2::Sha256>();
+        let threshold = 2u32;
+        let n_aux_contributors = 1u32;
+        let n_receivers = 2u32;
+        let (contributors, agg_input) = run_input_aggregation_stage(
+            threshold,
+            n_aux_contributors,
+            n_receivers,
+            (0..n_receivers)
+                .map(Party::Receiver)
+                .chain((0..n_aux_contributors).map(Party::AuxContributor)),
+        );
+
+        let honest = contributors
+            .last()
+            .unwrap()
+            .clone()
+            .verify_agg_input(&schnorr, agg_input)
+            .unwrap();
+
+        // Tampered view: same agg_input, swap two receiver keys so the slot
+        // assignment differs but the multiset doesn't.
+        let mut tampered_keys = honest.receiver_keys.clone();
+        tampered_keys.swap(0, 1);
+        let tampered = VerifiedAggKeygenInput {
+            simple_verified: honest.simple_verified.clone(),
+            encrypted_shares: honest.encrypted_shares.clone(),
+            encryption_nonces: honest.encryption_nonces.clone(),
+            receiver_keys: tampered_keys,
+        };
+
+        assert_ne!(
+            honest.cert_bytes(),
+            tampered.cert_bytes(),
+            "cert_bytes must bind receiver_keys"
+        );
+    }
+
+    // Duplicate receiver_keys are a fault signal (honest random
+    // keys collide with negligible probability) and would let the same party
+    // hold multiple shares. gen_keygen_input must reject this up front.
+    #[test]
+    fn gen_keygen_input_rejects_duplicate_receiver_keys() {
+        let schnorr = crate::new_with_deterministic_nonces::<sha2::Sha256>();
+        let mut rng = TestRng::deterministic_rng(RngAlgorithm::ChaCha);
+        let dupe = KeyPair::new(Scalar::random(&mut rng)).public_key();
+        let other = KeyPair::new(Scalar::random(&mut rng)).public_key();
+
+        let result = super::Contributor::<ShareReceiver>::gen_keygen_input(
+            &schnorr,
+            3,
+            0,
+            &[dupe, other, dupe],
+            0,
+            &mut rng,
+        );
+        assert_eq!(
+            result.err(),
+            Some(super::GenKeygenInputError::DuplicateReceiverKey)
+        );
     }
 }

--- a/schnorr_fun/src/frost/chilldkg/simplepedpop.rs
+++ b/schnorr_fun/src/frost/chilldkg/simplepedpop.rs
@@ -4,56 +4,102 @@
 //! The application must figure out:
 //!
 //! - How to secretly transport secret share contribution from each contributor to their intended destination
-//! - Checking that each party got the correct output by comparing [`AggKeygenInput::cert_bytes`] on each of them.
+//! - Checking that each party got the correct output by comparing
+//!   [`VerifiedAggKeygenInput::cert_bytes`] on each of them.
 //!
-//! [`AggKeygenInput::cert_bytes`]: AggKeygenInput::cert_bytes
+//! [`VerifiedAggKeygenInput::cert_bytes`]: VerifiedAggKeygenInput::cert_bytes
+use super::Role;
+pub use super::{AuxContributor, ShareReceiver};
 use crate::{Message, Schnorr, Signature, frost::*};
 use alloc::{
     collections::{BTreeMap, BTreeSet},
     vec::Vec,
 };
-use core::num::NonZeroU32;
+use core::marker::PhantomData;
 use secp256kfun::{KeyPair, hash::Hash32, nonce::NonceGen, poly, prelude::*, rand_core};
+
+pub(crate) mod role_sealed {
+    pub trait Sealed {
+        /// Translate a role-relative index to the absolute slot index in
+        /// `[0..n_contributors)`. Returns `None` if `role_index` is out of
+        /// range for this role.
+        fn slot_index(role_index: u32, n_receivers: u32, n_aux_contributors: u32) -> Option<u32>;
+    }
+}
+
+impl role_sealed::Sealed for ShareReceiver {
+    fn slot_index(role_index: u32, n_receivers: u32, _n_aux_contributors: u32) -> Option<u32> {
+        (role_index < n_receivers).then_some(role_index)
+    }
+}
+
+impl role_sealed::Sealed for AuxContributor {
+    fn slot_index(role_index: u32, n_receivers: u32, n_aux_contributors: u32) -> Option<u32> {
+        (role_index < n_aux_contributors)
+            .then(|| n_receivers.checked_add(role_index))
+            .flatten()
+    }
+}
 
 const POP_DOMAIN_SEP: &str = "BIP DKG/pop message";
 
-/// A party that generates secret input to the key generation. You need at least one of these
-/// and if at least one of these parties is honest then the final secret key will not be known by an
-/// attacker (unless they obtain `t` shares!).
+/// One party's protocol state for a `simplepedpop` keygen. Construct with
+/// [`gen_keygen_input`] and consume with [`verify_agg_input`] (or the
+/// `ShareReceiver` variant).
+///
+/// `R` selects the role-relative meaning of the `my_role_index` argument to
+/// [`gen_keygen_input`] — see the [module-level docs] for `R`'s overall job
+/// across the three layers.
+///
+/// Deliberately not serializable: `Contributor` is in-memory protocol state with
+/// invariants that can't be re-checked after decode. A tampered blob with
+/// consistent-looking fields could trick later checks.
+///
+/// [`gen_keygen_input`]: Self::gen_keygen_input
+/// [`verify_agg_input`]: Contributor::<AuxContributor>::verify_agg_input
+/// [module-level docs]: super
 #[derive(Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "bincode", derive(bincode::Encode, bincode::Decode))]
-#[cfg_attr(
-    feature = "serde",
-    derive(crate::fun::serde::Deserialize, crate::fun::serde::Serialize),
-    serde(crate = "crate::fun::serde")
-)]
-pub struct Contributor {
+pub struct Contributor<R: Role> {
     my_key_contrib: Point,
     my_index: u32,
-    n_contributors: u32,
+    threshold: u32,
+    n_aux_contributors: u32,
+    n_receivers: u32,
+    _role: PhantomData<R>,
 }
 
-impl Contributor {
-    /// Generates the keygen input for a party at `my_index`. Note that `my_index`
-    /// has nothing to do with the "receiver" index (the `ShareIndex` of share receivers). If
-    /// there are `n` `KeyGenInputParty`s then each party must be assigned an index from `0` to `n-1`.
+impl<R: Role> Contributor<R> {
+    /// Generate this contributor's keygen input for the protocol round.
     ///
-    /// This method returns `Self` to retain the state of the protocol which is needed to verify
-    /// the aggregated input later on.
+    /// `my_role_index` is role-relative: for [`ShareReceiver`] it's the receiver slot
+    /// in `[0..n_receivers)` (the polynomial is evaluated at `ShareIndex = my_role_index + 1`);
+    /// for [`AuxContributor`] it's in `[0..n_aux_contributors)`.
     pub fn gen_keygen_input<H, NG>(
         schnorr: &Schnorr<H, NG>,
         threshold: u32,
-        n_contributors: u32,
-        share_receivers: &BTreeSet<ShareIndex>,
-        my_index: u32,
+        n_aux_contributors: u32,
+        n_receivers: u32,
+        my_role_index: u32,
         rng: &mut impl rand_core::RngCore,
-    ) -> (Self, KeygenInput, SecretKeygenInput)
+    ) -> Result<(Self, KeygenInput, SecretKeygenInput), GenKeygenInputError>
     where
         H: Hash32,
         NG: NonceGen,
     {
-        assert!(threshold > 0);
-        assert!(my_index < n_contributors);
+        if threshold == 0 || threshold > n_receivers {
+            return Err(GenKeygenInputError::InvalidThreshold {
+                threshold,
+                n_receivers,
+            });
+        }
+        n_aux_contributors
+            .checked_add(n_receivers)
+            .ok_or(GenKeygenInputError::TooManyContributors)?;
+        let my_index = R::slot_index(my_role_index, n_receivers, n_aux_contributors).ok_or(
+            GenKeygenInputError::IndexOutOfRange {
+                role_index: my_role_index,
+            },
+        )?;
         let secret_poly = poly::scalar::generate(threshold as usize, rng);
         let com = poly::scalar::to_point_poly(&secret_poly);
         let pop_keypair = KeyPair::new_xonly(secret_poly[0]);
@@ -62,31 +108,38 @@ impl Contributor {
             Message::new(POP_DOMAIN_SEP, &pop_message_bytes(com[0], my_index)),
         );
 
-        let shares = share_receivers
-            .iter()
-            .map(|index| (*index, poly::scalar::eval(&secret_poly, *index)))
+        let shares = (1..=n_receivers)
+            .map(|i| {
+                let share_index = ShareIndex::try_from(i).expect("non-zero");
+                poly::scalar::eval(&secret_poly, share_index)
+            })
             .collect();
         let self_ = Self {
             my_key_contrib: com[0],
             my_index,
-            n_contributors,
+            threshold,
+            n_aux_contributors,
+            n_receivers,
+            _role: PhantomData,
         };
         let msg = KeygenInput { com, pop };
-        (self_, msg, shares)
+        Ok((self_, msg, shares))
     }
 
-    /// Verifies that the coordinator has honestly included this party's input into the
-    /// aggregated input.
-    ///
-    /// This passing by itself doesn't mean that the key generation was successful. All
-    /// `Contributor`s must agree on this fact and all parties must have received the same
-    /// `AggKeygenInput` and validated it.
-    pub fn verify_agg_input(
+    fn verify_agg_input_inner<H, NG>(
         self,
-        agg_input: &AggKeygenInput,
-    ) -> Result<(), ContributionDidntMatch> {
-        if agg_input.key_contrib.len() != self.n_contributors as usize {
-            return Err(ContributionDidntMatch);
+        schnorr: &Schnorr<H, NG>,
+        agg_input: AggKeygenInput,
+    ) -> Result<VerifiedAggKeygenInput, VerifyAggInputError>
+    where
+        H: Hash32,
+    {
+        if agg_input.key_contrib.len() != self.n_contributors() as usize {
+            return Err(VerifyAggInputError::ContributionDidntMatch);
+        }
+        // Reject zero-coefficient padding that would inflate the apparent threshold.
+        if agg_input.agg_poly.len() + 1 != self.threshold as usize {
+            return Err(VerifyAggInputError::ContributionDidntMatch);
         }
         let my_got_contrib = agg_input
             .key_contrib
@@ -94,20 +147,125 @@ impl Contributor {
             .map(|(point, _)| *point);
         let my_expected_contrib = self.my_key_contrib;
         if Some(my_expected_contrib) != my_got_contrib {
-            return Err(ContributionDidntMatch);
+            return Err(VerifyAggInputError::ContributionDidntMatch);
         }
 
-        Ok(())
+        agg_input.verify_proofs_of_possession(schnorr)?;
+
+        let shared_key = agg_input
+            .shared_key()
+            .non_zero()
+            .ok_or(VerifyAggInputError::SharedKeyIsZero)?;
+
+        Ok(VerifiedAggKeygenInput {
+            inner: agg_input,
+            shared_key,
+        })
     }
 
-    /// Get the index for the contributor
+    /// Absolute slot index in `[0..n_contributors)`.
     pub fn contributor_index(&self) -> u32 {
         self.my_index
     }
 
-    /// Get the number of contributors this contributor was configured for.
+    /// The `my_role_index` this contributor was constructed with.
+    pub fn role_index(&self) -> u32 {
+        if self.my_index < self.n_receivers {
+            self.my_index
+        } else {
+            self.my_index - self.n_receivers
+        }
+    }
+
+    /// `n_aux_contributors + n_receivers`.
     pub fn n_contributors(&self) -> u32 {
-        self.n_contributors
+        self.n_aux_contributors + self.n_receivers
+    }
+
+    /// Number of receivers configured at construction.
+    pub fn n_receivers(&self) -> u32 {
+        self.n_receivers
+    }
+
+    /// Threshold configured at construction.
+    pub fn threshold(&self) -> u32 {
+        self.threshold
+    }
+}
+
+impl Contributor<AuxContributor> {
+    /// Verify the coordinator faithfully included this contributor's input.
+    /// Parties must still confirm agreement on the result by comparing
+    /// [`VerifiedAggKeygenInput::cert_bytes`] out-of-band.
+    pub fn verify_agg_input<H, NG>(
+        self,
+        schnorr: &Schnorr<H, NG>,
+        agg_input: AggKeygenInput,
+    ) -> Result<VerifiedAggKeygenInput, VerifyAggInputError>
+    where
+        H: Hash32,
+    {
+        self.verify_agg_input_inner(schnorr, agg_input)
+    }
+}
+
+impl Contributor<ShareReceiver> {
+    /// Verify the aggregated input and extract this contributor's paired secret share
+    /// atomically. `secret_share` is already summed across contributors; if you have
+    /// per-contributor inputs use [`verify_agg_input_combining`] instead. Parties must
+    /// still confirm agreement out-of-band via [`VerifiedAggKeygenInput::cert_bytes`].
+    ///
+    /// [`verify_agg_input_combining`]: Self::verify_agg_input_combining
+    pub fn verify_agg_input<H, NG>(
+        self,
+        schnorr: &Schnorr<H, NG>,
+        agg_input: AggKeygenInput,
+        secret_share: Scalar<Secret, Zero>,
+    ) -> Result<(VerifiedAggKeygenInput, PairedSecretShare), ShareReceiverError>
+    where
+        H: Hash32,
+    {
+        let my_position = self.my_index;
+        let verified = self.verify_agg_input_inner(schnorr, agg_input)?;
+        let my_share_index = ShareIndex::try_from(my_position + 1).expect("non-zero");
+        let secret_share = SecretShare {
+            index: my_share_index,
+            share: secret_share,
+        };
+        let paired = verified
+            .shared_key
+            .pair_secret_share(secret_share)
+            .ok_or(ShareReceiverError::InvalidSecretShare)?;
+        Ok((verified, paired))
+    }
+
+    /// Like [`verify_agg_input`] but sums per-contributor share contributions first.
+    ///
+    /// Pass the `i`th entry from every contributor's [`SecretKeygenInput`] in
+    /// slot order; `secret_share_inputs.len()` must equal `n_contributors`.
+    ///
+    /// [`verify_agg_input`]: Self::verify_agg_input
+    pub fn verify_agg_input_combining<H, NG>(
+        self,
+        schnorr: &Schnorr<H, NG>,
+        agg_input: AggKeygenInput,
+        secret_share_inputs: &[Scalar<Secret, Zero>],
+    ) -> Result<(VerifiedAggKeygenInput, PairedSecretShare), ShareReceiverError>
+    where
+        H: Hash32,
+    {
+        let n_contributors = self.n_contributors();
+        if secret_share_inputs.len() != n_contributors as usize {
+            return Err(ShareReceiverError::WrongShareInputCount {
+                expected: n_contributors,
+                got: secret_share_inputs.len() as u32,
+            });
+        }
+        let mut secret_share = s!(0);
+        for share in secret_share_inputs {
+            secret_share += share;
+        }
+        self.verify_agg_input(schnorr, agg_input, secret_share)
     }
 }
 
@@ -127,38 +285,45 @@ pub struct KeygenInput {
     pub pop: Signature,
 }
 
-/// Map from share index to secret share contribution from the [`Contributor`].
+/// One [`Contributor`]'s share contributions, indexed by receiver slot
+/// (position `i` is the share for `ShareIndex = i + 1`). The application
+/// must transport each entry to the corresponding receiver out-of-band —
+/// `simplepedpop` does not encrypt them; use [`encpedpop`] for that.
 ///
-/// Each entry in the map must be sent to the corresponding party.
-pub type SecretKeygenInput = BTreeMap<ShareIndex, Scalar<Secret, Zero>>;
+/// [`encpedpop`]: super::encpedpop
+pub type SecretKeygenInput = Vec<Scalar<Secret, Zero>>;
 
 /// Stores the state of the coordinator as it aggregates inputs from [`Contributor`]s.
 #[derive(Clone, Debug, PartialEq)]
 pub struct Coordinator {
     threshold: u32,
-    inputs: BTreeMap<u32, Option<KeygenInput>>,
+    n_receivers: u32,
+    inputs: BTreeMap<super::Party, Option<KeygenInput>>,
 }
 
 impl Coordinator {
-    /// Creates a new coordinator with:
-    ///
-    /// - `threshold`: of key we're trying to generate
-    /// - `n_contributors`: The number of [`Contributor`]s
-    pub fn new(threshold: u32, n_contributors: u32) -> Self {
+    /// Total contributor slots = `n_aux_contributors + n_receivers`; receivers
+    /// occupy `[0..n_receivers)`, aux contributors fill the rest.
+    pub fn new(threshold: u32, n_aux_contributors: u32, n_receivers: u32) -> Self {
         assert!(threshold > 0);
+        let inputs = (0..n_receivers)
+            .map(super::Party::Receiver)
+            .chain((0..n_aux_contributors).map(super::Party::AuxContributor))
+            .map(|party| (party, None))
+            .collect();
         Self {
             threshold,
-            inputs: (0..n_contributors).map(|i| (i, None)).collect(),
+            n_receivers,
+            inputs,
         }
     }
 
-    /// Adds an `input` from a [`Contributor`].
-    ///
-    /// Note verifying this is the correct input from the correct party is up to your application!
+    /// Adds an `input` from a [`Contributor`]. Authentication of the sender —
+    /// confirming `from` is who you think it is — is up to the application.
     pub fn add_input<H: Hash32, NG>(
         &mut self,
         schnorr: &Schnorr<H, NG>,
-        from: u32,
+        from: super::Party,
         input: KeygenInput,
     ) -> Result<(), AddInputError> {
         let entry = match self.inputs.get_mut(&from) {
@@ -175,10 +340,11 @@ impl Coordinator {
             });
         }
 
+        let slot = from.slot_index(self.n_receivers);
         let (first_coeff_even_y, _) = input.com[0].into_point_with_even_y();
         if !schnorr.verify(
             &first_coeff_even_y,
-            Message::new(POP_DOMAIN_SEP, &pop_message_bytes(input.com[0], from)),
+            Message::new(POP_DOMAIN_SEP, &pop_message_bytes(input.com[0], slot)),
             &input.pop,
         ) {
             return Err(AddInputError::InvalidProofOfPossession);
@@ -189,13 +355,10 @@ impl Coordinator {
     }
 
     /// Which [`Contributor`]s are we missing input from.
-    pub fn missing_from(&self) -> BTreeSet<u32> {
+    pub fn missing_from(&self) -> BTreeSet<super::Party> {
         self.inputs
             .iter()
-            .filter_map(|(index, input)| match input {
-                None => Some(*index),
-                Some(_) => None,
-            })
+            .filter_map(|(party, input)| input.is_none().then_some(*party))
             .collect()
     }
 
@@ -249,26 +412,17 @@ impl Coordinator {
 )]
 pub struct AggKeygenInput {
     /// The key contribution from each [`Contributor`]
-    pub key_contrib: Vec<(Point, Signature)>,
+    key_contrib: Vec<(Point, Signature)>,
     /// The aggregated non-constant term polynomial
-    pub agg_poly: Vec<Point<Normal, Public, Zero>>,
+    agg_poly: Vec<Point<Normal, Public, Zero>>,
 }
 
 impl AggKeygenInput {
-    /// The number of contributors whose key contributions are aggregated into this input.
-    pub fn n_contributors(&self) -> usize {
+    pub(in crate::frost::chilldkg) fn n_contributors(&self) -> usize {
         self.key_contrib.len()
     }
 
-    /// Gets the `SharedKey` that this aggregated input produces.
-    ///
-    /// ## Security
-    ///
-    /// ⚠ Just because you can call this doesn't mean you can use the `SharedKey` securely yet!
-    ///
-    /// You have to have checked that all parties (contributors and receivers) think it's valid
-    /// *and* have the same copy first.
-    pub fn shared_key(&self) -> SharedKey<Normal, Zero> {
+    fn shared_key(&self) -> SharedKey<Normal, Zero> {
         let public_key = self
             .key_contrib
             .iter()
@@ -279,10 +433,73 @@ impl AggKeygenInput {
         SharedKey::from_poly(poly)
     }
 
-    /// The *certification* bytes. Checking all parties have the same output of this function is
-    /// enough to check they have the same `AggKeygenInput`.
+    /// Grind `fingerprint` into the aggregated polynomial coefficients. Returns
+    /// the tweak polynomial so [`encpedpop`] can apply the same tweak
+    /// homomorphically to encrypted shares.
     ///
-    /// In `simplepedpop` this is just the coefficients of the polynomial.
+    /// [`encpedpop`]: super::encpedpop
+    pub(in crate::frost::chilldkg) fn grind_fingerprint<H: Hash32>(
+        &mut self,
+        fingerprint: Fingerprint,
+    ) -> Vec<Scalar<Public, Zero>> {
+        let mut shared_key = self.shared_key();
+        let tweak_poly = shared_key.grind_fingerprint::<H>(fingerprint);
+        self.agg_poly = shared_key.point_polynomial()[1..].to_vec();
+        debug_assert!(
+            self.shared_key()
+                .check_fingerprint::<H>(fingerprint)
+                .is_some()
+        );
+        tweak_poly
+    }
+
+    fn verify_proofs_of_possession<H, NG>(
+        &self,
+        schnorr: &Schnorr<H, NG>,
+    ) -> Result<(), VerifyAggInputError>
+    where
+        H: Hash32,
+    {
+        for (i, (key_contrib, pop)) in self.key_contrib.iter().enumerate() {
+            let (first_coeff_even_y, _) = key_contrib.into_point_with_even_y();
+            if !schnorr.verify(
+                &first_coeff_even_y,
+                Message::new(POP_DOMAIN_SEP, &pop_message_bytes(*key_contrib, i as u32)),
+                pop,
+            ) {
+                return Err(VerifyAggInputError::InvalidProofOfPossession { from: i as u32 });
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// An [`AggKeygenInput`] that this contributor has verified against its own protocol state.
+#[derive(Clone, Debug, PartialEq)]
+pub struct VerifiedAggKeygenInput {
+    inner: AggKeygenInput,
+    shared_key: SharedKey,
+}
+
+impl VerifiedAggKeygenInput {
+    /// The raw aggregate that was verified.
+    pub fn agg_input(&self) -> &AggKeygenInput {
+        &self.inner
+    }
+
+    /// The [`SharedKey`] this aggregated input produces.
+    pub fn shared_key(&self) -> SharedKey {
+        self.shared_key.clone()
+    }
+
+    /// Bytes that uniquely identify this verified aggregate. Compare this
+    /// out-of-band with every other party — if you all match, you all
+    /// produced the same key. Outer layers ([`encpedpop`], [`certpedpop`])
+    /// extend these bytes to bind their own state.
+    ///
+    /// [`encpedpop`]: super::encpedpop
+    /// [`certpedpop`]: super::certpedpop
     pub fn cert_bytes(&self) -> Vec<u8> {
         let shared_key = self.shared_key();
         let poly = shared_key.point_polynomial();
@@ -295,172 +512,234 @@ impl AggKeygenInput {
     }
 }
 
-/// Receive secret share after summing the secret input from each [`Contributor`] with
-/// [`collect_secret_inputs`] and getting the `AggKeygenInput` from the coordinator.
-///
-/// This also validates `agg_input`.
-pub fn receive_secret_share<H, NG>(
-    schnorr: &Schnorr<H, NG>,
-    agg_input: &AggKeygenInput,
-    secret_share: SecretShare,
-) -> Result<PairedSecretShare<Normal, Zero>, ReceiveShareError>
-where
-    H: Hash32,
-{
-    for (i, (key_contrib, pop)) in agg_input.key_contrib.iter().enumerate() {
-        let (first_coeff_even_y, _) = key_contrib.into_point_with_even_y();
-        if !schnorr.verify(
-            &first_coeff_even_y,
-            Message::new(POP_DOMAIN_SEP, &pop_message_bytes(*key_contrib, i as u32)),
-            pop,
-        ) {
-            return Err(ReceiveShareError::InvalidPop);
-        }
-    }
-
-    let shared_key = agg_input.shared_key();
-
-    let paired_secret_share = shared_key
-        .pair_secret_share(secret_share)
-        .ok_or(ReceiveShareError::InvalidSecretShare)?;
-
-    Ok(paired_secret_share)
-}
-
-/// Collect the secret inputs from each [`Contributor`] destined for a particular party at `ShareIndex`.
-pub fn collect_secret_inputs(
-    my_index: ShareIndex,
-    secret_share_inputs: impl IntoIterator<Item = Scalar<Secret, Zero>>,
-) -> SecretShare {
-    let mut sum = s!(0);
-    for share in secret_share_inputs {
-        sum += share;
-    }
-
-    SecretShare {
-        index: my_index,
-        share: sum,
-    }
-}
-
-/// Simulate running a key generation with `simplepedpop`.
-///
-/// This calls all the other functions defined in this module to get the whole job done on a
-/// single computer by simulating all the other parties.
+/// Test/example helper: run every `simplepedpop` party in-process. Not for production.
 pub fn simulate_keygen<H, NG>(
     schnorr: &Schnorr<H, NG>,
     threshold: u32,
     n_receivers: u32,
-    n_contributors: u32,
+    n_aux_contributors: u32,
     rng: &mut impl rand_core::RngCore,
-) -> (SharedKey<Normal>, Vec<PairedSecretShare<Normal>>)
+) -> (SharedKey, Vec<PairedSecretShare>)
 where
     H: Hash32,
     NG: NonceGen,
 {
-    let share_receivers = (1..=n_receivers)
-        .map(|i| ShareIndex::from(NonZeroU32::new(i).unwrap()))
-        .collect::<BTreeSet<_>>();
+    let mut aggregator = Coordinator::new(threshold, n_aux_contributors, n_receivers);
+    let mut receivers: Vec<Contributor<ShareReceiver>> = vec![];
+    let mut auxes: Vec<Contributor<AuxContributor>> = vec![];
+    // Per-receiver list of share contributions (indexed by receiver position).
+    let mut secret_inputs: Vec<Vec<Scalar<Secret, Zero>>> = vec![vec![]; n_receivers as usize];
 
-    let mut aggregator = Coordinator::new(threshold, n_contributors);
-    let mut contributors = vec![];
-    let mut secret_inputs = BTreeMap::<ShareIndex, Vec<Scalar<Secret, Zero>>>::default();
-
-    for i in 0..n_contributors {
-        let (contributor, to_coordinator, shares) = Contributor::gen_keygen_input(
+    for receiver_idx in 0..n_receivers {
+        let (contributor, to_coordinator, shares) = Contributor::<ShareReceiver>::gen_keygen_input(
             schnorr,
             threshold,
-            n_contributors,
-            &share_receivers,
-            i,
+            n_aux_contributors,
+            n_receivers,
+            receiver_idx,
             rng,
-        );
-
-        contributors.push(contributor);
-        aggregator.add_input(schnorr, i, to_coordinator).unwrap();
-
-        for (receiver_index, share) in shares {
-            secret_inputs.entry(receiver_index).or_default().push(share);
+        )
+        .unwrap();
+        aggregator
+            .add_input(
+                schnorr,
+                super::Party::Receiver(receiver_idx),
+                to_coordinator,
+            )
+            .unwrap();
+        for (receiver_position, share) in shares.into_iter().enumerate() {
+            secret_inputs[receiver_position].push(share);
         }
+        receivers.push(contributor);
+    }
+    for aux_idx in 0..n_aux_contributors {
+        let (contributor, to_coordinator, shares) =
+            Contributor::<AuxContributor>::gen_keygen_input(
+                schnorr,
+                threshold,
+                n_aux_contributors,
+                n_receivers,
+                aux_idx,
+                rng,
+            )
+            .unwrap();
+        aggregator
+            .add_input(
+                schnorr,
+                super::Party::AuxContributor(aux_idx),
+                to_coordinator,
+            )
+            .unwrap();
+        for (receiver_position, share) in shares.into_iter().enumerate() {
+            secret_inputs[receiver_position].push(share);
+        }
+        auxes.push(contributor);
     }
 
     let agg_input = aggregator.finish().unwrap();
 
-    for contributor in contributors {
-        contributor.verify_agg_input(&agg_input).unwrap();
-    }
-
+    let mut verified: Option<VerifiedAggKeygenInput> = None;
     let mut paired_shares = vec![];
-
-    for receiver in share_receivers {
-        let secret_share =
-            collect_secret_inputs(receiver, secret_inputs.remove(&receiver).unwrap());
-        let paired_share = receive_secret_share(schnorr, &agg_input, secret_share).unwrap();
-        paired_shares.push(paired_share.non_zero().unwrap());
+    for (receiver_position, contributor) in receivers.into_iter().enumerate() {
+        let contributions = core::mem::take(&mut secret_inputs[receiver_position]);
+        let (v, paired) = contributor
+            .verify_agg_input_combining(schnorr, agg_input.clone(), &contributions)
+            .unwrap();
+        paired_shares.push(paired);
+        verified.get_or_insert(v);
     }
+    for contributor in auxes {
+        verified.get_or_insert(
+            contributor
+                .verify_agg_input(schnorr, agg_input.clone())
+                .unwrap(),
+        );
+    }
+    let verified = verified.expect("at least one contributor");
 
-    (agg_input.shared_key().non_zero().unwrap(), paired_shares)
+    (verified.shared_key(), paired_shares)
 }
 
-/// The input the contributor provided has been manipulated
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub struct ContributionDidntMatch;
+/// Reasons [`Contributor::gen_keygen_input`] may fail.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum GenKeygenInputError {
+    /// `threshold == 0` or `threshold > n_receivers`. A threshold above the
+    /// receiver count produces an un-reconstructible key.
+    InvalidThreshold {
+        /// The supplied threshold.
+        threshold: u32,
+        /// The supplied number of receivers.
+        n_receivers: u32,
+    },
+    /// `my_role_index` was out of range for the role. For [`ShareReceiver`] the
+    /// max is `n_receivers`; for [`AuxContributor`] it is `n_aux_contributors`.
+    IndexOutOfRange {
+        /// The supplied role-relative index.
+        role_index: u32,
+    },
+    /// `n_aux_contributors + n_receivers` overflowed `u32`.
+    TooManyContributors,
+}
 
-impl core::fmt::Display for ContributionDidntMatch {
+impl core::fmt::Display for GenKeygenInputError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(
-            f,
-            "the contribution assigned to us was not what we contributed"
-        )
+        match self {
+            GenKeygenInputError::InvalidThreshold {
+                threshold,
+                n_receivers,
+            } => write!(
+                f,
+                "threshold {threshold} is invalid for {n_receivers} receivers"
+            ),
+            GenKeygenInputError::IndexOutOfRange { role_index } => write!(
+                f,
+                "role-relative index {role_index} is out of range for this role"
+            ),
+            GenKeygenInputError::TooManyContributors => {
+                write!(f, "n_aux_contributors + n_receivers overflowed u32")
+            }
+        }
     }
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for ContributionDidntMatch {}
+impl std::error::Error for GenKeygenInputError {}
 
-/// The [`AggKeygenInput`] was invalid so a valid secret share couldn't be extracted.
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub enum ReceiveShareError {
-    /// Invalid POP for one of the contributions
-    InvalidPop,
-    /// The secret share we got was invalid
-    InvalidSecretShare,
-    /// No encrypted share exists at the receiver's share index.
-    UnknownShareIndex,
-    /// The supplied keypair isn't the encryption key registered for this share.
-    WrongEncryptionKey,
+/// Reasons [`Contributor::verify_agg_input`] may fail.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum VerifyAggInputError {
+    /// This contributor's input was not faithfully included in the aggregated input.
+    ContributionDidntMatch,
+    /// A key contribution had an invalid proof of possession.
+    InvalidProofOfPossession {
+        /// The contributor slot whose PoP failed.
+        from: u32,
+    },
+    /// The aggregated key contributions summed to the point at infinity —
+    /// negligible with one honest random contributor, so this indicates malice.
+    SharedKeyIsZero,
 }
 
-impl core::fmt::Display for ReceiveShareError {
+impl core::fmt::Display for VerifyAggInputError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(
-            f,
-            "{}",
-            match self {
-                ReceiveShareError::InvalidPop => "Invalid POP for one of the contributions",
-                ReceiveShareError::InvalidSecretShare =>
-                    "The share extracted from the key generation was invalid",
-                ReceiveShareError::UnknownShareIndex =>
-                    "no encrypted share exists at the requested share index",
-                ReceiveShareError::WrongEncryptionKey =>
-                    "keypair is not the encryption key registered for this share",
+        match self {
+            VerifyAggInputError::ContributionDidntMatch => write!(
+                f,
+                "the contribution assigned to us was not what we contributed"
+            ),
+            VerifyAggInputError::InvalidProofOfPossession { from } => {
+                write!(f, "invalid proof of possession from contributor {from}")
             }
-        )
+            VerifyAggInputError::SharedKeyIsZero => write!(
+                f,
+                "aggregated key contributions summed to the point at infinity"
+            ),
+        }
     }
 }
+
+#[cfg(feature = "std")]
+impl std::error::Error for VerifyAggInputError {}
+
+/// Reasons [`Contributor::<ShareReceiver>::verify_agg_input`] (or its
+/// summing variant [`verify_agg_input_combining`]) may fail.
+///
+/// [`verify_agg_input_combining`]: Contributor::<ShareReceiver>::verify_agg_input_combining
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum ShareReceiverError {
+    /// The aggregated input failed to verify.
+    VerifyAggInput(VerifyAggInputError),
+    /// The supplied `secret_share` did not pair with the verified aggregate.
+    InvalidSecretShare,
+    /// `secret_share_inputs.len()` passed to `verify_agg_input_combining`
+    /// did not match `n_contributors`.
+    WrongShareInputCount {
+        /// The configured number of contributors.
+        expected: u32,
+        /// The number of share inputs actually supplied.
+        got: u32,
+    },
+}
+
+impl From<VerifyAggInputError> for ShareReceiverError {
+    fn from(err: VerifyAggInputError) -> Self {
+        ShareReceiverError::VerifyAggInput(err)
+    }
+}
+
+impl core::fmt::Display for ShareReceiverError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            ShareReceiverError::VerifyAggInput(err) => write!(f, "{err}"),
+            ShareReceiverError::InvalidSecretShare => {
+                write!(
+                    f,
+                    "the secret share did not pair with the verified aggregate"
+                )
+            }
+            ShareReceiverError::WrongShareInputCount { expected, got } => write!(
+                f,
+                "expected {expected} secret share inputs (one per contributor), got {got}"
+            ),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for ShareReceiverError {}
 
 /// Reasons [`Coordinator::add_input`] may reject a contributor's input.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum AddInputError {
     /// Input from this contributor has already been recorded.
     DuplicateInput {
-        /// The contributor index that already has an input recorded.
-        from: u32,
+        /// The party that already has an input recorded.
+        from: super::Party,
     },
-    /// No contributor is expected at this index.
+    /// No contributor is expected at this party.
     UnknownContributor {
-        /// The unexpected contributor index.
-        from: u32,
+        /// The unexpected party.
+        from: super::Party,
     },
     /// Polynomial commitment length doesn't match the configured threshold.
     WrongThreshold {
@@ -477,10 +756,10 @@ impl core::fmt::Display for AddInputError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             AddInputError::DuplicateInput { from } => {
-                write!(f, "already have input from contributor {from}")
+                write!(f, "already have input from {from:?}")
             }
             AddInputError::UnknownContributor { from } => {
-                write!(f, "no input expected from contributor {from}")
+                write!(f, "no input expected from {from:?}")
             }
             AddInputError::WrongThreshold { expected, got } => write!(
                 f,
@@ -496,14 +775,9 @@ impl core::fmt::Display for AddInputError {
 #[cfg(feature = "std")]
 impl std::error::Error for AddInputError {}
 
-/// Build the bytes that the proof-of-possession signs.
-///
-/// Binding format is `parity_byte || contributor_index_be`, where `parity_byte`
-/// is `0` if `com[0]` has even y and `1` otherwise. Including the parity closes
-/// the BIP340 x-only gap: a replay of `(A, pop)` under the negated key `-A`
-/// reconstructs a different message and so fails PoP verification.
-///
-/// SPEC DEVIATION: we add the parity byte where as the spec only has the contribution_index.
+// `parity_byte || contributor_index_be`. The parity byte closes the BIP340
+// x-only gap so a replay of `(A, pop)` under `-A` fails PoP verification.
+// SPEC DEVIATION: spec only has the contribution_index.
 fn pop_message_bytes(first_coeff: Point, contributor_index: u32) -> [u8; 5] {
     let mut bytes = [0u8; 5];
     bytes[0] = u8::from(!first_coeff.is_y_even());
@@ -514,7 +788,7 @@ fn pop_message_bytes(first_coeff: Point, contributor_index: u32) -> [u8; 5] {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::frost::chilldkg::simplepedpop;
+    use crate::frost::chilldkg::{Party, simplepedpop};
 
     use proptest::{
         prelude::*,
@@ -526,12 +800,12 @@ mod test {
         #[test]
         fn simplepedpop_run_simulate_keygen(
             (n_receivers, threshold) in (1u32..=4).prop_flat_map(|n| (Just(n), 1u32..=n)),
-            n_contributors in 1u32..5,
+            n_aux_contributors in 0u32..5,
         ) {
             let schnorr = crate::new_with_deterministic_nonces::<sha2::Sha256>();
             let mut rng = TestRng::deterministic_rng(RngAlgorithm::ChaCha);
 
-            simplepedpop::simulate_keygen(&schnorr, threshold, n_receivers, n_contributors, &mut rng);
+            simplepedpop::simulate_keygen(&schnorr, threshold, n_receivers, n_aux_contributors, &mut rng);
         }
     }
 
@@ -544,23 +818,24 @@ mod test {
         let schnorr = crate::new_with_deterministic_nonces::<sha2::Sha256>();
         let mut rng = TestRng::deterministic_rng(RngAlgorithm::ChaCha);
         let threshold = 2u32;
-        let n_contributors = 2u32;
-        let share_receivers: BTreeSet<ShareIndex> = [ShareIndex::from(NonZeroU32::new(1).unwrap())]
-            .into_iter()
-            .collect();
+        let n_aux_contributors = 0u32;
+        let n_receivers = 2u32;
 
-        let (_alice_state, alice_msg, _alice_shares) = simplepedpop::Contributor::gen_keygen_input(
-            &schnorr,
-            threshold,
-            n_contributors,
-            &share_receivers,
-            0,
-            &mut rng,
-        );
+        let (_alice_state, alice_msg, _alice_shares) =
+            simplepedpop::Contributor::<ShareReceiver>::gen_keygen_input(
+                &schnorr,
+                threshold,
+                n_aux_contributors,
+                n_receivers,
+                0,
+                &mut rng,
+            )
+            .unwrap();
 
-        let mut coord_replay_slot = simplepedpop::Coordinator::new(threshold, n_contributors);
+        let mut coord_replay_slot =
+            simplepedpop::Coordinator::new(threshold, n_aux_contributors, n_receivers);
         assert_eq!(
-            coord_replay_slot.add_input(&schnorr, 1, alice_msg.clone()),
+            coord_replay_slot.add_input(&schnorr, Party::Receiver(1), alice_msg.clone()),
             Err(AddInputError::InvalidProofOfPossession),
             "Alice's pop for slot 0 must not verify at slot 1"
         );
@@ -571,18 +846,129 @@ mod test {
                 .collect(),
             pop: alice_msg.pop,
         };
-        let mut coord_negate_same_slot = simplepedpop::Coordinator::new(threshold, n_contributors);
+        let mut coord_negate_same_slot =
+            simplepedpop::Coordinator::new(threshold, n_aux_contributors, n_receivers);
         assert_eq!(
-            coord_negate_same_slot.add_input(&schnorr, 0, negated_msg.clone()),
+            coord_negate_same_slot.add_input(&schnorr, Party::Receiver(0), negated_msg.clone()),
             Err(AddInputError::InvalidProofOfPossession),
             "negated-key replay at the original slot must now be rejected by the PoP check"
         );
 
-        let mut coord_negate_other_slot = simplepedpop::Coordinator::new(threshold, n_contributors);
+        let mut coord_negate_other_slot =
+            simplepedpop::Coordinator::new(threshold, n_aux_contributors, n_receivers);
         assert_eq!(
-            coord_negate_other_slot.add_input(&schnorr, 1, negated_msg),
+            coord_negate_other_slot.add_input(&schnorr, Party::Receiver(1), negated_msg),
             Err(AddInputError::InvalidProofOfPossession),
             "negated-key replay at a different slot must be rejected by the PoP check"
+        );
+    }
+
+    fn run_input_aggregation_stage(
+        threshold: u32,
+        n_aux_contributors: u32,
+        n_receivers: u32,
+    ) -> (
+        Vec<simplepedpop::Contributor<AuxContributor>>,
+        simplepedpop::AggKeygenInput,
+    ) {
+        let schnorr = crate::new_with_deterministic_nonces::<sha2::Sha256>();
+        let mut rng = TestRng::deterministic_rng(RngAlgorithm::ChaCha);
+        let mut coordinator =
+            simplepedpop::Coordinator::new(threshold, n_aux_contributors, n_receivers);
+        for receiver_idx in 0..n_receivers {
+            let (_, msg, _) = simplepedpop::Contributor::<ShareReceiver>::gen_keygen_input(
+                &schnorr,
+                threshold,
+                n_aux_contributors,
+                n_receivers,
+                receiver_idx,
+                &mut rng,
+            )
+            .unwrap();
+            coordinator
+                .add_input(&schnorr, Party::Receiver(receiver_idx), msg)
+                .unwrap();
+        }
+        let mut auxes = vec![];
+        for aux_idx in 0..n_aux_contributors {
+            let (contributor, msg, _) =
+                simplepedpop::Contributor::<AuxContributor>::gen_keygen_input(
+                    &schnorr,
+                    threshold,
+                    n_aux_contributors,
+                    n_receivers,
+                    aux_idx,
+                    &mut rng,
+                )
+                .unwrap();
+            coordinator
+                .add_input(&schnorr, Party::AuxContributor(aux_idx), msg)
+                .unwrap();
+            auxes.push(contributor);
+        }
+        (auxes, coordinator.finish().unwrap())
+    }
+
+    #[test]
+    fn verify_agg_input_rejects_tampered_pop() {
+        let schnorr = crate::new_with_deterministic_nonces::<sha2::Sha256>();
+        let (auxes, mut agg_input) = run_input_aggregation_stage(2, 1, 2);
+        let wrong_pop = agg_input.key_contrib[1].1;
+        agg_input.key_contrib[0].1 = wrong_pop;
+
+        assert_eq!(
+            auxes
+                .into_iter()
+                .next()
+                .unwrap()
+                .verify_agg_input(&schnorr, agg_input),
+            Err(simplepedpop::VerifyAggInputError::InvalidProofOfPossession { from: 0 }),
+            "verify_agg_input must reject raw aggregates with tampered PoPs"
+        );
+    }
+
+    // A malicious aggregator could pad agg_poly with a zero high-order
+    // coefficient to inflate the apparent threshold without changing the
+    // polynomial's value at any ShareIndex. verify_agg_input must reject this
+    // — contributors signed up for a specific threshold and that determines
+    // the polynomial degree.
+    #[test]
+    fn verify_agg_input_rejects_padded_threshold() {
+        use secp256kfun::Point;
+        let schnorr = crate::new_with_deterministic_nonces::<sha2::Sha256>();
+        let (auxes, mut agg_input) = run_input_aggregation_stage(2, 1, 2);
+        agg_input
+            .agg_poly
+            .push(Point::<Normal, Public, Zero>::zero());
+
+        assert_eq!(
+            auxes
+                .into_iter()
+                .next()
+                .unwrap()
+                .verify_agg_input(&schnorr, agg_input),
+            Err(simplepedpop::VerifyAggInputError::ContributionDidntMatch),
+            "verify_agg_input must reject agg_poly padding that inflates the threshold"
+        );
+    }
+
+    // A threshold higher than the number of receivers produces an
+    // un-reconstructible key generation. gen_keygen_input must reject this up
+    // front rather than silently producing a useless aggregate.
+    #[test]
+    fn gen_keygen_input_rejects_threshold_above_n_receivers() {
+        let schnorr = crate::new_with_deterministic_nonces::<sha2::Sha256>();
+        let mut rng = TestRng::deterministic_rng(RngAlgorithm::ChaCha);
+
+        let result = simplepedpop::Contributor::<ShareReceiver>::gen_keygen_input(
+            &schnorr, 3, 0, 2, 0, &mut rng,
+        );
+        assert_eq!(
+            result.err(),
+            Some(simplepedpop::GenKeygenInputError::InvalidThreshold {
+                threshold: 3,
+                n_receivers: 2,
+            })
         );
     }
 }


### PR DESCRIPTION
## Summary

Stacked on #247. A single squashed commit that tightens the chilldkg API.

The core idea: each `Contributor` now saves the parameters it was set up with (encryption keys, contributor nonce, threshold, role, slot) and verifies the aggregated input against that saved view rather than trusting whatever the coordinator returns. `cert_bytes()` incorporates the saved keysets, so a malicious coordinator that shows different parties different views of the receiver- or aux-keyset produces different `cert_bytes` per victim and mutual certification fails.

The biggest consequences:

- **Receiver encryption keys leave the encpedpop wire form** (they were embedded next to each encrypted share) and **aux contributor keys stop being a `finalize` parameter**; both move onto the contributor at `gen_keygen_input` time and feed into `cert_bytes()` via the verified state.

- **`encpedpop::AggKeygenInput` length consistency is enforced on deserialize** via a private wire type, so downstream code can assume the embedded simplepedpop contributor count matches the encryption-nonce count.

- **`Contributor` is type-parameterized by role** (`ShareReceiver` | `AuxContributor`). The role decides slot-index translation at compile time and selects the verify shape; `ShareReceiver`'s verify atomically pairs the secret share, and the share is gated behind a final certificate check.

- **Errors are split into per-function variants** so each call site enumerates exactly the conditions it can produce; an `EncryptionCheckError` sub-enum is shared between aux and share-receiver verify paths so simplepedpop errors flow through one `Inner` path with no ambiguity.

The only thing missing from this PR is a way to "keep around" the final agg keygen so you can actually recover from it. We don't use that in frostsnap but the feature has been soft-deleted since it's hard to create a `VerifiedAggKeygenInput` (which is the thing you can actually recover from) and you can't serialize it.

Frostsnap is updated against this branch in [frostsnap/frostsnap#chilldkg-api-update](https://github.com/frostsnap/frostsnap/tree/chilldkg-api-update).